### PR TITLE
Get configuration from environment variables as well as config.yaml

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,7 @@ from .config import config
 rconn = redis.from_url(config.app.redis_url)
 
 def db_connect():
-    dbconnect = config.database
+    dbconnect = dict(config.database)
     # Taken from peewee's flask_utils
     try:
         name = dbconnect.pop('name')

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,3 +1,8 @@
+# Any value in this file can be overridden by an environment variable
+# named using the keys, in upper case, joined by underscores.  So for
+# example, if the environment variable $SITE_NAME is set, its value
+# will be used instead of the site name declared below.
+
 site:
   name: 'Throat'
   # Lema shown in the page's title


### PR DESCRIPTION
In order to support dockerizing Throat, add the ability for environment variables to supplement or override the default values or the values from `config.yaml`.

In the process I changed the `Map` class in `app/config.py` to gather config, default and environment variables together into one dictionary in the constructor.  I think this is an improvement over the previous version, where if you printed a `Map` you wouldn't see the defaults, but you could access them using `__getattr__`. Now what you see is what you get.

That didn't play well with `db_connect` in `app.models.py` which wants to change the `config` dictionary.  This appears to only be needed for the call to `database_class` so I dealt with it by modifying a duplicate copy of the dictionary.

Since underscores are used to separate the keys in the construction of environment variable names and are also present in some of the key names, there would be a bit of ambiguity if keys are someday nested more than two levels deep.  If that happens, this code would deal with it by throwing it all into the dictionary. So for example setting the environment variable `FOO_BAR_BAZ=bop` when `cfg_defaults['foo']['bar']` is present would result in both `config['foo']['bar']['baz'] == 'bop'` and `config['foo']['bar_baz'] == 'bop'`.