### PR TITLE
Create a new config option to allow only Admins to create new subs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ target/
 # webassets tmp stuff
 app/static/gen
 app/static/.webassets-cache
-config.py
 config.yaml
 
 # thumbs

--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,7 @@ cfg_defaults = { # key => default value
             "title_edit_timeout": 300,
 
             "sub_creation_min_level": 2,
+            "sub_creation_admin_only": False,
             "sub_ownership_limit": 20,
 
             "daily_sub_posting_limit": 10,
@@ -81,7 +82,7 @@ class Config(Map):
     def __init__(self):
         with open('config.yaml','r') as stream:
             self._cfg = yaml.safe_load(stream)
-        
+
         super(Config, self).__init__(self._cfg, cfg_defaults)
 
     def get_flask_dict(self):

--- a/app/html/shared/sidebar/home.html
+++ b/app/html/shared/sidebar/home.html
@@ -10,6 +10,8 @@
 <hr>
 <a href="@{url_for('home.view_subs')}" class="sbm-post pure-button">@{_('View all subs')}</a>
 <a href="@{url_for('subs.random_sub')}" class="sbm-post pure-button">@{_('Go to random sub')}</a>
+@end
+@if config.site.sub_creation_admin_only == False or current_user.is_admin():
 <a href="@{url_for('subs.create_sub')}" class="sbm-post pure-button">@{_('Create a sub')}</a>
 @end
   @if func.getTodaysTopPosts():

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -298,6 +298,11 @@ def create_sub():
     except Sub.DoesNotExist:
         pass
 
+    if config.site.sub_creation_admin_only and not current_user.admin:
+        return engine.get_template('sub/create.html').render(
+            {'error': _("Only Site Admins may create new subs. Please contact an administrator to request a new sub.", level=config.site.sub_creation_min_level),
+             'csubform': form})
+
     level = misc.get_user_level(current_user.uid)[0]
     if not config.app.testing and config.site.sub_creation_min_level != 0:
         if (level <= 1) and (not current_user.admin):

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -20,9 +20,13 @@ site:
   # was created. Set to zero to disable title editing (default is 5 minutes)
   title_edit_timeout: 300
 
-  # If True, enables setting security questions on the admin page. 
+  # If True, enables setting security questions on the admin page.
   # Users will be asked to answer one of these security questions before registering
   enable_security_question: False
+
+  # Only allow Admins to create new subs
+  # If True, only admins can create new subs
+  sub_creation_admin_only: False
 
   # Minimum level a user must have before being able to create a sub.
   # Set to zero to disable sub creation level limits
@@ -89,7 +93,7 @@ storage:
     path: './thumbs'
     # URL or relative path where thumbnails are served (must end with forward slash)
     url: 'https://thumbs.example.com/'
-  
+
   uploads:
     # Same rules as thumbnails
     path: './stor'
@@ -101,7 +105,7 @@ database:
   # - PostgresqlDatabase
   # - SqliteDatabase (untested)
   engine: 'PICK ONE'
-  
+
   # Parameters for both MySQL and postgres
   #host: 'localhost'
   #port: 3306
@@ -112,7 +116,7 @@ database:
 
   # For sqlite:
   #database: '/path/to/sqlite.db'
-  
+
   # Uncomment if using Postgres:
   #autocommit: True
 


### PR DESCRIPTION
This PR adds a new config option in config.yaml to allow only Admins to create new subs.

- Defaults to `False`.
- When enabled, it both hides the "Create a Sub" sidebar button from non-admin users, and also throws an error if they try to submit the CreateSub form.  