### PR TITLE
Automatically reload wheezy templates

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -44,12 +44,14 @@ import logging
 
 from wheezy.template.engine import Engine
 from wheezy.template.ext.core import CoreExtension
-from wheezy.template.loader import FileLoader
+from wheezy.template.loader import FileLoader, autoreload
 
 engine = Engine(
     loader=FileLoader([os.path.split(__file__)[0] + '/html']),
     extensions=[CoreExtension()]
 )
+if config.app.debug:
+    engine = autoreload(engine)
 
 redis = redis.from_url(config.app.redis_url)
 


### PR DESCRIPTION
The jinja2 templates reload when edited, but the wheezy ones don't.  Make them autoreload when running in debug mode.