### PR TITLE
Create config option to enable/disable chat globally

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,7 @@ cfg_defaults = { # key => default value
             "enable_security_question": False,
             "cas_authorized_hosts": [],
             "allow_uploads": False,
+            "enable_chat": True,
 
             "changelog_sub": None,
             "btc_address": None,

--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -157,20 +157,22 @@
     @end
     @footer()
   </div>
-  @def chat():
-    @#...
-    @if not current_user.is_anonymous and 'nochat' not in current_user.prefs:
-    <div id="chpop" style="height: 1.65em">
-      <div id="chtitle" hid="true"><span id="cht-text">@{_('Chat')}</span> <div class="glyphbutton"><a href="/chat"><span class="p-icon " data-icon="resize"></span></a></div></div>
-      <div id="chcont"></div>
-      <div id="chbott" style="display: none"><input type="text" id="chsend" maxlength="250" placeholder="@{_('Type here')}"/></div>
-    </div>
+  @if config.site.enable_chat:
+    @def chat():
+      @#...
+      @if not current_user.is_anonymous and 'nochat' not in current_user.prefs:
+      <div id="chpop" style="height: 1.65em">
+        <div id="chtitle" hid="true"><span id="cht-text">@{_('Chat')}</span> <div class="glyphbutton"><a href="/chat"><span class="p-icon " data-icon="resize"></span></a></div></div>
+        <div id="chcont"></div>
+        <div id="chbott" style="display: none"><input type="text" id="chsend" maxlength="250" placeholder="@{_('Type here')}"/></div>
+      </div>
+      @end
     @end
+    @chat()
+    <script type="text/javascript">
+      window.chat = @{('nochat' not in current_user.prefs) and 'true' or 'false'};
+    </script>
   @end
-  @chat()
-  <script type="text/javascript">
-    window.chat = @{('nochat' not in current_user.prefs) and 'true' or 'false'};
-  </script>
   <script type="text/javascript" src="@{ asset_url_for('main.js') }"></script>
   <style>@{current_user.get_global_stylesheet()}</style>
   @def pagefoot():

--- a/app/html/user/settings/preferences.html
+++ b/app/html/user/settings/preferences.html
@@ -32,10 +32,12 @@
                 <label for="noscroll" class="pure-checkbox">@{edituserform.noscroll.label.text!!s}</label>
                 @{edituserform.noscroll()}
             </div>
-            <div class="pure-control-group">
-                <label for="nochat" class="pure-checkbox">@{edituserform.nochat.label.text!!s}</label>
-                @{edituserform.nochat()}
-            </div>
+            @if config.site.enable_chat:
+              <div class="pure-control-group">
+                  <label for="nochat" class="pure-checkbox">@{edituserform.nochat.label.text!!s}</label>
+                  @{edituserform.nochat()}
+              </div>
+            @end
 
             <div class="pure-control-group">
                 <label for="nochat" class="pure-checkbox">@{edituserform.subtheme.label.text!!s}</label>

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -47,7 +47,9 @@
       <li>/u/username goes to the user's profile</li>
       <li><a href="{{url_for('home.all_new')}}">/all/new</a> shows a live view of new posts, the votes and comment counts auto update</li>
       <li><a href="/m/news+sports+music">/m/news+sports+music</a> shows all posts, sorted by new, from those subs</li>
-      <li><a href="{{url_for('site.chat')}}">/chat</a> goes to a full page chat window for all users</li>
+      @if config.site.enable_chat:
+        <li><a href="{{url_for('site.chat')}}">/chat</a> goes to a full page chat window for all users</li>
+      @end
       <li><span class="tx-icon hasmail" data-icon="edit"></span> allows you to change the order of the top bar subscription list</li>
     </ul>
     <!--

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -21,6 +21,10 @@ site:
   # (by default it's only admins and users authorized through a metadata key)
   allow_uploads: False
 
+  # Allow chat access for all users
+  # If True, each user will have the option of disabling chat for themselves
+  enable_chat: True
+
   # Amount of time in seconds the post author can edit a post's title after the post
   # was created. Set to zero to disable title editing (default is 5 minutes)
   title_edit_timeout: 300


### PR DESCRIPTION
This PR adds a config option to enable/disable chat globally. If chat is enabled, each user will still have the option of disabling chat for themselves.