### PR TITLE
New site and sub log privacy settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,7 @@ cfg_defaults = { # key => default value
             "cas_authorized_hosts": [],
             "allow_uploads": False,
             "enable_chat": True,
+            "sitelog_public": True,
 
             "changelog_sub": None,
             "btc_address": None,

--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -88,6 +88,7 @@ class EditSubForm(FlaskForm):
                                   ('v_three', 'Top')],
                          validators=[Optional()])
     sidebar = TextAreaField(_l('Sidebar text'), validators=[Length(max=8000)])
+    sublogprivate = BooleanField(_l('Make the sub log private'))
 
 
 class EditMod2Form(FlaskForm):

--- a/app/html/shared/sidebar/home.html
+++ b/app/html/shared/sidebar/home.html
@@ -52,7 +52,7 @@
 @end
 <hr>
 <a href="@{url_for('wiki.donate')}" class="sbm-post pure-button">@{_('Donate')}</a>
-@if current_user.is_authenticated:
+@if current_user.is_authenticated and (config.site.sitelog_public or current_user.can_admin):
 <hr>
 <a href="@{url_for('site.view_sitelog')}" class="sbm-post pure-button">@{_('Site logs')}</a>
 @end

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -86,5 +86,7 @@
 @end
 <hr>
 
-<a href="@{url_for('sub.view_sublog', sub=sub['name'])}" class="sbm-post pure-button">@{_('Sub Log')}</a>
+@if (subInfo.get('sublog_private', 0) != '1') or (current_user.uid in (subMods['all'])) or current_user.can_admin:
+  <a href="@{url_for('sub.view_sublog', sub=sub['name'])}" class="sbm-post pure-button">@{_('Sub Log')}</a>
+@end
 <a href="@{url_for('sub.view_sub_bans', sub=sub['name'])}" class="sbm-post pure-button">@{_('Banned Users')}</a>

--- a/app/templates/editsub.html
+++ b/app/templates/editsub.html
@@ -55,6 +55,13 @@
         </label>
       </div>
 
+      <div class="pure-control-group">
+        <label for="sublogprivate" class="pure-checkbox">
+          {{editsubform.sublogprivate(checked=True if metadata.sublog_private else False)}}
+          {{editsubform.sublogprivate.label.text}}
+        </label>
+      </div>
+
       <h4>Default post sort</h4>
       {% for kl in editsubform.subsort %}
         <div class="pure-control-group">

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -246,6 +246,7 @@ def edit_sub(sub):
             sub.update_metadata('ucf', form.usercanflair.data)
             sub.update_metadata('videomode', form.videomode.data)
             sub.update_metadata('allow_polls', form.polling.data)
+            sub.update_metadata('sublog_private', form.sublogprivate.data)
 
             if form.subsort.data != "None":
                 sub.update_metadata('sort', form.subsort.data)

--- a/app/views/site.py
+++ b/app/views/site.py
@@ -1,10 +1,11 @@
 """ Miscellaneous site endpoints """
 from peewee import SQL
 from flask import Blueprint, redirect, url_for, abort, render_template
-from flask_login import login_required
+from flask_login import login_required, current_user
 from .. import misc
 from ..models import SiteLog, SubPost, SubLog, Sub, SubPostComment
 from ..misc import engine
+from ..config import config
 
 bp = Blueprint('site', __name__)
 
@@ -21,6 +22,10 @@ def chat():
 @login_required
 def view_sitelog(page):
     """ Here we can see a log of admin activity on the site """
+
+    if not config.site.sitelog_public and not current_user.can_admin:
+        abort(404)
+
     s1 = SiteLog.select(SiteLog.time, SiteLog.action, SiteLog.desc, SiteLog.link, SiteLog.uid, SQL("'' as sub"),
                         SiteLog.target)
     s2 = SubLog.select(SubLog.time, SubLog.action, SubLog.desc, SubLog.link, SubLog.uid, Sub.name.alias('sub'),

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -138,6 +138,12 @@ def view_sublog(sub, page):
     except Sub.DoesNotExist:
         abort(404)
 
+    subInfo = misc.getSubData(sub.sid)
+    log_is_private = subInfo.get('sublog_private', 0) == '1'
+
+    if log_is_private and not (current_user.is_mod(sub.sid, 1) or current_user.is_admin()):
+        abort(404)
+
     logs = SubLog.select().where(SubLog.sid == sub.sid).order_by(SubLog.lid.desc()).paginate(page, 50)
     return engine.get_template('sub/log.html').render({'sub': sub, 'logs': logs, 'page': page})
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -25,6 +25,10 @@ site:
   # If True, each user will have the option of disabling chat for themselves
   enable_chat: True
 
+  # Allow all users to view the site log
+  # If False, only Admin can view the sitelog
+  sitelog_public: True
+
   # Amount of time in seconds the post author can edit a post's title after the post
   # was created. Set to zero to disable title editing (default is 5 minutes)
   title_edit_timeout: 300


### PR DESCRIPTION
Ths PR provides two new privacy settings for the site and sub logs:

1. `sitelog_public` configured in config.py, defaults to True 
When False, only Admins can view the site log

2. Sub `metadata.sublog_private` configured on a per-sub basis from sub settings
When True, only Sub Mods and Admins can view a sub's Sub Log. 