### PR TITLE
New site config, min level for file upload

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ cfg_defaults = { # key => default value
             "enable_security_question": False,
             "cas_authorized_hosts": [],
             "allow_uploads": False,
+            "upload_min_level": 0,
             "enable_chat": True,
             "sitelog_public": True,
             "force_sublog_public": True,

--- a/app/misc.py
+++ b/app/misc.py
@@ -117,7 +117,9 @@ class SiteUser(object):
             self.admin = False
 
         self.canupload = True if ('canupload' in self.prefs) or self.admin else False
-        if config.site.allow_uploads:
+        if config.site.allow_uploads and config.site.upload_min_level == 0:
+            self.canupload = True
+        elif config.site.allow_uploads and (config.site.upload_min_level <= get_user_level(self, self.score)[0]):
             self.canupload = True
 
     def __repr__(self):

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -21,6 +21,10 @@ site:
   # (by default it's only admins and users authorized through a metadata key)
   allow_uploads: False
 
+  # Minimum level a user must have before being able to upload files.
+  # Set to zero to disable file upload level limits
+  upload_min_level: 0
+
   # Allow chat access for all users
   # If True, each user will have the option of disabling chat for themselves
   enable_chat: True


### PR DESCRIPTION
This PR introduces a new config option to set a minimum level for file uploads, when allowed. 