### PR TITLE
Add a default value for config.app.testing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -58,7 +58,8 @@ cfg_defaults = { # key => default value
             "development": False,
             "wtf_csrf_time_limit": None,
             "max_content_length": 10485760,  # 10mb
-            "fallback_language": "en"
+            "fallback_language": "en",
+            "testing": False
         },
     "database": {}
     }


### PR DESCRIPTION
Prevent an error in the event that `app: testing` is not set to something in `config.yaml`.