### PR TITLE
Improve the test infrastructure

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -78,7 +78,7 @@ cfg_defaults = {  # key => default value
 
 class Map(dict):
     """ A dictionary object whose keys are accessable as attributes. """
-    def __init__(self, sdict, defaults, prefix=''):
+    def __init__(self, sdict, defaults, use_environment=True, prefix=''):
         """Create a Map from the dictionary sdict, with missing values filled
         in from defaults. If a non-empty prefix string is supplied,
         and any environment variables exist beginning with that
@@ -92,12 +92,13 @@ class Map(dict):
         # Turn all subdictionaries into Maps as well.
         for key, val in defaults.items():
             if isinstance(val, dict):
-                self[key] = Map(self.get(key, {}), val, f'{self.prefix}{key}')
+                self[key] = Map(self.get(key, {}), val, use_environment,
+                                f'{self.prefix}{key}')
             elif key not in self.keys():
                 self[key] = val
 
-        # Look for environment variables that override values or add additional values.
-        if self.prefix != '':
+       # Look for environment variables that override values or add additional values.
+        if self.prefix != '' and use_environment:
             for var in os.environ.keys():
                 if var.startswith(self.prefix):
                     self[var[len(self.prefix):].lower()] = os.environ.get(var)
@@ -108,14 +109,14 @@ class Map(dict):
 
 class Config(Map):
     """ Main config object """
-    def __init__(self, config_filename=None):
+    def __init__(self, config_filename=None, use_environment=True):
         if config_filename is None:
             cfg = {}
         else:
             with open(config_filename, 'r') as stream:
                 cfg = yaml.safe_load(stream)
 
-        super(Config, self).__init__(cfg, cfg_defaults)
+        super(Config, self).__init__(cfg, cfg_defaults, use_environment=use_environment)
 
     def get_flask_dict(self):
         flattened = {}

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 import pytest
@@ -8,6 +9,8 @@ from app import create_app
 from app.config import Config
 from app.models import db
 
+peewee_migrate_logger = logging.getLogger("peewee_migrate")
+peewee_migrate_logger.setLevel(logging.WARNING)
 @pytest.fixture
 def client():
     """Create the Flask test client."""

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -16,9 +16,12 @@ def client():
     """Create the Flask test client."""
     db_fd, db_name = tempfile.mkstemp()
 
-    config = Config()
+    # Start with the defaults in config.py.
+    config = Config(use_environment=False)
+
     config['app']['testing'] = True
     config['app']['debug'] = False
+    config['app']['development'] = False
     config['cache']['type'] = 'simple'
     config['database']['engine'] = 'SqliteDatabase'
     config['database']['name'] = db_name


### PR DESCRIPTION
Peewee migrations logging is very spammy, so I turned it down to `logging.WARNING`. I also added a flag to control whether `config.py` looks at environment variables so that developers won't have to pull their hair out if a test that works in one development environment doesn't on another. I could have monkey-patched `os.environ`, but I'd like to leave the possibility open that someday we could tell the tests to use Postgres instead of SQLite by setting environment variables with a prefix which doesn't conflict with anything else in the config, such as THROATTEST_DATABASE_ENGINE.