### PR TITLE
Reporting bug fixes

### DIFF
--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -91,7 +91,7 @@
         @if not sub and not announcement:
           <span><a data-ac="block" class="unblk">@{_('block sub')}</a></span>
         @end
-        <a data-ac="report" class="report-post">@{_('report')}</a>
+        <a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a>
       </div>
     </div>
 </div>

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -153,7 +153,7 @@
               @end
             @end
           @end
-          <li><a data-ac="report" class="report-post">@{_('report')}</a></li>
+          <li><a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a></li>
         @end
       </ul>
     </div>

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -48,7 +48,7 @@
                 @{comment['content']!!html}
               @end
             </div>
-            
+
             @if comment['status'] != 1:
               <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
             @end
@@ -64,7 +64,7 @@
                 @if (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']) and not comment['status'] == 1:
                   <li><a @{(comment['uid'] == current_user.uid) and 'selfdel="true"' or ''} class="delete-comment" data-cid="@{comment['cid']}">@{_('delete')}</a></li>
                 @end
-                <a data-ac="report" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
+                <a data-ac="report" data-pid="@{comment['pid']}" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
               @end
               @if comment['status'] != 1:
                 <li><a class="comment-source" data-cid="@{comment['cid']}">@{_('source')}</a></li>
@@ -86,7 +86,7 @@
           @{_('Load more (1 comment)')}
         @end
         </a>
-    @end 
+    @end
   @end
 @end
 


### PR DESCRIPTION
This fixes two bugs that were introduced in the new reporting features, related to #32 :

1. A bug where reporting a Comment for a Sub Rule Violation did not pull in the relevant Sub Rules
2. A bug with the logic on when to display the write-in text field while reporting

Includes a very slight refactor of the code that opens the Report Post modal so Comment and Post reports are both using the same event listener. 