### PR TITLE
Mods and Admins Viewing Deleted Comments

### DIFF
--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -161,15 +161,18 @@ Mod |\
 
             @else:
             <h3>@{_('Comment Preview:')}</h3>
-              <div class="preview-text-container">
+              <div class="preview-text-container @{((comment['status'] == 1) or (comment['status'] == 2)) and 'deleted ' or ''}">
                 <div class="preview-text">
                   @if comment['status'] != 1:
                     @if comment['status'] == 2:
-                      @{_('[comment deleted by mod or admin]')}
+                      <p class="helper=text">@{_('[comment deleted by mod or admin]')}</p>
                     @end
                     <div id="commentcontent">@{comment['content']}</div>
+                  @elif current_user.is_admin():
+                    <p class="helper=text">@{_('[comment deleted by user]')}</p>
+                    <div id="commentcontent">@{comment['content']}</div>
                   @else:
-                    @{_('[comment deleted by user]')}
+                    <p class="helper=text">@{_('[comment deleted by user]')}</p>
                   @end
                 </div>
               </div>

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -3,76 +3,82 @@
   @#ignore
   @for comment in comments:
     @if comment['cid']:
-      <article id="@{comment['cid']}" data-cid="@{comment['cid']}" class="commentrow @{(comment['cid'] == highlight) and 'highlight ' or ''}@{(comment.get('hl')) and 'active' or ''} text-post no-padding comment">
+      <article id="@{comment['cid']}" data-cid="@{comment['cid']}" class="commentrow @{(comment['cid'] == highlight) and 'highlight ' or ''}@{(comment.get('hl')) and 'active' or ''}@{((comment['visibility'] != '') and (comment['visibility'] != 'none')) and 'deleted ' or ''} text-post no-padding comment">
         <div id="comment-@{comment['cid']}">
-          <div class="pull left votecomment" @{(comment['status'] == 1) and 'style="display:none;"' or ''}>
-            @if comment['userstatus'] != 10:
-              <div title="@{_('Upvote')}" class="c-upvote @{(comment.get('positive') == True) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
-              <div title="@{_('Downvote')}" class="c-downvote @{(comment.get('positive') == False) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>
-            @end
-          </div>
+          @if comment['userstatus'] != 10:
+            <div class="pull left votecomment" @{(comment['visibility'] != '') and 'style=display:none;' or ''}>
+                <div title="@{_('Upvote')}" class="c-upvote @{(comment.get('positive') == True) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
+                <div title="@{_('Downvote')}" class="c-downvote @{(comment.get('positive') == False) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>
+            </div>
+          @end
           <div class="commblock">
             <div class="commenthead">
-              <a class="togglecomment @{(comment['status'] == 1) and 'expand' or 'collapse'}" data-cid="@{comment['cid']}">
-                @{(comment['status'] == 1) and '[+]' or '[–]'} \
+              <a class="togglecomment @{(comment['visibility'] != '') and 'expand' or 'collapse'}" data-cid="@{comment['cid']}">
+                @{(comment['visibility'] != '') and '[+]' or '[–]'} \
               </a>
-              @if comment['status'] != 1:
-                @if comment['userstatus'] == 10:
+              @if comment['visibility'] == 'none':
                   <a class="poster deleted">@{_('[Deleted]')}</a>
-                @else:
-                  <a href="/u/@{comment['user']}" class="poster">
-                    @{comment['user']}
-                    @if comment['user'] == post['user']:
-                      <span class="op-tag">@{_('[OP]')}</span>
-                    @end
-                  </a>
-                @end
               @else:
-                <a class="poster deleted">@{_('[Deleted]')}</a>
+                <a href="/u/@{comment['user']}" class="poster">
+                  @{comment['user']}
+                  @if comment['user'] == post['user']:
+                    <span class="op-tag">@{_('[OP]')}</span>
+                  @end
+                </a>
               @end
               <b>@{_('<span class="cscore">%(score)i</span> points</b> (+<b>%(upvotes)i</b>|-<b>%(downvotes)i</b>)', score=comment['score'], upvotes=comment['upvotes'], downvotes=comment['downvotes'])!!html}
               <span class="time ">
                   <time-ago datetime="@{comment['time'].isoformat()}Z"></time-ago>
               </span>
-              @if comment['lastedit'] and comment['status'] != 1:
+              @if comment['lastedit'] and comment['visibility'] != 'none':
                 <span class="time edited">
                   @{_('Edited %(timeago)s', timeago='<time-ago datetime="' + comment['lastedit'].isoformat() + 'Z"></time-ago>')!!html}<br/>
                 </span>
               @end
             </div>
 
-            <div class="content" id="content-@{comment['cid']}" @{(comment['status'] == 1) and 'style="display:none;"' or ''}>
-              @if comment['status'] == 1:
+            <div class="content" id="content-@{comment['cid']}">
+              @if comment['visibility'] == 'none':
                 @{_('[Deleted]')} \
+              @elif comment['visibility'] == 'admin-self-del':
+                <p class="helper-text">@{_('[Post deleted by user]')}</p>
+                @{comment['content']!!html}
+              @elif comment['visibility'] == 'mod-self-del':
+                <p class="helper-text">@{_('[Post deleted by user]')}</p>
+              @elif comment['visibility'] == 'mod-del':
+                <p class="helper-text">@{_('[Post deleted by mod or admin]')}</p>
+                @{comment['content']!!html}
               @else:
                 @{comment['content']!!html}
               @end
             </div>
 
-            @if comment['status'] != 1:
+            @if comment['visibility'] != 'none':
               <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
             @end
-            <ul class="bottombar links" @{(comment['status'] == 1) and 'style="display:none;"' or ''}>
+            <ul class="bottombar links" @{(comment['visibility'] == '') and 'style="display:none;"' or ''}>
               <li><a href="@{url_for('sub.view_perm', sub=post['sub'], cid=comment['cid'], pid=post['pid'])}#comment-@{comment['cid']}">@{_('permalink')}</a></li>
-              @if current_user.is_authenticated and not post['deleted']:
+              @if current_user.is_authenticated and comment['visibility'] == '':
                 @if not current_user.is_subban(post['sid']):
                   <li><a class="reply-comment" data-pid="@{comment['pid']}" data-to="@{comment['cid']}">@{_('reply')}</a></li>
                 @end
-                @if comment['uid'] == current_user.uid and not comment['status'] == 1:
+                @if comment['uid'] == current_user.uid and comment['visibility'] == '':
                   <li><a class="edit-comment" data-cid="@{comment['cid']}">@{_('edit')}</a></li>
                 @end
-                @if (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']) and not comment['status'] == 1:
+                @if (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']) and comment['visibility'] == '':
                   <li><a @{(comment['uid'] == current_user.uid) and 'selfdel="true"' or ''} class="delete-comment" data-cid="@{comment['cid']}">@{_('delete')}</a></li>
                 @end
-                <a data-ac="report" data-pid="@{comment['pid']}" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
+                @if comment['visibility'] == '':
+                  <a data-ac="report" data-pid="@{comment['pid']}" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
+                @end
               @end
-              @if comment['status'] != 1:
+              @if comment['visibility'] == '':
                 <li><a class="comment-source" data-cid="@{comment['cid']}">@{_('source')}</a></li>
               @end
             </ul>
           </div>
         </div>
-        <div id="child-@{comment['cid']}" class="pchild" @{(comment['status'] == 1) and 'style="display:none;"' or ''}>
+        <div id="child-@{comment['cid']}" class="pchild" @{(comment['visibility'] != '') and 'style=display:none;' or ''}>
           @if comment['children']:
             @{renderComments(post, subInfo, subMods, comment['children'], highlight)!!html}
           @end

--- a/app/misc.py
+++ b/app/misc.py
@@ -1585,13 +1585,38 @@ def get_comment_tree(comments, root=None, only_after=None, uid=None, provide_con
 
     commdata = {}
     for comm in expcomms:
-        if comm['userstatus'] == 10 or comm['status']:
-            comm['user'] = _('[Deleted]')
-            comm['uid'] = None
+        comm['visibility'] = ''
+        sub = Sub.select().join(SubPost).join(SubPostComment).where(SubPostComment.cid == comm['cid']).get()
 
         if comm['status']:
-            comm['content'] = ''
-            comm['lastedit'] = None
+            if comm['status'] == 1:
+                if current_user.is_admin():
+                    comm['visibility'] = 'admin-self-del'
+                elif current_user.is_mod(sub.sid, 1):
+                    comm['visibility'] = 'mod-self-del'
+                else:
+                    comm['user'] = _('[Deleted]')
+                    comm['uid'] = None
+                    comm['content'] = ''
+                    comm['lastedit'] = None
+                    comm['visibility'] = 'none'
+            elif comm['status'] == 2:
+                if current_user.is_admin() or current_user.is_mod(sub.sid, 1):
+                    comm['visibility'] = 'mod-del'
+                else:
+                    comm['user'] = _('[Deleted]')
+                    comm['uid'] = None
+                    comm['content'] = ''
+                    comm['lastedit'] = None
+                    comm['visibility'] = 'none'
+
+        if comm['userstatus'] == 10:
+            comm['user'] = _('[Deleted]')
+            comm['uid'] = None
+            if comm['status'] == 1:
+                comm['content'] = ''
+                comm['lastedit'] = None
+                comm['visibility'] = 'none'
         # del comm['userstatus']
         commdata[comm['cid']] = comm
 

--- a/app/models.py
+++ b/app/models.py
@@ -332,7 +332,7 @@ class SubPostComment(BaseModel):
     score = IntegerField(null=True)
     upvotes = IntegerField(default=0)
     downvotes = IntegerField(default=0)
-    status = IntegerField(null=True) # 1=self delete, 2=mod delete, 0=not deleted
+    status = IntegerField(null=True) # 1=self delete, 2=mod delete, 0 or null=not deleted
     time = DateTimeField(null=True)
     uid = ForeignKeyField(db_column='uid', null=True, model=User,
                           field='uid', backref='comments')

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2093,6 +2093,10 @@ a.close-report {
   padding-left: 10px;
 }
 
+.mod.report.preview .preview-text-container.deleted {
+  background-color: #FDD8D4;
+}
+
 .mod.report.preview .preview-meta-data {
   display: flex;
   align-items: center;
@@ -2105,4 +2109,12 @@ a.close-report {
 
 .mod-sidebar.header {
   text-align: center;
+}
+
+article.text-post.comment.deleted {
+  background-color: #FDD8D4;
+}
+
+#postcontent.deleted {
+  background-color: #FDD8D4;
 }


### PR DESCRIPTION
**This PR is one piece of a larger feature implementation that includes:**

- [x] Allowing Mods and Admins to view some deleted comments
- [ ] Allowing Mods and Admins to view some deleted posts
- [ ] Allowing Mods and Admins to view edit history

This PR only does the first of those three. Future PRs to come for the other two, but I wanted to keep these PRs manageable in size.

We had initially discussed making the permission structure here as it relates to SubMods configurable, however, I realized as I was going that this does not actually change what SubMods have permission to see - it only shows it to them in a different (better?) UI. For example, SubMods still cannot view self-deleted comments, only Admins can. And SubMods could already view the text of a mod-deleted comment in the Report View anyways. However, if you require specific config settings for this PR, let me know what they would be.

**Below is a chart demonstrating how 3 different users would see the same list of comments: User, Sub Mod, and Admin.**
- There should be no change for regular (non-submod) users.
- SubMod users will now be able to see the content of comments *that have been deleted by mods or admins* in the comment tree. They will also have a visual indicator of self-deleted posts, but still can not see the content of them.
- Admins will now be able to see the content of comments that have been deleted by anyone *except when the user has also deleted their entire account in addition to deleting the comment*. 
- No one can ever see a post that has been deleted by a user AND the user deleted their account

**Notes:**
This was accomplished through changes to how `get_comment_tree()` returns comment data. The function now returns a new key for each comment, `comm['visibility']`. This is because what a user can see in the UI now depends on both the `comm['status']` and the permissions of the `current_user`.  `comm['visibility']` is now checked in the postcomments template rather than status in most instances.

Important to note: the way `comm['status']` was previously being used in the postcomments template had already become deprecated with the implementation of `status = 2` for Admin and Mod deleted comments (PR #62). I did not realize this at the time of that PR. The template was checking if a comment was deleted by if `['status'] != 1` , however, this is no longer an accurate way to check if a comment is deleted or not, since `2` is also a valid deleted status. The new way of using `visibility` instead solves this problem, in addition to presenting the new features of this PR.

![viewing-deleted-comments](https://user-images.githubusercontent.com/17955536/87590925-2b850080-c6ad-11ea-8fad-5e294e9bb361.png)

**This also includes corresponding UI changes in the Report Details View**
![Screenshot from 2020-07-15 15 14 15](https://user-images.githubusercontent.com/17955536/87591392-dd243180-c6ad-11ea-825b-1b3749e5209d.png)
