### PR TITLE
Mods and Admins Viewing Deleted Posts

### DIFF
--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -131,15 +131,16 @@ Mod |\
           <hr>
 
           <div class="mod report preview">
-
             @if report['type'] == 'post':
             <h3>@{_('Post Preview:')}</h3>
-              <div class="preview-text-container">
+              <div class="preview-text-container @{(post['deleted'] != 0) and 'deleted ' or ''}">
                 <div class="preview-text">
                   <div class="postinfo" id="postinfo" pid="@{report['pid']!!s}">
-                    @if post['deleted'] != 1:
+                    @if post['deleted'] != 1 or current_user.is_admin():
                       @if post['deleted'] == 2:
-                        @{_('[post deleted by mod or admin]')}
+                        <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
+                      @else:
+                        <p class="helper-text">@{_('[post deleted by user]')}</p>
                       @end
                       <h3>@{post['title']}</h3>
                       @if post['content']:
@@ -152,7 +153,7 @@ Mod |\
                         @{_('[post preview could not be rendered]')}
                       @end
                     @else:
-                      @{_('[post deleted by user]')}
+                      <p class="helper-text">@{_('[post deleted by user]')}</p>
                     @end
                     <div id="delpostli"></div>
                   </div>

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -5,7 +5,12 @@
 
 
 @def title():
-  @{post['title']} |\
+  @if (post['visibility'] == ''):
+    @{post['title']} |\
+  @else:
+    @{_('[Deleted Post]')}
+  @end
+
 @end
 
 @def meta_description():
@@ -43,7 +48,7 @@
 
 @def main():
 <div class="wholepost">
-  <div class="postbar post" pid="@{post['pid']}">
+  <div class="postbar post @{((post['visibility'] != '') and (post['visibility'] != 'none')) and 'deleted ' or ''}" pid="@{post['pid']}">
     <div class="misctainer">
       <div class="votebuttons">
         @if post['userstatus'] != 10 and (datetime.datetime.utcnow() - post['posted'].replace(tzinfo=None)) < datetime.timedelta(days=60):
@@ -79,9 +84,33 @@
         @end
 
         @if post['link'] == None:
-          <h1><a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">@{post['title']}</a></h1>
+          <h1><a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
+            @if (post['visibility'] == ''):
+              @{post['title']}
+            @elif (post['visibility'] == 'admin-self-del'):
+              @{_('[Deleted by User]')} @{post['title']}
+            @elif (post['visibility'] == 'mod-self-del'):
+              @{_('[Deleted by User]')}
+            @elif (post['visibility'] == 'mod-del'):
+              @{_('[Deleted by Mod]')} @{post['title']}
+            @elif (post['visibility'] == 'none'):
+              @{_('[Deleted]')}
+            @end
+          </a></h1>
         @else:
-          <h1><a rel="noopener nofollow ugc" href="@{(post['deleted'] == 0) and post['link'] or '#'}" class="title">@{post['title']}</a></h1>
+          <h1><a rel="nofollow ugc @{(post['visibility'] == 'none') and 'noopener ' or ''}" href="@{(post['visibility'] != 'none') and post['link'] or '#'}" class="title">
+            @if (post['visibility'] == ''):
+              @{post['title']}
+            @elif (post['visibility'] == 'admin-self-del'):
+            @{_('[Deleted by User]')} @{post['title']}
+            @elif (post['visibility'] == 'mod-self-del'):
+              @{_('[Deleted by User]')}
+            @elif (post['visibility'] == 'mod-del'):
+              @{_('[Deleted by Mod]')} @{post['title']}
+            @elif (post['visibility'] == 'none'):
+              @{_('[Deleted]')}
+            @end
+          </a></h1>
           @if post['deleted'] == 0:
             <a href="/domain/@{func.getDomain(post['link'])}" class="domain">(@{func.getDomain(post['link'])})</a>
           @end
@@ -172,18 +201,28 @@
     </div>
   @end
 
-  @if post['deleted'] == 0 and post['ptype'] == 3:
+  @if (post['ptype'] == 3) and (post['deleted'] == 0 or post['visibility'] == 'admin-self-del' or post['visibility'] == 'mod-del'):
     @{polls.renderPoll(pollData, postmeta, post)!!html}
   @end
 
   @if post['content']:
+    <!-- <p class="helper-text">Post Visibility: @{post['visibility']}</p> -->
     @if post['deleted'] == 0:
       <div id="postcontent">
         @{markdown(post['content'])!!html}
       </div>
       <div id="post-source">@{post['content']}</div>
     @else:
-      <div class="deleted">@{_('[deleted]')}</div>
+      @if ((post['visibility'] == 'none') or (post['visibility'] == 'mod-self-del')):
+        <div id="postcontent" class="@{(post['visibility'] == 'mod-self-del') and 'deleted ' or ''}">
+          @{_('[deleted]')}
+        </div>
+      @elif ((post['visibility'] == 'admin-self-del') or (post['visibility'] == 'mod-del')):
+        <div id="postcontent" class="deleted">
+          @{markdown(post['content'])!!html}
+        </div>
+        <div id="post-source">@{post['content']}</div>
+      @end
     @end
   @elif not post['link']:
     <div id="postcontent"></div>

--- a/app/html/sub/postpoll.html
+++ b/app/html/sub/postpoll.html
@@ -1,7 +1,7 @@
 @require(pollData, postmeta, post)
 
 @def renderPoll(pollData, postmeta, post):
-  <div class="poll-space" data-pid="@{post['pid']}" data-votes="@{pollData['total_votes']}">
+  <div class="poll-space @{((post['visibility'] != '') and (post['visibility'] != 'none')) and 'deleted ' or ''}" data-pid="@{post['pid']}" data-votes="@{pollData['total_votes']}">
     @if not pollData['poll_open']:
       <p>@{_('This poll is now <b>closed</b>.')!!html}</p>
     @elif not pollData['has_voted']:

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -470,3 +470,34 @@ body.dark .bot-tag{
   background: #111;
   color: #7d7d7d;
 }
+
+/* deleted comments and posts view for mods and admins */
+body.dark .mod.report.preview .preview-text-container.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
+body.dark .mod.report.preview .preview-text-container.deleted #postcontent {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
+body.dark article.text-post.comment.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
+body.dark #postcontent.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
+body.dark .postbar.post.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
+body.dark .poll-space.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2097,6 +2097,10 @@ a.close-report {
   background-color: #FDD8D4;
 }
 
+.mod.report.preview .preview-text-container.deleted #postcontent {
+  background-color: #FDD8D4;
+}
+
 .mod.report.preview .preview-meta-data {
   display: flex;
   align-items: center;
@@ -2116,5 +2120,13 @@ article.text-post.comment.deleted {
 }
 
 #postcontent.deleted {
+  background-color: #FDD8D4;
+}
+
+.postbar.post.deleted {
+  background-color: #FDD8D4;
+}
+
+.poll-space.deleted {
   background-color: #FDD8D4;
 }

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -302,6 +302,23 @@ def view_post(sub, pid, comments=False, highlight=None):
         else:
             comments = misc.get_comment_tree(comments, uid=current_user.uid)
 
+    post['visibility'] = ''
+    if post['deleted'] == 1:
+        if current_user.is_admin():
+            post['visibility'] = 'admin-self-del'
+        elif current_user.is_mod(sub['sid'], 1):
+            post['visibility'] = 'mod-self-del'
+        else:
+            post['visibility'] = 'none'
+    elif post['deleted'] == 2:
+        if current_user.is_admin() or current_user.is_mod(sub['sid'], 1):
+            post['visibility'] = 'mod-del'
+        else:
+            post['visibility'] = 'none'
+
+    if post['userstatus'] == 10 and post['deleted'] == 1:
+        post['visibility'] = 'none'
+
     pollData = {'has_voted': False}
     postmeta = {}
     if post['ptype'] == 3:


### PR DESCRIPTION
**This PR is one piece of a larger feature implementation that includes:**

- [x] Allowing Mods and Admins to view some deleted comments (#75)
- [x] Allowing Mods and Admins to view some deleted posts
- [ ] Allowing Mods and Admins to view edit history

This PR only does the second of those three.

Follows the same permissions pattern as outlined in #75 . However, there is one change to how deleted posts used to look. Now, the title of a Deleted Post is only visible to Mods and Admins. I don't know if it was intentional that the titles of deleted posts were still displayed... to me I don't see why they should be, especially since titles can contain rule violations themselves. I can change this is people disagree, though.

Example of a user-deleted post as viewed by Admin:
![Screenshot from 2020-07-15 16 57 30](https://user-images.githubusercontent.com/17955536/87607915-149dd880-c6c4-11ea-8453-cfdf5fc6eb41.png)

Example of a Mod-deleted post as viewed by a Mod or Admin:
![Screenshot from 2020-07-15 16 52 41](https://user-images.githubusercontent.com/17955536/87607961-431bb380-c6c4-11ea-9258-bd3be262cbe2.png)

Example of a deleted post to a regular User:
![Screenshot from 2020-07-15 16 54 59](https://user-images.githubusercontent.com/17955536/87607930-28493f00-c6c4-11ea-95f1-966f34932959.png)

**This also includes corresponding UI changes in the Report Details View**
![Screenshot from 2020-07-15 17 59 54](https://user-images.githubusercontent.com/17955536/87608281-16b46700-c6c5-11ea-881b-67337c0c068e.png)

**Also, dark mode updates**
![Screenshot from 2020-07-15 17 36 12](https://user-images.githubusercontent.com/17955536/87607629-64c86b00-c6c3-11ea-91b0-ef941afd1c89.png)