### PR TITLE
Refactor Default Script

### DIFF
--- a/scripts/defaults.py
+++ b/scripts/defaults.py
@@ -11,10 +11,12 @@ app = create_app()
 
 # Args
 parser = argparse.ArgumentParser(description='Manage default subs.')
-parser.add_argument('subname', help='name of the sub you want to work with')
+
 addremove = parser.add_mutually_exclusive_group()
-addremove.add_argument('-a', '--add', action='store_true', help='add a sub to defaults')
-addremove.add_argument('-r', '--remove', action='store_true', help='remove a sub from defaults')
+addremove.add_argument('-a', '--add', metavar='SUBNAME', help='add a sub to defaults')
+addremove.add_argument('-r', '--remove', metavar='SUBNAME', help='remove a sub from defaults')
+addremove.add_argument('-l', '--list', action='store_true', help='List administrators')
+
 args = parser.parse_args()
 
 
@@ -30,8 +32,12 @@ def getSid(subname):
 def addSub(subname):
     isSub, sid = getSid(subname)
     if isSub:
-        SiteMetadata.create(key='default', value=sid)
-        print('SUCCESS: Sub \"' + subname + '\" added to defaults.')
+        try:
+            metadata = SiteMetadata.get((SiteMetadata.key == 'default') & (SiteMetadata.value == sid))
+            print('ERROR: Sub \"' + subname + '\" is already a default!')
+        except SiteMetadata.DoesNotExist:
+            SiteMetadata.create(key='default', value=sid)
+            print('SUCCESS: Sub \"' + subname + '\" added to defaults.')
     else:
         print('ERROR: Sub \"' + subname + '\" does not exist!')
 
@@ -51,10 +57,20 @@ def remSub(subname):
         print('ERROR: Sub \"' + subname + '\" does not exist!')
 
 
+def listSubs():
+    defaults = [x.value for x in SiteMetadata.select().where(SiteMetadata.key == 'default')]
+    defaults = Sub.select(Sub.sid, Sub.name).where(Sub.sid << defaults)
+    print("Default Subs: ")
+    for i in defaults:
+        print("  ", i.name)
+
+
 # Main
 if args.add:
-    addSub(args.subname)
+    addSub(args.add.lower())
 elif args.remove:
-    remSub(args.subname)
+    remSub(args.remove.lower())
+elif args.list:
+    listSubs()
 else:
     print('ERROR: No action specified. Try \"-h\" for help.')


### PR DESCRIPTION
We noticed a bug where it was possible to add a default sub twice, which was causing the Default Feed for a Logged Out user to display posts from that Default Sub twice on that feed. It is a little bit hard to reproduce because of the caching on default subs - but if you add the sub twice and wait the bug will eventually appear.

I've refactored the default sub script a bit to avoid this bug by checking if the default sub already exists first, and to be more like the Admin script. Also added new option `--list` to list current defaults.

cc: @ferocious-ferret who first noticed this

Bug screenshot:
![Screenshot from 2020-07-16 00 05 31](https://user-images.githubusercontent.com/17955536/87701449-a3126880-c75d-11ea-9450-15a83e29b7b2.png)
