### PR TITLE
Allow Mods and Admins to view comment edit history

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,7 @@ cfg_defaults = {  # key => default value
             "sub_creation_min_level": 2,
             "sub_creation_admin_only": False,
             "sub_ownership_limit": 20,
+            "edit_history": False,
 
             "daily_sub_posting_limit": 10,
             "daily_site_posting_limit": 25,

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -53,13 +53,19 @@
               @end
               @if current_user.is_admin() and comment['history']:
                   @for count, history in enumerate(comment['history']):
-                  <span style="display:none;" class="history" data-id="@{(count + 1)!!s}">
+                  <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
                       @{history['content']!!html}
                   </span>
                   @end
                   <div>
-                    <button class="content-forward-history">←</button>&nbsp;
-                    <button class="content-back-history">→</button> (<span class="count">@{1 + len(comment['history'])!!s}</span> / @{1 + len(comment['history'])!!s})
+                    <button class="browse-comment-history back" data-action="back">←</button>
+                    <button class="browse-comment-history forward disabled" action="forward">→</button>
+                    <span class="history-meta">
+                      @{_('Viewing edit history:')}
+                        <span class="history-version">
+                          1/@{1 + len(comment['history'])!!s}
+                        </span>
+                    </span>
                   </div>
               @end
             </div>

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -42,14 +42,25 @@
                 @{_('[Deleted]')} \
               @elif comment['visibility'] == 'admin-self-del':
                 <p class="helper-text">@{_('[Post deleted by user]')}</p>
-                @{comment['content']!!html}
+                <span class="current history" data-id="0">@{comment['content']!!html}</span>
               @elif comment['visibility'] == 'mod-self-del':
                 <p class="helper-text">@{_('[Post deleted by user]')}</p>
               @elif comment['visibility'] == 'mod-del':
                 <p class="helper-text">@{_('[Post deleted by mod or admin]')}</p>
-                @{comment['content']!!html}
+                <span class="current history" data-id="0">@{comment['content']!!html}</span>
               @else:
-                @{comment['content']!!html}
+                <span class="current history" data-id="0">@{comment['content']!!html}</span>
+              @end
+              @if current_user.is_admin() and comment['history']:
+                  @for count, history in enumerate(comment['history']):
+                  <span style="display:none;" class="history" data-id="@{(count + 1)!!s}">
+                      @{history['content']!!html}
+                  </span>
+                  @end
+                  <div>
+                    <button class="content-forward-history">←</button>&nbsp;
+                    <button class="content-back-history">→</button> (<span class="count">@{1 + len(comment['history'])!!s}</span> / @{1 + len(comment['history'])!!s})
+                  </div>
               @end
             </div>
 

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -51,7 +51,7 @@
               @else:
                 <span class="current history" data-id="0">@{comment['content']!!html}</span>
               @end
-              @if current_user.is_admin() and comment['history']:
+              @if comment['history'] and (comment['visibility'] != 'none' and  comment['visibility'] != 'mod-self-del'):
                   @for count, history in enumerate(comment['history']):
                   <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
                       @{history['content']!!html}

--- a/app/misc.py
+++ b/app/misc.py
@@ -1616,7 +1616,7 @@ def get_comment_tree(comments, root=None, only_after=None, uid=None, provide_con
         # del comm['userstatus']
         commdata[comm['cid']] = comm
 
-    if include_history:
+    if config.site.edit_history and include_history:
         history = SubPostCommentHistory.select(SubPostCommentHistory.cid, SubPostCommentHistory.content,
                 SubPostCommentHistory.datetime) \
                         .where(SubPostCommentHistory.cid << cid_list) \

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2130,3 +2130,31 @@ article.text-post.comment.deleted {
 .poll-space.deleted {
   background-color: #FDD8D4;
 }
+
+.browse-comment-history.disabled:focus {
+  outline-color: lightgray;
+  outline: none;
+}
+
+.browse-comment-history {
+  cursor: pointer;
+  -webkit-box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
+  -moz-box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
+  box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
+}
+
+.browse-comment-history.disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  border-color: lightgray;
+  color: lightgray;
+}
+
+.content .old.history {
+  color: gray;
+}
+
+.content .history-meta {
+  color: gray;
+  font-size: smaller;
+}

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -42,49 +42,41 @@ u.addEventForChild(document, 'click', '.delete-post', function (e, qelem) {
     });
 });
 
-u.addEventForChild(document, 'click', '.content-back-history', function (e, qelem) {
-    const content = qelem.parentNode.parentNode;
-    console.log("CONTENT:" + content)
-    const history = content.querySelectorAll('.history')
-    console.log("HISTORY:" + history)
-    const shown = Array.from(history).filter(function(span) {
-        return span.style['display'] != 'none'
-    })[0]
-    console.log("SHOWN:" + shown)
+u.addEventForChild(document, 'click', '.browse-comment-history', function (e, qelem) {
+  const action = qelem.getAttribute("data-action")
+  const content = qelem.parentNode.parentNode;
+  const history = content.querySelectorAll('.history')
+  const shown = Array.from(history).filter(function(span) {
+      return span.style['display'] != 'none'
+  })[0]
+  const id = parseInt(shown.getAttribute("data-id"))
+  let next_id
 
+  if (action == "back") {
+    next_id = (id + 1)
+  } else {
+    next_id = (id - 1)
+  }
 
-    const id = parseInt(shown.getAttribute("data-id"))
-    const next_id = ((id - 1) < 0 ? history.length : id) - 1
+  history[next_id].style['display'] = ''
+  shown.style['display'] = 'none'
 
-    const currentVis = parseInt(content.querySelector(".count").innerText, 10)
-    content.querySelector(".count").innerText = (currentVis  % history.length) + 1
+  const fwd_button = content.querySelector('.browse-comment-history.forward')
+  const back_button = content.querySelector('.browse-comment-history.back')
 
-    history[next_id].style['display'] = ''
-    shown.style['display'] = 'none'
+  if (next_id == 0){
+    fwd_button.classList.add('disabled')
+    back_button.classList.remove('disabled')
+  } else if (next_id == (history.length - 1)) {
+    back_button.classList.add('disabled')
+    fwd_button.classList.remove('disabled')
+  }
+  else {
+    fwd_button.classList.remove('disabled')
+    back_button.classList.remove('disabled')
+  }
 
-});
-
-u.addEventForChild(document, 'click', '.content-forward-history', function (e, qelem) {
-    const content = qelem.parentNode.parentNode;
-    console.log("CONTENT:" + content)
-
-    const history = content.querySelectorAll('.history')
-    console.log("HISTORY:" + history)
-
-    const shown = Array.from(history).filter(function(span) {
-        return span.style['display'] != 'none'
-    })[0]
-    console.log("SHOWN:" + shown)
-
-
-    const id = parseInt(shown.getAttribute("data-id"))
-    const next_id = (id + 1) % history.length
-
-    const currentVis = parseInt(content.querySelector(".count").innerText, 10)
-    content.querySelector(".count").innerText = (currentVis - 1 < 0 ? history.length: currentVis) - 1
-
-    history[next_id].style['display'] = ''
-    shown.style['display'] = 'none'
+  content.querySelector('.history-version').innerHTML = (next_id + 1) + '/' + history.length
 
 });
 

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -42,6 +42,52 @@ u.addEventForChild(document, 'click', '.delete-post', function (e, qelem) {
     });
 });
 
+u.addEventForChild(document, 'click', '.content-back-history', function (e, qelem) {
+    const content = qelem.parentNode.parentNode;
+    console.log("CONTENT:" + content)
+    const history = content.querySelectorAll('.history')
+    console.log("HISTORY:" + history)
+    const shown = Array.from(history).filter(function(span) {
+        return span.style['display'] != 'none'
+    })[0]
+    console.log("SHOWN:" + shown)
+
+
+    const id = parseInt(shown.getAttribute("data-id"))
+    const next_id = ((id - 1) < 0 ? history.length : id) - 1
+
+    const currentVis = parseInt(content.querySelector(".count").innerText, 10)
+    content.querySelector(".count").innerText = (currentVis  % history.length) + 1
+
+    history[next_id].style['display'] = ''
+    shown.style['display'] = 'none'
+
+});
+
+u.addEventForChild(document, 'click', '.content-forward-history', function (e, qelem) {
+    const content = qelem.parentNode.parentNode;
+    console.log("CONTENT:" + content)
+
+    const history = content.querySelectorAll('.history')
+    console.log("HISTORY:" + history)
+
+    const shown = Array.from(history).filter(function(span) {
+        return span.style['display'] != 'none'
+    })[0]
+    console.log("SHOWN:" + shown)
+
+
+    const id = parseInt(shown.getAttribute("data-id"))
+    const next_id = (id + 1) % history.length
+
+    const currentVis = parseInt(content.querySelector(".count").innerText, 10)
+    content.querySelector(".count").innerText = (currentVis - 1 < 0 ? history.length: currentVis) - 1
+
+    history[next_id].style['display'] = ''
+    shown.style['display'] = 'none'
+
+});
+
 u.addEventForChild(document, 'click', '.edit-title', function (e, qelem) {
     const tg = e.currentTarget;
     TextConfirm(qelem, function () {

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1596,7 +1596,7 @@ def edit_comment():
             return jsonify(status='error', error=_("Post is archived"))
 
         dt = datetime.datetime.utcnow()
-        spm = SubPostCommentHistory.create(cid=comment.cid, content=comment.content, datetime=dt if not comment.lastedit else comment.lastedit)
+        spm = SubPostCommentHistory.create(cid=comment.cid, content=comment.content, datetime=dt)
         spm.save()
         comment.content = form.text.data
         comment.lastedit = dt

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -642,12 +642,13 @@ def create_comment(pid):
                           room='user' + to)
 
         subMods = misc.getSubMods(sub.sid)
+        include_history = current_user.is_mod(sub.sid, 1) or current_user.is_admin()
 
         # 6 - Process mentions
         misc.workWithMentions(form.comment.data, to, post, sub, cid=comment.cid)
         renderedComment = engine.get_template('sub/postcomments.html').render({
             'post': misc.getSinglePost(post.pid),
-            'comments': misc.get_comment_tree([{'cid': str(comment.cid), 'parentcid': None}], uid=current_user.uid, include_history=current_user.is_admin()),
+            'comments': misc.get_comment_tree([{'cid': str(comment.cid), 'parentcid': None}], uid=current_user.uid, include_history=include_history),
             'subInfo': misc.getSubData(sub.sid),
             'subMods': subMods,
             'highlight': str(comment.cid)
@@ -1687,10 +1688,12 @@ def get_sibling(pid, cid, lim):
     if not comments.count():
         return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': [], 'subInfo': {}, 'highlight': ''})
 
+    include_history = current_user.is_mod(sub.sid, 1) or current_user.is_admin()
+
     if lim:
-        comment_tree = misc.get_comment_tree(comments, cid if cid != '0' else None, lim, provide_context=False, uid=current_user.uid, include_history=current_user.is_admin())
+        comment_tree = misc.get_comment_tree(comments, cid if cid != '0' else None, lim, provide_context=False, uid=current_user.uid, include_history=include_history)
     elif cid != '0':
-        comment_tree = misc.get_comment_tree(comments, cid, provide_context=False, uid=current_user.uid, include_history=current_user.is_admin())
+        comment_tree = misc.get_comment_tree(comments, cid, provide_context=False, uid=current_user.uid, include_history=include_history)
     else:
         return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': [], 'subInfo': {}, 'highlight': ''})
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -59,6 +59,9 @@ site:
   # Set to zero to disable sub creation level limits
   sub_creation_min_level: 2
 
+  # Allows Sub Mods and Admins to view the edit history of posts
+  edit_history: False
+
   # Maximum amount of subs a single user can own.
   # The actual amount of subs a user may register scales with user level (user level minus one)
   # so a level 0 or level 1 user cannot register any subs. This scaling is disabled if `sub_creation_min_level` is zero


### PR DESCRIPTION
This PR introduces the ability for Admins and Sub Mods to view edit history on comments. This can be turned on and off with `config.site.edit_history`, and off is set to config default so as not to interfere with existing sites. 

The permission for viewing edits on deleted posts is the same as permissions for viewing the deleted post.
![Screenshot from 2020-07-16 18 19 46](https://user-images.githubusercontent.com/17955536/87731877-1da8ab80-c791-11ea-948e-28119b1aaea5.png)

Also works on deleted posts:
![Screenshot from 2020-07-16 18 20 35](https://user-images.githubusercontent.com/17955536/87731875-1d101500-c791-11ea-8fb6-dae7dc0b2642.png)

