### PR TITLE
Admins and Submods can view post title and content edit history

### DIFF
--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -139,12 +139,12 @@ Mod |\
                     @if post['deleted'] != 1 or current_user.is_admin():
                       @if post['deleted'] == 2:
                         <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
-                      @else:
+                      @elif post['deleted'] == 1:
                         <p class="helper-text">@{_('[post deleted by user]')}</p>
                       @end
                       <h3>@{post['title']}</h3>
                       @if post['content']:
-                        <div id="postcontent">
+                        <div id="postcontent" class="post-content-container">
                           @{markdown(post['content'])!!html}
                         </div>
                         <div id="post-source">@{post['content']}</div>

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(post, sub, is_saved, subInfo, pollData, commentform, comments, postmeta, subMods, highlight)
+@require(post, sub, is_saved, subInfo, pollData, commentform, comments, postmeta, subMods, highlight, content_history, title_history)
 @import "sub/postcomments.html" as pcomm
 @import "sub/postpoll.html" as polls
 
@@ -83,6 +83,7 @@
           <span class="postflair">@{post['flair']}</span>
         @end
 
+        <span class="current history" data-id="0">
         @if post['link'] == None:
           <h1><a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
             @if (post['visibility'] == ''):
@@ -114,6 +115,33 @@
           @if post['deleted'] == 0:
             <a href="/domain/@{func.getDomain(post['link'])}" class="domain">(@{func.getDomain(post['link'])})</a>
           @end
+        @end
+        </span>
+
+        @if title_history and (post['visibility'] != 'none' and  post['visibility'] != 'mod-self-del'):
+            @for count, old_title in enumerate(title_history):
+              <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
+                @if post['link'] == None:
+                  <h1><a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
+                      @{old_title['title']}
+                  </a></h1>
+                @else:
+                <h1><a rel="nofollow ugc @{(post['visibility'] == 'none') and 'noopener ' or ''}" href="@{(post['visibility'] != 'none') and post['link'] or '#'}" class="title">
+                  @{old_title['title']}
+                </a></h1>
+                @end
+              </span>
+            @end
+            <div class="title-history-controls">
+              <button class="browse-history back" data-action="back">←</button>
+              <button class="browse-history forward disabled" action="forward">→</button>
+              <span class="history-meta">
+                @{_('Viewing title history:')}
+                  <span class="history-version">
+                    1/@{1 + len(title_history)!!s}
+                  </span>
+              </span>
+            </div>
         @end
       </div>
       <ul class="links" data-pid="@{post['pid']}">
@@ -206,29 +234,47 @@
   @end
 
   @if post['content']:
-    <!-- <p class="helper-text">Post Visibility: @{post['visibility']}</p> -->
+  <div>
     @if post['deleted'] == 0:
-      <div id="postcontent">
-        @{markdown(post['content'])!!html}
-      </div>
+      <span class="current history" data-id="0">
+        <div id="postcontent" class="post-content-container">@{markdown(post['content'])!!html}</div>
+      </span>
       <div id="post-source">@{post['content']}</div>
     @else:
       @if ((post['visibility'] == 'none') or (post['visibility'] == 'mod-self-del')):
-        <div id="postcontent" class="@{(post['visibility'] == 'mod-self-del') and 'deleted ' or ''}">
+        <div id="postcontent" class="post-content-container @{(post['visibility'] == 'mod-self-del') and 'deleted ' or ''}">
           @{_('[deleted]')}
         </div>
       @elif ((post['visibility'] == 'admin-self-del') or (post['visibility'] == 'mod-del')):
-        <div id="postcontent" class="deleted">
-          @{markdown(post['content'])!!html}
-        </div>
+        <span class="current history" data-id="0">
+          <div id="postcontent" class="post-content-container deleted">@{markdown(post['content'])!!html}</div>
+        </span>
         <div id="post-source">@{post['content']}</div>
       @end
     @end
   @elif not post['link']:
-    <div id="postcontent"></div>
-    <div id="post-source"></div>
+    <div id="postcontent" class="post-content-container"></div>
+    <div id="post-source" class="post-content-container"></div>
   @end
 
+  @if content_history and post['content'] and  (post['visibility'] != 'none' and  post['visibility'] != 'mod-self-del'):
+      @for count, old_version in enumerate(content_history):
+        <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
+          <div class="post-content-container @{(post['visibility'] != '') and 'deleted ' or ''}">@{markdown(old_version['content'])!!html}</div>
+        </span>
+      @end
+      <div class="post-history-controls @{(post['visibility'] != '') and 'deleted ' or ''}"">
+        <button class="browse-history back" data-action="back">←</button>
+        <button class="browse-history forward disabled" action="forward">→</button>
+        <span class="history-meta">
+          @{_('Viewing edit history:')}
+            <span class="history-version">
+              1/@{1 + len(content_history)!!s}
+            </span>
+        </span>
+      </div>
+  @end
+  </div>
 
   @if current_user.is_authenticated and post['deleted'] == 0 and not current_user.is_subban(sub):
   <form data-reset="true" data-redir="true" action="@{url_for('do.create_comment', pid=post['pid'])}" id="rcomm-0" class="comment-form ajaxform static pure-form">

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -58,8 +58,8 @@
                   </span>
                   @end
                   <div>
-                    <button class="browse-comment-history back" data-action="back">←</button>
-                    <button class="browse-comment-history forward disabled" action="forward">→</button>
+                    <button class="browse-history back" data-action="back">←</button>
+                    <button class="browse-history forward disabled" action="forward">→</button>
                     <span class="history-meta">
                       @{_('Viewing edit history:')}
                         <span class="history-version">

--- a/app/misc.py
+++ b/app/misc.py
@@ -37,7 +37,7 @@ from .models import Sub, SubPost, User, SiteMetadata, SubSubscriber, Message, Us
 from .models import SubPostVote, SubPostComment, SubPostCommentVote, SiteLog, SubLog, db
 from .models import SubPostReport, SubPostCommentReport, PostReportLog, CommentReportLog, Notification
 from .models import SubMetadata, rconn, SubStylesheet, UserIgnores, SubUploads, SubFlair, InviteCode
-from .models import SubMod, SubBan, SubPostCommentHistory
+from .models import SubMod, SubBan, SubPostCommentHistory, SubPostContentHistory
 from .storage import store_thumbnail, file_url, thumbnail_url
 from peewee import JOIN, fn, SQL, NodeList, Value
 import requests

--- a/app/models.py
+++ b/app/models.py
@@ -548,6 +548,31 @@ class SubPostCommentHistory(BaseModel):
         table_name = "sub_post_comment_history"
 
 
+class SubPostContentHistory(BaseModel):
+    pid = ForeignKeyField(db_column='pid', model=SubPost, field='pid')
+    datetime = DateTimeField(default=datetime.datetime.now)
+    content = TextField(null=True)
+
+    def __repr__(self):
+        return f'<SubPostContentHistory "{self.content[:20]}">'
+
+    class Meta:
+        table_name = "sub_post_content_history"
+
+
+
+class SubPostTitleHistory(BaseModel):
+    pid = ForeignKeyField(db_column='pid', model=SubPost, field='pid')
+    datetime = DateTimeField(default=datetime.datetime.now)
+    title = TextField(null=True)
+
+    def __repr__(self):
+        return f'<SubPostContentHistory "{self.content[:20]}">'
+
+    class Meta:
+        table_name = "sub_post_title_history"
+
+
 class UserIgnores(BaseModel):
     uid = ForeignKeyField(db_column='uid', model=User, field='uid')
     target = CharField(max_length=40)

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -213,7 +213,7 @@ body.dark{
   color: #666;
 }
 
-body.dark #postcontent, body.dark .poll-space{
+body.dark .post-content-container, body.dark .poll-space{
   background: #111;
 }
 body.dark .editbtns{
@@ -477,7 +477,7 @@ body.dark .mod.report.preview .preview-text-container.deleted {
   border: 1px solid red;
 }
 
-body.dark .mod.report.preview .preview-text-container.deleted #postcontent {
+body.dark .mod.report.preview .preview-text-container.deleted.post-content-container {
   background-color: #171717;
   border: 1px solid red;
 }
@@ -487,9 +487,8 @@ body.dark article.text-post.comment.deleted {
   border: 1px solid red;
 }
 
-body.dark #postcontent.deleted {
+body.dark .post-content-container.deleted {
   background-color: #171717;
-  border: 1px solid red;
 }
 
 body.dark .postbar.post.deleted {
@@ -500,4 +499,28 @@ body.dark .postbar.post.deleted {
 body.dark .poll-space.deleted {
   background-color: #171717;
   border: 1px solid red;
+}
+
+body.dark .browse-history {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  background-color: #171717;
+  border: 1px solid #d94f00;
+  color: lightgray;
+}
+
+body.dark .browse-history.disabled {
+  border-color: #333;
+  color: #171717;
+}
+
+body.dark .browse-history.disabled:focus {
+  outline-color: #333;
+  outline: none;
+}
+
+body.dark .browse-history:focus {
+  outline-color: #d94f00;
+  outline: none;
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1286,12 +1286,12 @@ input[type=search] {
   margin-top: .3em;
 }
 
-#postcontent, .poll-space {
+.post-content-container, .poll-space {
   background-color: #f6f6f6;
   padding: .4em 1em; /* 1px margin on botton and top so it respects <p>'s margin */
 }
 
-#postcontent textarea, .commblock textarea{
+.post-content-container textarea, .commblock textarea{
   resize: vertical;
   width: 100%;
   overflow: auto;
@@ -1906,11 +1906,11 @@ a[href="#toodamncool"]{
 
 @keyframes rb3{20%{color: red;}40%{color: yellow;}60%{color: green;}80%{color: blue;}100%{color: orange;}}
 
-.expandotxt, #postcontent, .commblock .content{
+.expandotxt, .post-content-container, .commblock .content{
   word-wrap: break-word;
 }
 
-#postcontent img, .comments .content img{
+.post-content-container img, .comments .content img{
   max-width: 100%;
 }
 
@@ -2097,7 +2097,7 @@ a.close-report {
   background-color: #FDD8D4;
 }
 
-.mod.report.preview .preview-text-container.deleted #postcontent {
+.mod.report.preview .preview-text-container.deleted.post-content-container {
   background-color: #FDD8D4;
 }
 
@@ -2119,7 +2119,7 @@ article.text-post.comment.deleted {
   background-color: #FDD8D4;
 }
 
-#postcontent.deleted {
+.post-content-container.deleted {
   background-color: #FDD8D4;
 }
 
@@ -2131,30 +2131,47 @@ article.text-post.comment.deleted {
   background-color: #FDD8D4;
 }
 
-.browse-comment-history.disabled:focus {
+.post-history-controls {
+  margin: 1em 1em 0 1em;
+}
+
+.title-history-controls {
+  margin: 1em 0;
+}
+
+.title-history-controls button {
+  font-size: 1em;
+}
+
+.browse-history:focus {
+  outline: none;
+}
+
+.browse-history.disabled:focus {
   outline-color: lightgray;
   outline: none;
 }
 
-.browse-comment-history {
+.browse-history {
+  border-radius: 2px;
   cursor: pointer;
   -webkit-box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
   -moz-box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
   box-shadow: -2px 1px 3px 0px rgba(0,0,0,0.1);
 }
 
-.browse-comment-history.disabled {
+.browse-history.disabled {
   cursor: not-allowed;
   pointer-events: none;
   border-color: lightgray;
   color: lightgray;
 }
 
-.content .old.history {
+.wholepost .old.history {
   color: gray;
 }
 
-.content .history-meta {
+.wholepost .history-meta {
   color: gray;
   font-size: smaller;
 }

--- a/app/static/js/Poll.js
+++ b/app/static/js/Poll.js
@@ -10,7 +10,7 @@ u.sub('#poll-addoption', 'click', function(e){
     if(opts.childElementCount >= 6){
         return;
     }
-    
+
     // All is OK, add the option.
     var node = document.createElement('li');
     var tb = document.createElement('input');
@@ -38,7 +38,6 @@ u.addEventForChild(document, 'click', '.poll-del-opt', function(e, qelem){
 
 
 u.sub('#closetime', 'click', function(e){
-    console.log('wooo')
     if(this.checked){
         document.getElementById('closetime_date').removeAttribute('disabled');
         document.querySelector('.date-picker-future.input').removeAttribute('disabled');
@@ -156,7 +155,7 @@ u.addEventForChild(document, 'click', '.poll-withdraw-btn', function(e, qelem){
                     if(locoid == veoid){
                         locvotes--;
                         k.setAttribute('data-votes', locvotes)
-                    }    
+                    }
                     var pbar = document.querySelector(".poll-option[data-oid='" + locoid + "'] .poll-pbar").children[0];
                     if(locvotes != 0){
                         var percent = Math.round(locvotes/totalVotes*100);
@@ -170,6 +169,6 @@ u.addEventForChild(document, 'click', '.poll-withdraw-btn', function(e, qelem){
                 })
             }
             te.parentNode.style.display = 'none';
-        }   
+        }
     });
 });

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -42,7 +42,7 @@ u.addEventForChild(document, 'click', '.delete-post', function (e, qelem) {
     });
 });
 
-u.addEventForChild(document, 'click', '.browse-comment-history', function (e, qelem) {
+u.addEventForChild(document, 'click', '.browse-history', function (e, qelem) {
   const action = qelem.getAttribute("data-action")
   const content = qelem.parentNode.parentNode;
   const history = content.querySelectorAll('.history')
@@ -61,8 +61,8 @@ u.addEventForChild(document, 'click', '.browse-comment-history', function (e, qe
   history[next_id].style['display'] = ''
   shown.style['display'] = 'none'
 
-  const fwd_button = content.querySelector('.browse-comment-history.forward')
-  const back_button = content.querySelector('.browse-comment-history.back')
+  const fwd_button = content.querySelector('.browse-history.forward')
+  const back_button = content.querySelector('.browse-history.back')
 
   if (next_id == 0){
     fwd_button.classList.add('disabled')

--- a/migrations/016_subposthistory.py
+++ b/migrations/016_subposthistory.py
@@ -1,0 +1,35 @@
+"""Peewee migrations -- 016_SubPostContentHistory.py.
+"""
+
+import datetime as dt
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+
+    @migrator.create_model
+    class SubPostContentHistory(pw.Model):
+        pid = pw.ForeignKeyField(backref='SubPostContentHistory_set', column_name='pid', field='pid', model=migrator.orm['sub_post'], null=True)
+        content = pw.CharField(max_length=255, null=True)
+        datetime = pw.DateTimeField()
+
+        class Meta:
+            table_name = "sub_post_content_history"
+
+    @migrator.create_model
+    class SubPostTitleHistory(pw.Model):
+        pid = pw.ForeignKeyField(backref='SubPostTitleHistory', column_name='pid', field='pid', model=migrator.orm['sub_post'], null=True)
+        title = pw.CharField(max_length=255, null=True)
+        datetime = pw.DateTimeField()
+
+        class Meta:
+            table_name = "sub_post_title_history"
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    migrator.remove_model('SubPostContentHistory')
+    migrator.remove_model('SubPostTitleHistory')


### PR DESCRIPTION
Building off #75, this PR allows SubMods and Admins to view post content and title edit history.
Can be turned on and off along with comment edit history with `config.site.edit_history`

Works pretty much exactly the same as the comment edit history.
Should not change anything for regular (non-mod. non-admin) users.

![Screenshot from 2020-07-17 19 28 27](https://user-images.githubusercontent.com/17955536/87841021-21f3c800-c868-11ea-8881-a2faab728db9.png)

![Screenshot from 2020-07-17 19 48 09](https://user-images.githubusercontent.com/17955536/87841028-26b87c00-c868-11ea-9264-bf8507baa505.png)

![Screenshot from 2020-07-17 19 28 43](https://user-images.githubusercontent.com/17955536/87841032-2c15c680-c868-11ea-8cf8-070d29193ed8.png)
 