### PR TITLE
Fix display of errors and messages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,6 +40,10 @@ login_manager = LoginManager()
 login_manager.anonymous_user = SiteAnon
 login_manager.login_view = 'auth.login'
 
+# Allow translation of the messages shown by flask_login.
+login_manager.login_message = _('Please log in to access this page.')
+login_manager.needs_refresh_message = _('Please reauthenticate to access this page.')
+
 
 def create_app(config=Config('config.yaml')):
     app = Flask(__name__)

--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -130,6 +130,12 @@
   @def content():
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-18-24"> <!-- main -->
+      @for err in get_flashed_messages(category_filter=["error"]):
+        <div class="error" style="margin-top: 2em;">@{ err }</div>
+      @end
+      @for message in get_flashed_messages(category_filter=["message"]):
+        <div class="message" style="margin-top: 2em;">@{ message }</div>
+      @end
       @def main():
       @end
       @{main()!!html}

--- a/app/html/user/password_recovery.html
+++ b/app/html/user/password_recovery.html
@@ -8,9 +8,6 @@
 <div id="center-container">
   <div class="content">
     <div class="alert div-error"></div>
-    @for err in get_flashed_messages(category_filter=["error"]):
-    <div class="error" style="margin-top: 2em;">@{ err }</div>
-    @end
     <form  method="POST" action="@{url_for('do.recovery')}" class="ajaxform pure-form pure-form-aligned">
       <h1>@{_('Password recovery')}</h1> @{ lpform.csrf_token() !!html}
       <fieldset>

--- a/app/html/user/register.html
+++ b/app/html/user/register.html
@@ -11,12 +11,6 @@
       @if error:
         <div class="error" style="margin-top: 2em;">@{ error }</div>
       @end
-      @for err in get_flashed_messages(category_filter=["error"]):
-        <div class="error" style="margin-top: 2em;">@{ err }</div>
-      @end
-      @for message in get_flashed_messages(category_filter=["message"]):
-        <div class="message" style="margin-top: 2em;">@{ message }</div>
-      @end
         <form method="POST" class="pure-form pure-form-aligned">
             @{ regform.csrf_token()!!html }
             <h1>@{_('Register')}</h1>

--- a/app/html/user/settings/account.html
+++ b/app/html/user/settings/account.html
@@ -7,12 +7,6 @@
 @def main():
 <div id="container">
   <h1>@{_('%(user)s\'s account', user=user.name)}</h1>
-  @for err in get_flashed_messages(category_filter=["error"]):
-    <div class="error" style="margin-top: 2em;">@{ err }</div>
-  @end
-  @for message in get_flashed_messages(category_filter=["message"]):
-    <div class="message" style="margin-top: 2em;">@{ message }</div>
-  @end
   <form  method="POST" id="edit-user-form" data-refresh='true'  action="@{url_for('do.edit_account')}" class="ajaxform pure-form pure-form-aligned">
     @{form.csrf_token()!!html}
     <fieldset>

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -234,7 +234,11 @@ u.ready(function() {
           }
           if(target.querySelector('.div-message')){
             target.querySelector('.div-message').innerHTML = message;
-            target.querySelector('.div-message').style.display = 'block';
+            if (message) {
+                target.querySelector('.div-message').style.display = 'block';
+            } else {
+                target.querySelector('.div-message').style.display = 'none';
+            }
           }
           if(target.querySelector('.div-error')){
             target.querySelector('.div-error').style.display = 'none';

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -130,6 +130,20 @@
 
   <div class="pure-g">
     <div class="pure-u-1 pure-u-md-18-24"> <!-- main -->
+      {% with errors = get_flashed_messages(category_filter=["error"]) %}
+        {% if errors %}
+          {% for err in errors %}
+            <div class="error" style="margin-top: 2em;">@{ err }</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% with messages = get_flashed_messages(category_filter=["message"]) %}
+        {% if messages %}
+          {% for msg in messages %}
+            <div class="message" style="margin-top: 2em;">@{ msg }</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
       {% block main %}
         <div id="container">{% block content %}{% endblock %}</div>
       {% endblock %}

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -97,7 +97,7 @@ def edit_account():
             return json.dumps({'status': 'error',
                                'error': [_('Incorrect password')]})
 
-        messages = []
+        messages = None
         if form.password.data or email != user.email:
             if form.password.data:
                 auth_provider.change_password(user, form.oldpassword.data, form.password.data)
@@ -108,8 +108,8 @@ def edit_account():
                 else:
                     auth_provider.set_pending_email(user, email)
                     send_email_confirmation_link_email(user, email)
-                    messages.append(_('To confirm, click the link in the email we sent to you. '
-                                      'You may want to check your spam folder, just in case ;)'))
+                    messages = [_('To confirm, click the link in the email we sent to you. '
+                                  'You may want to check your spam folder, just in case ;)')]
         return json.dumps({'status': 'ok', 'message': messages})
     return json.dumps({'status': 'error', 'error': get_errors(form)})
 


### PR DESCRIPTION
`flask-login` uses 'flash' to display messages, and `flash` saves messages in the session cookie until a page uses `get_flashed_messages`.  The messages from `flask-login` never used to show up at all, but now that the email confirmation views use 'flash', `flask-login` messages are showing up in those views, possibly a long time after they were originally issued.  Move the flashed messages to the main layout templates so that the messages from `flask-login` get displayed immediately.

Also get rid of a green line that was showing up on a successful password change.
