### PR TITLE
Cyrillic character ranges in regex

### DIFF
--- a/app/html/sub/create.html
+++ b/app/html/sub/create.html
@@ -18,7 +18,7 @@
             <fieldset>
                 <div class="pure-control-group">
                     <label for="subname">@{_('Sub name')}</label>
-                    @{ csubform.subname(placeholder=csubform.subname.label.text, required=True, pattern="[a-zA-Z0-9]+", title=_('Alphanumeric characters')) !!html}
+                    @{ csubform.subname(placeholder=csubform.subname.label.text, required=True, pattern="[a-zA-Zа-яА-Я0-9]+", title=_('Alphanumeric characters')) !!html}
                 </div>
                 <div class="pure-control-group">
                     <label for="description">@{_('Description')}</label>

--- a/app/misc.py
+++ b/app/misc.py
@@ -48,7 +48,7 @@ from wheezy.template.loader import FileLoader, autoreload
 
 
 # Regex that matches VALID user and sub names
-allowedNames = re.compile("^[a-zA-Z0-9_-]+$")
+allowedNames = re.compile("^[a-zA-Zа-яА-Я0-9_-]+$")
 WHITESPACE = "\u0009\u000A\u000B\u000C\u000D\u0020\u0085\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007" \
              "\u2008\u2009\u200a\u200b\u2029\u202f\u205f\u3000\u180e\u200b\u200c\u200d\u2060\ufeff\u00AD\ufffc "
 

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -67,7 +67,7 @@ def search(stype):
     if not current_user.is_admin() and stype.startswith('admin'):
         abort(403)
     form = SearchForm()
-    term = re.sub(r'[^A-Za-z0-9.,\-_\'" ]+', '', form.term.data)
+    term = re.sub(r'[^A-Za-zа-яА-Яё0-9.,\-_\'" ]+', '', form.term.data)
     return redirect(url_for(stype, term=term))
 
 

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -100,7 +100,7 @@ def all_domain_new(domain, page):
 @bp.route("/search/<term>/<int:page>")
 def search(page, term):
     """ The index page, with basic title search """
-    term = re.sub(r'[^A-Za-z0-9.,\-_\'" ]+', '', term)
+    term = re.sub(r'[^A-Za-zа-яА-Яё0-9.,\-_\'" ]+', '', term)
     posts = misc.getPostList(misc.postListQueryBase().where(SubPost.title ** ('%' + term + '%')),
                              'new', page).dicts()
     return engine.get_template('index.html').render({'posts': posts, 'sort_type': 'home.search', 'page': page,
@@ -179,7 +179,7 @@ def view_subs(page, sort):
 @bp.route("/subs/search/<term>/<int:page>/<sort>")
 def subs_search(page, term, sort):
     """ The subs index page, with basic title search """
-    term = re.sub(r'[^A-Za-z0-9\-_]+', '', term)
+    term = re.sub(r'[^A-Za-zа-яА-Я0-9\-_]+', '', term)
     c = Sub.select(Sub.sid, Sub.name, Sub.title, Sub.nsfw, Sub.creation, Sub.subscribers, Sub.posts)
 
     c = c.where(Sub.name.contains(term))


### PR DESCRIPTION
It is also possible to use `\p{L}` and `p{Cyrillic}` in unicode mode.  But this requires apparently minor changes to these expressions. But the letters work both in the search for posts and in the search for `sub` (and creation). `ё` added to posts search. I don't think she will meet in 'sub'.