### PR TITLE
Undelete post permission hotfix

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -212,7 +212,7 @@
           @end
           <li><a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a></li>
         @end
-        @if current_user.is_admin and post['deleted'] == 2:
+        @if current_user.is_admin() and post['deleted'] == 2:
           <li id="delpostli"><a class="undelete-post"> @{_('un-delete')} </a></li>
         @end
 


### PR DESCRIPTION
Fixing bug that allows non-admins to see "un-delete" button on deleted posts.