### PR TITLE
Remove type attribute

### DIFF
--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -179,7 +179,7 @@
     @end
     @{chat()!!html}
   @end
-  <script type="text/javascript" src="@{ asset_url_for('main.js') }"></script>
+  <script src="@{ asset_url_for('main.js') }"></script>
   <style>@{current_user.get_global_stylesheet()}</style>
   @def pagefoot():
   @end

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -168,7 +168,7 @@
       {%if config.app.debug or current_user.admin%} | Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries{%endif%}
     {% endblock %}
   </div>
-  <script type="text/javascript" src="{{ asset_url_for('main.js') }}"></script>
+  <script src="{{ asset_url_for('main.js') }}"></script>
   <style>{{current_user.get_global_stylesheet()|safe}}</style>
   {%block pagefoot%}{%endblock%}
 </body>


### PR DESCRIPTION
The type attribute is unnecessary for JavaScript resources.