### PR TITLE
Make forcing HTTPS optional

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -66,7 +66,8 @@ def create_app(config=Config('config.yaml')):
            'img-src':     ['\'self\'', 'data:', 'https:'],
            'media-src':   ['\'self\'', 'https:'],
            'style-src':   ['\'self\'', '\'unsafe-inline\'']}
-    talisman.init_app(app, content_security_policy=csp)
+    talisman.init_app(app, content_security_policy=csp,
+                      force_https=config.app.force_https)
 
     babel.init_app(app)
     jwt.init_app(app)

--- a/app/config.py
+++ b/app/config.py
@@ -80,6 +80,7 @@ cfg_defaults = {  # key => default value
         "app": {
             "redis_url": 'redis://127.0.0.1:6379',
             "secret_key": 'yS\x1c\x88\xd7\xb5\xb0\xdc\t:kO\r\xf0D{"Y\x1f\xbc^\xad',
+            "force_https": False,
             "debug": True,
             "development": False,
             "wtf_csrf_time_limit": None,

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -123,6 +123,12 @@ app:
   # Used for websockets (if enabled)
   redis_url: 'redis://127.0.0.1:6379'
 
+  # Whether to force all traffic to HTTPS.  If you terminate SSL with
+  # gunicorn in production you should set this to True.  If you use
+  # another server such as nginx or a load balancer to terminate SSL,
+  # this should be False.  Ignored in debug mode.
+  force_https: False
+
   # Secret key used to encrypt session cookies.
   # You can generate one by using `os.urandom(24)`
   # ///// YOU MUST CHANGE THIS VALUE \\\\\


### PR DESCRIPTION
One of the defaults in `flask-talisman` is to always force HTTPS. This is undesirable if you are running Throat behind another server such as nginx which terminates SSL for you.  Add a new config setting to control this behavior, `config.app.force_https`, which defaults to off.