### PR TITLE
Fix the load more comments link

### DIFF
--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -116,4 +116,4 @@
   @end
 @end
 
-@{renderComments(post, subInfo, subMods, comments, highlight)!!html}}
+@{renderComments(post, subInfo, subMods, comments, highlight)!!html}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -945,6 +945,10 @@ a.slink{
   margin-left: 1em;
 }
 
+.loadsibling{
+  font-size: smaller;
+}
+
 .canclose .closemsg{
   position: absolute;
   top: 0;

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1778,7 +1778,7 @@ def get_sibling(pid, cid, lim):
     if not comments.count():
         return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': [], 'subInfo': {}, 'highlight': ''})
 
-    include_history = current_user.is_mod(sub.sid, 1) or current_user.is_admin()
+    include_history = current_user.is_mod(post['sid'], 1) or current_user.is_admin()
 
     if lim:
         comment_tree = misc.get_comment_tree(comments, cid if cid != '0' else None, lim, provide_context=False, uid=current_user.uid, include_history=include_history)


### PR DESCRIPTION
Fix a bug introduced with the comment history feature, remove an extraneous brace from the template, and make the text of the link a little smaller.