### PR TITLE
New sub setting: Option to make banned users list private

### DIFF
--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -94,6 +94,7 @@ class EditSubForm(FlaskForm):
                          validators=[Optional()])
     sidebar = TextAreaField(_l('Sidebar text'), validators=[Length(max=8000)])
     sublogprivate = BooleanField(_l('Make the sub log private'))
+    subbannedusersprivate = BooleanField(_l('Make the list of banned users on this sub private'))
 
 
 class EditMod2Form(FlaskForm):

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -89,4 +89,6 @@
 @if config.site.force_sublog_public or (subInfo.get('sublog_private', 0) != '1') or (current_user.uid in (subMods['all'])) or current_user.can_admin:
   <a href="@{url_for('sub.view_sublog', sub=sub['name'])}" class="sbm-post pure-button">@{_('Sub Log')}</a>
 @end
-<a href="@{url_for('sub.view_sub_bans', sub=sub['name'])}" class="sbm-post pure-button">@{_('Banned Users')}</a>
+@if config.site.force_sublog_public or (subInfo.get('sub_banned_users_private', 0) != '1') or (current_user.uid in (subMods['all'])) or current_user.can_admin:
+  <a href="@{url_for('sub.view_sub_bans', sub=sub['name'])}" class="sbm-post pure-button">@{_('Banned Users')}</a>
+@end

--- a/app/templates/editsub.html
+++ b/app/templates/editsub.html
@@ -60,6 +60,13 @@
           {{editsubform.sublogprivate.label.text}}
         </label>
       </div>
+      
+      <div class="pure-control-group">
+        <label for="subbannedusersprivate" class="pure-checkbox">
+          {{editsubform.subbannedusersprivate(checked=True if metadata.sub_banned_users_private else False)}}
+          {{editsubform.subbannedusersprivate.label.text}}
+        </label>
+      </div>
       {% endif %}
 
       <h4>Default post sort</h4>

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -331,6 +331,7 @@ def edit_sub(sub):
             sub.update_metadata('ucf', form.usercanflair.data)
             sub.update_metadata('allow_polls', form.polling.data)
             sub.update_metadata('sublog_private', form.sublogprivate.data)
+            sub.update_metadata('sub_banned_users_private', form.subbannedusersprivate.data)
 
             if form.subsort.data != "None":
                 sub.update_metadata('sort', form.subsort.data)

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -219,6 +219,13 @@ def view_sub_bans(sub):
     except Sub.DoesNotExist:
         abort(404)
 
+    subInfo = misc.getSubData(sub.sid)
+    if not config.site.force_sublog_public:
+        banned_users_is_private = subInfo.get('sub_banned_users_private', 0) == '1'
+
+        if banned_users_is_private and not (current_user.is_mod(sub.sid, 1) or current_user.is_admin()):
+            abort(404)
+
     user = User.alias()
     created_by = User.alias()
     banned = SubBan.select(user, created_by, SubBan.created, SubBan.reason, SubBan.expires)

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -40,7 +40,7 @@ site:
   # If False, only Admin can view the sitelog
   sitelog_public: True
 
-  # Forces all the sub logs to be public and removes the option to make them private.
+  # Forces all the sub logs and banned user lists to be public and removes the option to make them private.
   force_sublog_public: True
 
   # Amount of time in seconds the post author can edit a post's title after the post


### PR DESCRIPTION
A new sub setting option to allow Mods to hide the banned users list. 

By default they are public, and Admin can override using the "force_sublogs_public" config setting that already exists.