### PR TITLE
Better handle changes to auth.provider config setting

### DIFF
--- a/app/views/user.py
+++ b/app/views/user.py
@@ -6,7 +6,7 @@ from flask_login import login_required, current_user
 from flask_babel import _, Locale
 from .do import uid_from_recovery_token, info_from_email_confirmation_token
 from .. import misc, config
-from ..auth import auth_provider, email_validation_is_required
+from ..auth import auth_provider, email_validation_is_required, AuthError
 from ..misc import engine, send_email
 from ..forms import EditUserForm, CreateUserMessageForm, EditAccountForm, DeleteAccountForm, PasswordRecoveryForm
 from ..forms import PasswordResetForm
@@ -173,9 +173,12 @@ def confirm_email_change(token):
         return redirect(url_for('user.edit_account'))
 
     if user.status == UserStatus.OK:
-        auth_provider.confirm_pending_email(user, info['email'])
-        flash(_('Your password recovery email address is now confirmed!'), 'message')
-        return redirect(url_for('user.edit_account'))
+        try:
+            auth_provider.confirm_pending_email(user, info['email'])
+            flash(_('Your password recovery email address is now confirmed!'), 'message')
+            return redirect(url_for('user.edit_account'))
+        except AuthError:
+            flash(_('Unable to confirm your new email address. Please try again later.'), 'error')
     return redirect(url_for('home.index'))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,6 @@ pyOpenSSL
 pygobject
 mutagen
 flask-mail
-python-keycloak
+python-keycloak==0.21.0
 itsdangerous
 python-slugify


### PR DESCRIPTION
When I wrote the Keycloak integration, I wasn't thinking of site admins wanting to turn Keycloak on and off repeatedly, but of course that's what you do sometimes when trying to integrate something new into a site which other people are trying to get things done on.  Consequently some users ended up with borked accounts. This PR makes the authentication management code more robust to configuration changes to prevent that happening.

From the commit message:

After a site adminstrator changes the `auth.provider` setting from `LOCAL`
to `KEYCLOAK`, make Keycloak accounts for pre-existing users whenever
they enter their password, and keep track of their IDs on the Keycloak
server in `UserMetadata`.

Fix the reset password and change email flows to not create local
passwords or change emails for users with Keycloak accounts if the
Keycloak server is currently not configured, because this would cause
the local account and Keycloak to contain different information if the
Keycloak server is then re-configured (as might happen when a site
admin is learning Keycloak administration).  Add error messages to
tell the users to try again later.

Pin the dependency `python-keycloak` because they have some current
issues which would require changes to our code if fixed.  See
[the python-keycloak repo](https://github.com/marcospereirampj/python-keycloak) issues 90, 95 and 99.