### PR TITLE
Fix captcha error message on password recovery page

### DIFF
--- a/app/html/user/password_recovery.html
+++ b/app/html/user/password_recovery.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(lpform)
+@require(lpform, error)
 @def title():
   Password recovery |\
 @end
@@ -7,9 +7,11 @@
 @def main():
 <div id="center-container">
   <div class="content">
-    <div class="alert div-error"></div>
-    <form  method="POST" action="@{url_for('do.recovery')}" class="ajaxform pure-form pure-form-aligned">
+    <form  method="POST" class="pure-form pure-form-aligned">
       <h1>@{_('Password recovery')}</h1> @{ lpform.csrf_token() !!html}
+      @if error:
+      <div class="error">@{ error }</div>
+      @end
       <fieldset>
         <div class="pure-control-group">
           <label for="email">@{_('E-mail address')}</label>
@@ -24,7 +26,7 @@
           <input autocomplete="off" id="captcha" name="captcha" required="" type="text" value="">
         </div>
         <div class="pure-controls">
-          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary" data-success="@{_('mail sent!')}" data-prog="@{_('Processing...')}">@{_('Send recovery email')}</button>
+          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary">@{_('Send recovery email')}</button>
         </div>
 
       </fieldset>


### PR DESCRIPTION
The password recovery page would show nothing when the user entered an invalid captcha, just change the button from "Send Recovery Email" to "Processing" and back.  Fix it by handling the form in Python rather than as an ajax form, so that it can get a new captcha when it needs one.