### PR TITLE
fix error when editing a long post

### DIFF
--- a/migrations/018_fixsubposthistory.py
+++ b/migrations/018_fixsubposthistory.py
@@ -1,0 +1,46 @@
+"""Peewee migrations -- 018_fixsubposthistory.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    migrator.change_fields(migrator.orm['sub_post_content_history'], content = pw.TextField(null=True))
+    migrator.change_fields(migrator.orm['sub_post_title_history'], title = pw.TextField(null=True))
+
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    migrator.change_fields(migrator.orm['sub_post_content_history'], content = pw.CharField(max_length=255, null=True))
+    migrator.change_fields(migrator.orm['sub_post_title_history'], title = pw.CharField(max_length=255, null=True))


### PR DESCRIPTION
These migrations were setting the edit history content and title fields to a charfield with max 255, resulting in an error when user tries to edit a long post.

**Bug cannot be reproduced on SQLite**