### PR TITLE
Add configurable rate limiting for all views

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,7 +31,7 @@ from .views.messages import bp as messages
 
 from . import misc, forms, caching, storage
 from .socketio import socketio
-from .misc import SiteAnon, engine, engine_init_app, re_amention, mail, talisman
+from .misc import SiteAnon, engine, engine_init_app, re_amention, mail, talisman, limiter
 
 # /!\ FOR DEBUGGING ONLY /!\
 # from werkzeug.contrib.profiler import ProfilerMiddleware
@@ -84,6 +84,9 @@ def create_app(config=Config('config.yaml')):
         mail.init_app(app)
     storage.storage_init_app(app)
     auth_provider.init_app(app)
+
+    limiter.init_app(app)
+
     # app.wsgi_app = ProfilerMiddleware(app.wsgi_app)
 
     app.register_blueprint(home)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ from flask_login import LoginManager, current_user
 from flask_webpack import Webpack
 from flask_babel import Babel, _
 from wheezy.html.utils import escape_html
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .config import Config, config
 from .forms import LoginForm, LogOutForm, CreateSubForm
@@ -108,6 +109,9 @@ def create_app(config=Config('config.yaml')):
                                'BeautifulSoup': BeautifulSoup, 'thumbnail_url': storage.thumbnail_url,
                                'file_url': storage.file_url, 'get_flashed_messages': get_flashed_messages,
                                'email_validation_is_required': email_validation_is_required})
+
+    if config.site.trusted_proxy_count != 0:
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=config.site.trusted_proxy_count)
 
     if config.app.development:
         import logging

--- a/app/config.py
+++ b/app/config.py
@@ -91,7 +91,10 @@ cfg_defaults = {  # key => default value
             "testing": False
         },
         "aws": {},
-        "database": {}
+        "database": {},
+        "ratelimit": {
+            "default": "60/minute"
+        },
     }
 
 
@@ -138,6 +141,7 @@ class Config(Map):
         super(Config, self).__init__(cfg, cfg_defaults, use_environment=use_environment)
         self.check_storage_config()
         self.check_auth_config()
+        self.check_ratelimit_config()
 
     def check_storage_config(self):
         """Adjust our storage config for compatibility with flask-cloudy."""
@@ -164,9 +168,13 @@ class Config(Map):
     def check_auth_config(self):
         ensure_trailing_slash(self.auth.keycloak, 'server')
 
+    def check_ratelimit_config(self):
+        if 'storage_url' not in self.ratelimit:
+            self.ratelimit['storage_url'] = self.app.redis_url
+
     def get_flask_dict(self):
         flattened = {}
-        for cpk in ['cache', 'mail', 'sendgrid', 'app']:
+        for cpk in ['cache', 'mail', 'sendgrid', 'app', 'ratelimit']:
             if cpk in self.keys():
                 for i in self[cpk]:
                     if cpk == 'app':

--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,8 @@ cfg_defaults = {  # key => default value
                 }
             },
 
-            "archive_post_after": 60
+            "archive_post_after": 60,
+            "trusted_proxy_count": 0
         },
         "auth": {
             "provider": 'LOCAL',

--- a/app/html/errors/429.html
+++ b/app/html/errors/429.html
@@ -1,0 +1,16 @@
+@extends("shared/layout.html")
+
+@def title():
+@{_('Too many requests')} |\
+@end
+
+@def content():
+<div id="center-container">
+  <div class="content">
+    <h1>@{_('Too much, too fast!')}</h1>
+    <p>
+      @{_('Whoa, calm down, wait a bit and try again.')}
+    </p>
+    </div>
+  </div>
+@end

--- a/app/misc.py
+++ b/app/misc.py
@@ -10,6 +10,7 @@ import os
 import hashlib
 import re
 import gevent
+import ipaddress
 
 import tinycss2
 from captcha.image import ImageCaptcha
@@ -334,11 +335,12 @@ def on_over_limit():
 
 
 def get_ip():
-    """ Tries to return the user's actual IP address. """
-    if request.access_route:
-        return request.access_route[-1]
+    """ Return the user's IP address for rate-limiting. """
+    addr = ipaddress.ip_address(request.remote_addr or '127.0.0.1')
+    if isinstance(addr, ipaddress.IPv6Address):
+        return(addr.exploded[:19]) # use the /64
     else:
-        return request.remote_addr
+        return str(addr)
 
 
 def ratelimit(limit, per=300, send_x_headers=True,

--- a/app/misc.py
+++ b/app/misc.py
@@ -22,6 +22,7 @@ from functools import update_wrapper
 import misaka as m
 import sendgrid
 from flask import current_app
+from flask_limiter import Limiter
 from flask_mail import Mail
 from flask_mail import Message as EmailMessage
 from slugify import slugify as s_slugify
@@ -299,41 +300,6 @@ class SiteAnon(AnonymousUserMixin):
         return ''
 
 
-class RateLimit(object):
-    """ This class does the rate-limit magic """
-    expiration_window = 10
-
-    def __init__(self, key_prefix, limit, per, send_x_headers):
-        self.reset = (int(time.time()) // per) * per + per
-        self.key = key_prefix + str(self.reset)
-        self.limit = limit
-        self.per = per
-        self.send_x_headers = send_x_headers
-        p = rconn.pipeline()
-        p.incr(self.key)
-        p.expireat(self.key, self.reset + self.expiration_window)
-        self.current = min(p.execute()[0], limit)
-
-    def decr(self):
-        p = rconn.pipeline()
-        p.decr(self.key)
-        p.expireat(self.key, self.reset + self.expiration_window)
-        self.current = min(p.execute()[0], self.limit)
-
-    remaining = property(lambda self: self.limit - self.current)
-    over_limit = property(lambda self: self.current >= self.limit)
-
-
-def get_view_rate_limit():
-    """ Returns the rate limit for the current view """
-    return getattr(g, '_view_rate_limit', None)
-
-
-def on_over_limit():
-    """ This is called when the rate limit is reached """
-    return jsonify(status='error', error=[_('Whoa, calm down and wait a bit before posting again.')])
-
-
 def get_ip():
     """ Return the user's IP address for rate-limiting. """
     addr = ipaddress.ip_address(request.remote_addr or '127.0.0.1')
@@ -343,41 +309,11 @@ def get_ip():
         return str(addr)
 
 
-def ratelimit(limit, per=300, send_x_headers=True,
-              over_limit=on_over_limit,
-              scope_func=lambda: get_ip(),
-              key_func=lambda: request.endpoint, negative_score_per=900):
-    """ This is a decorator. It does the rate-limit magic. """
-
-    def decorator(f):
-        """ Function inside function! """
-
-        def rate_limited(*args, **kwargs):
-            """ FUNCTIONCEPTION """
-            persecond = per
-            # If the user has negative score, we use negative_score_per
-            if current_user.score < 0:
-                persecond = negative_score_per
-            key = 'rate-limit/%s/%s/' % (key_func(), scope_func())
-            rlimit = RateLimit(key, limit + 1, persecond, send_x_headers)
-            g._view_rate_limit = rlimit
-            if over_limit is not None and rlimit.over_limit:
-                if not config.app.testing and not config.app.development:
-                    return over_limit()
-            reslt = f(*args, **kwargs)
-            if isinstance(reslt, tuple) and reslt[1] != 200:
-                rlimit.decr()
-            return reslt
-
-        return update_wrapper(rate_limited, f)
-
-    return decorator
-
-
-def reset_ratelimit(per, scope_func=lambda: get_ip(), key_func=lambda: request.endpoint):
-    reset = (int(time.time()) // per) * per + per
-    key = 'rate-limit/%s/%s/%s' % (key_func(), scope_func(), reset)
-    rconn.delete(key)
+limiter = Limiter(key_func=get_ip)
+ratelimit = limiter.limit
+POSTING_LIMIT = '6/minute;120/hour'
+AUTH_LIMIT = '25/5minute'
+SIGNUP_LIMIT = '5/30minute'
 
 
 def safeRequest(url, recieve_timeout=10):

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -475,7 +475,11 @@ u.sub('#graburl', 'click', function (e) {
     u.post('/do/grabtitle', {u: uri},
         function (data) {
             if (data.status == 'error') {
-                alert(_('Error fetching title'));
+                let error = data.error;
+                if(Array.isArray(data.error)){
+                    error = data.error[0];
+                }
+                alert(error);
                 document.getElementById('graburl').removeAttribute('disabled');
                 document.getElementById('graburl').innerHTML = _('Grab title');
             } else {

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -12,6 +12,7 @@ from flask_jwt_extended import jwt_refresh_token_required, jwt_optional
 from .. import misc
 from ..auth import auth_provider
 from ..socketio import socketio
+from ..misc import ratelimit, POSTING_LIMIT, AUTH_LIMIT
 from ..models import Sub, User, SubPost, SubPostComment, SubMetadata, SubPostCommentVote, SubPostVote, SubSubscriber
 from ..models import SiteMetadata, UserMetadata, Message, SubRule, Notification
 from ..caching import cache
@@ -21,12 +22,13 @@ API = Blueprint('apiv3', __name__)
 JWT = JWTManager()
 
 
-def api_over_limit():
-    """ Called when triggering a rate-limit """
+@API.errorhandler(429)
+def ratelimit_handler(e):
     return jsonify(msg="Rate limited. Please try again later"), 429
 
 
 @API.route('/login', methods=['POST'])
+@ratelimit(AUTH_LIMIT)
 def login():
     """ Logs the user in.
     Parameters (json): username and password
@@ -77,6 +79,7 @@ def refresh():
 
 
 @API.route('/fresh-login', methods=['POST'])
+@ratelimit(AUTH_LIMIT)
 def fresh_login():
     """ Returns a fresh access token. Requires username and password """
     username = request.json.get('username', None)
@@ -361,7 +364,7 @@ def get_post_comments(sub, pid):
 
 @API.route('/post/<sub>/<int:pid>/comment', methods=['POST'])
 @jwt_required
-@misc.ratelimit(1, per=30, over_limit=api_over_limit)  # Once every 30 secs
+@ratelimit(POSTING_LIMIT)
 def create_comment(sub, pid):
     uid = get_jwt_identity()
     if not request.is_json:
@@ -618,7 +621,7 @@ def get_challenge():
 
 @API.route('/post', methods=['POST'])
 @jwt_required
-@misc.ratelimit(1, per=30, over_limit=api_over_limit)  # Once every 30 secs
+@ratelimit(POSTING_LIMIT)
 def create_post():
     uid = get_jwt_identity()
     if not request.is_json:
@@ -814,6 +817,7 @@ def set_settings():
 
 
 @API.route('/grabtitle', methods=['GET'])
+@ratelimit(POSTING_LIMIT)
 @jwt_required
 def grab_title():
     url = request.args.get('url', None)

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -12,6 +12,7 @@ from .. import misc, config
 from ..auth import auth_provider, registration_is_enabled, email_validation_is_required
 from ..forms import LoginForm, RegistrationForm
 from ..misc import engine, send_email
+from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..models import User, UserMetadata, UserStatus, InviteCode, SubSubscriber, rconn
 
 bp = Blueprint('auth', __name__)
@@ -31,6 +32,7 @@ def handle_cas_ok(uid):
 
 
 @bp.route("/proxyValidate", methods=['GET'])
+@ratelimit(AUTH_LIMIT)
 def sso_proxy_validate():
     if not request.args.get('ticket') or not request.args.get('service'):
         abort(400)
@@ -52,6 +54,7 @@ def sso_proxy_validate():
 
 
 @bp.route("/register", methods=['GET', 'POST'])
+@ratelimit(SIGNUP_LIMIT)
 def register():
     """ Endpoint for the registration form """
     if current_user.is_authenticated:
@@ -164,6 +167,7 @@ def confirm_registration():
 
 
 @bp.route('/login/with-token/<token>')
+@ratelimit(SIGNUP_LIMIT)
 def login_with_token(token):
     if current_user.is_authenticated:
         return redirect(url_for('home.index'))
@@ -182,6 +186,7 @@ def login_with_token(token):
 
 
 @bp.route("/login", methods=['GET', 'POST'])
+@ratelimit(AUTH_LIMIT)
 def login():
     """ Endpoint for the login form """
     if request.args.get('service'):

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -34,6 +34,12 @@ def forbidden_error(error):
     return engine.get_template('errors/417.html').render({}), 418
 
 
+@bp.app_errorhandler(429)
+def too_many_requests_error(error):
+    """ 429 Too many requests """
+    return engine.get_template('errors/429.html').render({}), 429
+
+
 @bp.app_errorhandler(500)
 def server_error(error):
     """ 500 Internal server error """

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -5,6 +5,7 @@ from flask import Blueprint, request, url_for, Response, abort, render_template,
 from flask_login import login_required, current_user
 from .. import misc
 from ..misc import engine
+from ..misc import ratelimit, POSTING_LIMIT
 from ..models import SubPost, UserUploads, Sub
 
 bp = Blueprint('home', __name__)
@@ -98,6 +99,7 @@ def all_domain_new(domain, page):
 
 @bp.route("/search/<term>", defaults={'page': 1})
 @bp.route("/search/<term>/<int:page>")
+@ratelimit(POSTING_LIMIT)
 def search(page, term):
     """ The index page, with basic title search """
     term = re.sub(r'[^A-Za-z0-9.,\-_\'" ]+', '', term)
@@ -177,6 +179,7 @@ def view_subs(page, sort):
 @bp.route("/subs/search/<term>/<sort>", defaults={'page': 1})
 @bp.route("/subs/search/<term>/<int:page>", defaults={'sort': 'name_asc'})
 @bp.route("/subs/search/<term>/<int:page>/<sort>")
+@ratelimit(POSTING_LIMIT)
 def subs_search(page, term, sort):
     """ The subs index page, with basic title search """
     term = re.sub(r'[^A-Za-z0-9\-_]+', '', term)

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -8,6 +8,7 @@ from flask_babel import _, lazy_gettext as _l
 from .. import misc
 from ..config import config
 from ..misc import engine
+from ..misc import ratelimit, POSTING_LIMIT
 from ..socketio import socketio
 from ..models import Sub, db as pdb, SubMod, SubMetadata, SubStylesheet, SubSubscriber, SiteMetadata, SubPost
 from ..models import SubPostPollOption, SubPostMetadata, SubPostVote, User, UserUploads
@@ -65,7 +66,7 @@ def submit(ptype, sub):
 @bp.route("/submit/<ptype>", defaults={'sub': ''}, methods=['POST'])
 @bp.route("/submit/<ptype>/<sub>", methods=['POST'])
 @login_required
-@misc.ratelimit(1, per=30, over_limit=post_over_limit)
+@ratelimit(POSTING_LIMIT)
 def create_post(ptype, sub):
     if ptype not in ['link', 'text', 'poll', 'upload']:
         abort(404)
@@ -278,6 +279,7 @@ def random_sub():
 
 @bp.route("/createsub", methods=['GET', 'POST'])
 @login_required
+@ratelimit(POSTING_LIMIT)
 def create_sub():
     """ Here we can view the create sub form """
     form = CreateSubForm()

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -9,6 +9,7 @@ from .do import info_from_email_confirmation_token
 from .. import misc, config
 from ..auth import auth_provider, email_validation_is_required, AuthError
 from ..misc import engine, send_email
+from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import EditUserForm, CreateUserMessageForm, EditAccountForm, DeleteAccountForm, PasswordRecoveryForm
 from ..forms import PasswordResetForm
 from ..models import User, UserStatus, UserMetadata
@@ -157,6 +158,7 @@ def edit_user():
 
 @bp.route("/settings/account")
 @login_required
+@ratelimit(AUTH_LIMIT)
 def edit_account():
     return engine.get_template('user/settings/account.html').render(
         {'form': EditAccountForm(),
@@ -164,6 +166,7 @@ def edit_account():
 
 
 @bp.route('/settings/account/confirm-email/<token>')
+@ratelimit(AUTH_LIMIT)
 def confirm_email_change(token):
     info = info_from_email_confirmation_token(token)
     user = None
@@ -190,6 +193,7 @@ def delete_account():
 
 
 @bp.route("/recover", methods=['GET', 'POST'])
+@ratelimit(SIGNUP_LIMIT)
 def password_recovery():
     """ Endpoint for the password recovery form """
     if current_user.is_authenticated:
@@ -221,6 +225,7 @@ def recovery_email_sent():
 
 
 @bp.route('/reset/<token>')
+@ratelimit(SIGNUP_LIMIT)
 def password_reset(token):
     """ The page that actually resets the password """
     user = None

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -145,7 +145,7 @@ app:
   # Enables debug mode. Always set to False in a production environment
   debug: True
 
-  # This will make all captchas valid, disable caching and rate limits
+  # This will make all captchas valid and disable caching
   # Always set to False in a production environment
   development: True
 
@@ -244,3 +244,13 @@ database:
 
   # Uncomment if using MySQL
   #charset: 'utf8mb4'
+
+ratelimit:
+  # Rate limiting configuration is not required, but all configuration
+  # variables for flask-limiter may be set here (in lowercase and
+  # without the RATELIMIT_ prefix).  See
+  # https://flask-limiter.readthedocs.io/en/stable/#configuration.
+
+  # Uncomment to disable rate limiting (recommended to leave it on in
+  # production).
+  #enabled: False

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -25,7 +25,7 @@ site:
   # Set to zero to disable file upload level limits
   upload_min_level: 0
 
-# For those who are allowed to upload files, allow video uploads
+  # For those who are allowed to upload files, allow video uploads
   # (.mp4 and .webm) as well.
   allow_video_uploads: True
 
@@ -88,6 +88,11 @@ site:
 
   # Time after which post will be archived
   archive_post_after: 60
+
+  # Number of trusted proxies which set the X-Forwarded-For header
+  # ahead of the application.  If you run the application behind
+  # a load balancer, this should be set to 1 or more.
+  trusted_proxy_count: 0
 
 auth:
   # Set to LOCAL to store user authentication in database,

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pyOpenSSL
 pygobject
 mutagen
 flask-mail
+flask-limiter
 python-keycloak==0.21.0
 itsdangerous
 python-slugify

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -40,6 +40,7 @@ def app(test_config):
     config['mail']['server'] = 'smtp.example.com'
     config['mail']['port'] = 8025
     config['mail']['default_from'] = 'test@example.com'
+    config['ratelimit']['enabled'] = False
 
     recursively_update(config, test_config)
 


### PR DESCRIPTION
Replace the existing rate limiter with `flask-limiter`, which has many more configuration options, and apply it to all the view functions in the application.  Set up a new default rate limit of 60 requests per minute which is configurable in `config.yaml` and separate rate limits for the activities of signup, authentication and posting, which are currently not configurable.

Fix the rate limiter key function `get_ip` so that it works behind a load balancer, and so you can configure the number of trusted proxies between the client and application.
