### PR TITLE
Normalize emails before storage and compare them in lower case

### DIFF
--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -10,6 +10,7 @@ from itsdangerous import URLSafeTimedSerializer
 from itsdangerous.exc import SignatureExpired, BadSignature
 from .. import misc, config
 from ..auth import auth_provider, registration_is_enabled, email_validation_is_required
+from ..auth import normalize_email
 from ..forms import LoginForm, RegistrationForm
 from ..misc import engine, send_email
 from ..models import User, UserMetadata, UserStatus, InviteCode, SubSubscriber, rconn
@@ -87,6 +88,8 @@ def register():
         email = form.email_required.data
     else:
         email = form.email_optional.data
+    if email:
+        email = normalize_email(email)
 
     if email:
         if auth_provider.get_user_by_email(email) is not None:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -21,7 +21,7 @@ from itsdangerous.exc import SignatureExpired, BadSignature
 from ..config import config
 from .. import forms, misc, caching, storage
 from ..socketio import socketio
-from ..auth import auth_provider, email_validation_is_required, AuthError
+from ..auth import auth_provider, email_validation_is_required, AuthError, normalize_email
 from ..forms import LogOutForm, CreateSubFlair, DummyForm, CreateSubRule
 from ..forms import CreateSubForm, EditSubForm, EditUserForm, EditSubCSSForm
 from ..forms import EditModForm, BanUserSubForm, DeleteAccountForm, EditAccountForm
@@ -87,11 +87,12 @@ def edit_account():
         else:
             email = form.email_optional.data
 
-        if (email and email != user.email and
-            email != auth_provider.get_pending_email(user) and
-            auth_provider.get_user_by_email(email) is not None):
-            return json.dumps({'status': 'error',
-                               'error': [_('E-mail address is already in use')]})
+        if email:
+            email = normalize_email(email)
+            user_from_email = auth_provider.get_user_by_email(email)
+            if user_from_email is not None and user.uid != user_from_email.uid:
+                return json.dumps({'status': 'error',
+                                   'error': [_('E-mail address is already in use')]})
 
         if not auth_provider.validate_password(user, form.oldpassword.data):
             return json.dumps({'status': 'error',

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -7,7 +7,7 @@ from flask_babel import _, Locale
 from .do import send_password_recovery_email, uid_from_recovery_token
 from .do import info_from_email_confirmation_token
 from .. import misc, config
-from ..auth import auth_provider, email_validation_is_required, AuthError
+from ..auth import auth_provider, email_validation_is_required, AuthError, normalize_email
 from ..misc import engine, send_email
 from ..forms import EditUserForm, CreateUserMessageForm, EditAccountForm, DeleteAccountForm, PasswordRecoveryForm
 from ..forms import PasswordResetForm
@@ -205,7 +205,8 @@ def password_recovery():
             {'lpform': form,
              'error': _("Invalid captcha.")})
     try:
-        user = User.get(User.email == form.email.data)
+        email = normalize_email(form.email.data)
+        user = User.get(fn.Lower(User.email) == email.lower())
         if user.status == UserStatus.OK:
             send_password_recovery_email(user)
     except User.DoesNotExist:


### PR DESCRIPTION
Use `email-validator` to parse emails and convert them to a consistent format for storage, which removes ambiguity since Unicode made it possible to have multiple equivalent forms of the same email address. See [the description of email-validator](https://pypi.org/project/email-validator/) for a more detailed explanation.

Since the username part of an email address is permitted to be case sensitive by RFC 5321, but in practice rarely is, store the email as the user gave it to us (after normalization by email_validator) and use that version for sending emails, but do all comparisons of and searches on email addresses in lower case.