### PR TITLE
Make logging configurable in config.yaml

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,7 +116,10 @@ def create_app(config=Config('config.yaml')):
     if config.site.trusted_proxy_count != 0:
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=config.site.trusted_proxy_count)
 
-    if config.app.development:
+    if 'logging' in config:
+        import logging.config
+        logging.config.dictConfig(config.logging)
+    elif config.app.development:
         import logging
         logging.basicConfig(level=logging.DEBUG)
         logging.getLogger("engineio.server").setLevel(logging.WARNING)

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -254,3 +254,27 @@ ratelimit:
   # Uncomment to disable rate limiting (recommended to leave it on in
   # production).
   #enabled: False
+
+logging:
+  # Configuration for logging.  This section is optional.
+  # See the Python documentation for logging.config.
+  version: 1
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: basic
+  formatters:
+    basic:
+      format: '%(levelname)s:%(name)s:%(message)s'
+  loggers:
+    engineio.server:
+      level: WARNING
+    socketio.server:
+      level: WARNING
+    peewee:
+      handlers:
+        - console
+  root:
+    level: DEBUG
+    handlers:
+      - console

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -41,6 +41,8 @@ def app(test_config):
     config['mail']['port'] = 8025
     config['mail']['default_from'] = 'test@example.com'
     config['ratelimit']['enabled'] = False
+    config['logging'] = {'version': 1,
+                         'root': {'level': 'DEBUG'}}
 
     recursively_update(config, test_config)
 


### PR DESCRIPTION
Allow administrators to include a Python logging configuration dictionary (as described in the [Python docs](https://docs.python.org/3/library/logging.config.html#module-logging.config)) in `config.yaml`.  If the section isn't present, no logging configuration will be done unless `config.app.development` is set, in which case debug logging to the console will be set up, as happened previously.

I included an example in `example.config.yaml` to get people started that works the same as the default development configuration.  First thing I'm adding to my logging config  is:

```
  peewee:
    level: WARNING
```
