### PR TITLE
Make request and current_user fields available to logging Formatters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,7 @@ from .views.messages import bp as messages
 from . import misc, forms, caching, storage
 from .socketio import socketio
 from .misc import SiteAnon, engine, engine_init_app, re_amention, mail, talisman, limiter
+from .misc import logging_init_app
 
 # /!\ FOR DEBUGGING ONLY /!\
 # from werkzeug.contrib.profiler import ProfilerMiddleware
@@ -84,7 +85,7 @@ def create_app(config=Config('config.yaml')):
         mail.init_app(app)
     storage.storage_init_app(app)
     auth_provider.init_app(app)
-
+    logging_init_app(app)
     limiter.init_app(app)
 
     # app.wsgi_app = ProfilerMiddleware(app.wsgi_app)
@@ -115,15 +116,6 @@ def create_app(config=Config('config.yaml')):
 
     if config.site.trusted_proxy_count != 0:
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=config.site.trusted_proxy_count)
-
-    if 'logging' in config:
-        import logging.config
-        logging.config.dictConfig(config.logging)
-    elif config.app.development:
-        import logging
-        logging.basicConfig(level=logging.DEBUG)
-        logging.getLogger("engineio.server").setLevel(logging.WARNING)
-        logging.getLogger("socketio.server").setLevel(logging.WARNING)
 
     @app.before_request
     def before_request():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -125,6 +125,7 @@ def create_app(config=Config('config.yaml')):
     @app.after_request
     def after_request(response):
         """ Called after the request is processed. Used to time the request """
+        app.logger.info("%s", response.status)
         if not app.debug and not current_user.is_admin():
             return response  # We won't do this if we're in production mode
         if app.config['THROAT_CONFIG'].app.development:

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -1,5 +1,5 @@
 """ Pages to be migrated to a wiki-like system """
-from flask import Blueprint, request, redirect, url_for, jsonify
+from flask import Blueprint, request, redirect, url_for, jsonify, current_app
 from ..misc import engine
 from ..forms import LoginForm
 
@@ -43,6 +43,10 @@ def too_many_requests_error(error):
 @bp.app_errorhandler(500)
 def server_error(error):
     """ 500 Internal server error """
+    import traceback
+    import sys
+    typ, val, tb = sys.exc_info()
+    current_app.logger.error('EXCEPTION: %s, "%s", %s', typ.__name__, val, traceback.format_tb(tb))
     if request.path.startswith('/api'):
         if request.path.startswith('/api/v3'):
             return jsonify(msg="Internal error"), 500

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -265,7 +265,7 @@ logging:
       formatter: basic
   formatters:
     basic:
-      format: '%(levelname)s:%(name)s:%(message)s'
+      format: '%(levelname)s:%(name)s:%(request.remote_addr)s:%(request.method)s %(request.path)s:%(message)s'
   loggers:
     engineio.server:
       level: WARNING
@@ -274,6 +274,14 @@ logging:
     peewee:
       handlers:
         - console
+    flask.app:
+      level: DEBUG
+    flask-limiter:
+      level: WARNING
+      handlers:
+        - console
+    geventwebsocket.handler:
+      level: WARNING
   root:
     level: DEBUG
     handlers:

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -41,8 +41,6 @@ def app(test_config):
     config['mail']['port'] = 8025
     config['mail']['default_from'] = 'test@example.com'
     config['ratelimit']['enabled'] = False
-    config['logging'] = {'version': 1,
-                         'root': {'level': 'DEBUG'}}
 
     recursively_update(config, test_config)
 


### PR DESCRIPTION
Extend Python's logging facility so that logging Formatters can reference any field in `request` or `current_user`, and unpack `request.headers` so that a logging format could refer to, for example, `request.headers.User-Agent`.

Use some of the new fields in the example logging configuration in `example.config.yaml` to demonstrate the capability.  Here's an example of its logging output:

```
INFO:flask.app:127.0.0.1:GET /s/announcements/17/big-news:200 OK
INFO:flask.app:127.0.0.1:GET /static/gen/main.ef379dce8e917f4bfe6e.css:304 NOT MODIFIED
INFO:flask.app:127.0.0.1:GET /static/gen/main.ef379dce8e917f4bfe6e.js:304 NOT MODIFIED
INFO:flask.app:127.0.0.1:POST /do/edit_txtpost/17:200 OK
```
