### PR TITLE
Let admins ban registrations by email domain

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -310,7 +310,13 @@ class AuthProvider:
                        'enabled': False}
             user.email = ''
             user.email_verified = False
+            self.clear_pending_email(user)
         elif user.status != 10 and new_status == 5:
+            if user.email and self.is_email_verified(user):
+                domain = user.email.split('@')[1]
+                current_app.logger.info('Banned %s; confirmed email on %s',
+                                        user.name, domain)
+
             payload = {'enabled': False}
         elif user.status != 10 and new_status == 0:
             payload = {'enabled': True}

--- a/app/html/shared/sidebar/admin.html
+++ b/app/html/shared/sidebar/admin.html
@@ -10,6 +10,7 @@
 <hr>
 <a href="@{url_for('admin.user_uploads')}" class="sbm-post pure-button">@{_('Uploads')}</a>
 <a href="@{url_for('admin.wiki')}" class="sbm-post pure-button">@{_('Wikis')}</a>
-<a href="@{url_for('admin.domains')}" class="sbm-post pure-button">@{_('Banned Domains')}</a>
+<a href="@{url_for('admin.domains', domain_type='link')}" class="sbm-post pure-button">@{_('Banned Domains')}</a>
+<a href="@{url_for('admin.domains', domain_type='email')}" class="sbm-post pure-button">@{_('Banned Email Domains')}</a>
 <hr>
 <a href="@{url_for('site.view_sitelog')}" class="sbm-post pure-button">@{_('Site log')}</a>

--- a/app/html/site/log.html
+++ b/app/html/site/log.html
@@ -72,6 +72,10 @@
                         @{_('Re-enabled new user registration')}
                     @elif log.action == 54:
                         @{_('Unbanned <a href="/u/%(user)s">%(user)s</a>', user=log.desc)!!html}
+                    @elif log.action == 69:
+                        @{_('Banned email domain <code>%(desc)s</code>', desc=e(log.desc))!!html}
+                    @elif log.action == 70:
+                        @{_('Unbanned email domain <code>%(desc)s</code>', desc=e(log.desc))!!html}
                     @else:
                         <i>[Type @{log.action}]</i> @{log.desc}
                     @end

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2231,3 +2231,8 @@ article.text-post.comment.deleted {
   color: red;
   font-weight: bold;
 }
+
+.removebanneddomain {
+  float: right;
+  margin-left: 10px;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -333,7 +333,8 @@ if(document.getElementById('delete_account')){
 if(document.querySelector('button.removebanneddomain')){
   u.addEventForChild(document, 'click', 'button.removebanneddomain', function(e, qelem){
     var domain=qelem.getAttribute('data-domain');
-    u.post('/do/remove_banned_domain/' + domain, {}, function(data){
+    var domain_type=qelem.getAttribute('data-domain-type')
+    u.post('/do/remove_banned_domain/' + domain_type + '/' + domain, {}, function(data){
       if (data.status == "ok") {
         document.location.reload();
       }

--- a/app/templates/admin/domains.html
+++ b/app/templates/admin/domains.html
@@ -16,11 +16,11 @@
 
 <div id="center-container">
   <div class="content">
-    <h2>Banned Domains</h2>
+    <h2>{{title}}</h2>
     <div class="admin section domains">
       <hr>
       <div class="col-12 admin-page-form">
-        <form class="nice-form ajaxform" method="POST" id="BanDomainForm" action="{{url_for('do.ban_domain')}}" data-reload="true">
+        <form class="nice-form ajaxform" method="POST" id="BanDomainForm" action="{{url_for('do.ban_domain', domain_type=domain_type)}}" data-reload="true">
           {% set bandomainform = form.BanDomainForm()%}
           {{bandomainform.csrf_token}}
           <h4>Add domain</h4>
@@ -41,7 +41,7 @@
           <tbody>
             {% for domain in domains %}
             <tr>
-              <td>{{domain.value}} <button data-domain="{{domain.value}}" type="submit" class="removebanneddomain pure-button">remove</button></td>
+              <td>{{domain.value}} <button data-domain="{{domain.value}}" data-domain-type="{{domain_type}}" type="submit" class="removebanneddomain pure-button">remove</button></td>
             </tr>
             {% endfor %}
           </tbody>

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -11,6 +11,7 @@
 <hr>
 <a href="{{url_for('admin.user_uploads')}}" class="sbm-post pure-button">Uploads</a>
 <a href="{{url_for('admin.wiki')}}" class="sbm-post pure-button">Wiki</a>
-<a href="{{url_for('admin.domains')}}" class="sbm-post pure-button">Banned Domains</a>
+<a href="{{url_for('admin.domains', domain_type='link')}}" class="sbm-post pure-button">Banned Domains</a>
+<a href="{{url_for('admin.domains', domain_type='email')}}" class="sbm-post pure-button">Banned Email Domains</a>
 <hr>
 <a href="{{url_for('site.view_sitelog')}}" class="sbm-post pure-button">Sitelog</a>

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -375,16 +375,26 @@ def post_search(term):
         abort(404)
 
 
-@bp.route("/domains", defaults={'page': 1})
-@bp.route("/domains/<int:page>")
+@bp.route("/domains/<domain_type>", defaults={'page': 1})
+@bp.route("/domains/<domain_type>/<int:page>")
 @login_required
-def domains(page):
+def domains(domain_type, page):
     """ WIP: View Banned Domains """
+    if domain_type == "email":
+        key = 'banned_email_domain'
+        title = _('Banned Email Domains')
+    elif domain_type == 'link':
+        key = 'banned_domain'
+        title = _('Banned Domains')
+    else:
+        abort(404)
     if current_user.is_admin():
-        domains = SiteMetadata.select().where(SiteMetadata.key == 'banned_domain')
+        domains = (SiteMetadata.select()
+                   .where(SiteMetadata.key == key)
+                   .order_by(SiteMetadata.value))
         return render_template('admin/domains.html', domains=domains,
-                               page=page, admin_route='admin.domains',
-                               bandomainform=BanDomainForm())
+                               title=title, domain_type=domain_type,
+                               page=page, bandomainform=BanDomainForm())
     else:
         abort(404)
 

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -693,7 +693,7 @@ def create_post():
         if content:
             return jsonify(msg='Link posts do not accept content'), 400
 
-        if misc.is_domain_banned(link):
+        if misc.is_domain_banned(link, domain_type='link'):
             return jsonify(msg="Link's domain is banned"), 400
 
         recent = datetime.datetime.utcnow() - datetime.timedelta(days=5)

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -12,7 +12,7 @@ from .. import misc, config
 from ..auth import auth_provider, registration_is_enabled, email_validation_is_required
 from ..auth import normalize_email
 from ..forms import LoginForm, RegistrationForm
-from ..misc import engine, send_email
+from ..misc import engine, send_email, is_domain_banned
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..models import User, UserMetadata, UserStatus, InviteCode, SubSubscriber, rconn
 
@@ -95,6 +95,9 @@ def register():
         email = normalize_email(email)
 
     if email:
+        if is_domain_banned(email, domain_type='email'):
+            return engine.get_template('user/register.html').render(
+                {'error': _("We do not accept emails from your email provider."), 'regform': form})
         if auth_provider.get_user_by_email(email) is not None:
             return engine.get_template('user/register.html').render(
                 {'error': _("E-mail address is already in use."), 'regform': form})

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -176,7 +176,7 @@ def create_post(ptype, sub):
         except SubPost.DoesNotExist:
             pass
 
-        if misc.is_domain_banned(form.link.data.lower()):
+        if misc.is_domain_banned(form.link.data.lower(), domain_type='link'):
             return engine.get_template('sub/createpost.html').render(
                 {'error': _("This domain is banned."), 'form': form, 'sub': sub, 'captcha': captcha}), 400
         img = misc.get_thumbnail(form.link.data)

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -3,6 +3,7 @@ import pytest
 
 from peewee import fn
 from flask import url_for
+from app import mail
 
 from pytest_flask.fixtures import client
 from test.fixtures import*
@@ -43,3 +44,34 @@ def test_admin_can_ban_and_unban_user(client, user_info, user2_info):
 
     log_out_current_user(client)
     log_in_user(client, user_info, expect_success=True)
+
+
+@pytest.mark.parametrize('test_config', [{'auth': {'require_valid_emails': True}}])
+def test_admin_can_ban_email_domain(client, user_info):
+    register_user(client, user_info)
+    promote_user_to_admin(client, user_info)
+
+    rv = client.get(url_for('admin.domains', domain_type='email'))
+    rv = client.post(url_for('do.ban_domain', domain_type='email'),
+                     data=dict(csrf_token=csrf_token(rv.data),
+                               domain='spam4u.com'),
+                     follow_redirects=True)
+    reply = json.loads(rv.data.decode('utf-8'))
+    assert reply['status'] == 'ok'
+
+    log_out_current_user(client)
+    rv = client.get(url_for('auth.register'))
+    with mail.record_messages() as outbox:
+        data = dict(csrf_token=csrf_token(rv.data),
+                    username='troll',
+                    password='Safe123#$@lolnot',
+                    confirm='Safe123#$@lolnot',
+                    email_required='troll@spam4u.com',
+                    invitecode='',
+                    accept_tos=True,
+                    captcha='xyzzy')
+        rv = client.post(url_for('auth.register'), data=data, follow_redirects=True)
+        assert len(outbox) == 0
+        assert b'do not accept emails' in rv.data
+        assert b'Register' in rv.data
+        assert b'Log out' not in rv.data


### PR DESCRIPTION
We have a list from another project of 200 email providers that were favored by spammers.  Allow the admins to manage this list from the admin interface, and stop anyone trying to register with or change their email to one of the banned domains.