### PR TITLE
Add the ability to resend confirmation emails

### DIFF
--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 
 from .user import RegistrationForm, LoginForm, LogOutForm, PasswordResetForm
 from .user import CreateUserMessageForm, EditUserForm, PasswordRecoveryForm
+from .user import ResendConfirmationForm
 from .user import EditAccountForm, DeleteAccountForm
 from .sub import CreateSubForm, EditSubForm, EditSubTextPostForm, EditSubFlair, EditSubRule
 from .sub import CreateSubPostForm, EditCommentForm

--- a/app/forms/user.py
+++ b/app/forms/user.py
@@ -84,6 +84,12 @@ class RegistrationForm(FlaskForm):
     securityanswer = StringField(_l('Security question'))
 
 
+class ResendConfirmationForm(FlaskForm):
+    """ For resending emails """
+    email = EmailField(_l('Email Address'),
+                       validators=[Email(_l("Invalid email address."))])
+
+
 class EditAccountForm(FlaskForm):
     email_optional = EmailField(_l('Email Address (optional)'),
                                 validators=[OptionalIfFieldIsEmpty('email_optional'),

--- a/app/html/user/login.html
+++ b/app/html/user/login.html
@@ -19,7 +19,6 @@
             <label for="password">@{_('Password')}</label>
             @{loginform.password(placeholder=loginform.password.label.text, required=True)!!html}
           </div>
-          <a href="/recover">@{_('Forgot your password?')}</a>
           <div class="pure-controls">
             <label for="remember" class="pure-checkbox">
               @{loginform.remember()!!html} @{_('Remember me')}
@@ -30,6 +29,13 @@
             <button type="submit" class="pure-button pure-button-primary">@{_('Log in')}</button>
           </div>
         </fieldset>
+        <ul class="loginlinklist">
+          <li><a href="@{url_for('user.password_recovery')}">@{_('Forgot your password?')}</a></li>
+          @if email_validation_is_required():
+            <li><a href="@{url_for('auth.resend_confirmation_email')}">@{_("Didn't get confirmation instructions?")}</a></li>
+          @end
+          <li><a href="@{url_for('auth.register')}">@{_('Sign up')}</a></li>
+        </ul>
       </form>
   </div>
 </div>

--- a/app/html/user/password_recovery.html
+++ b/app/html/user/password_recovery.html
@@ -32,6 +32,13 @@
         </div>
 
       </fieldset>
+      <ul class="loginlinklist">
+        <li><a href="@{url_for('auth.login')}">@{_('Log in')}</a></li>
+        <li><a href="@{url_for('auth.register')}">@{_('Sign up')}</a></li>
+        @if email_validation_is_required():
+          <li><a href="@{url_for('auth.resend_confirmation_email')}">@{_("Didn't get confirmation instructions?")}</a></li>
+        @end
+      </ul>
     </form>
   </div>
 </div>

--- a/app/html/user/register.html
+++ b/app/html/user/register.html
@@ -70,6 +70,13 @@
                     <button type="submit" class="pure-button pure-button-primary">@{_('Register')}</button>
                 </div>
             </fieldset>
+            <ul class="loginlinklist">
+              <li><a href="@{url_for('auth.login')}">@{_('Log in')}</a></li>
+              <li><a href="@{url_for('user.password_recovery')}">@{_('Forgot your password?')}</a></li>
+              @if email_validation_is_required():
+                <li><a href="@{url_for('auth.resend_confirmation_email')}">@{_("Didn't get confirmation instructions?")}</a></li>
+              @end
+            </ul>
         </form>
     </div>
 </div>

--- a/app/html/user/resend_confirmation.html
+++ b/app/html/user/resend_confirmation.html
@@ -1,0 +1,32 @@
+@extends("shared/layout.html")
+@require(form, error)
+@def title():
+  Send confirmation instructions |\
+@end
+
+@def main():
+<div id="center-container">
+  <div class="content">
+    <form  method="POST" class="pure-form pure-form-aligned">
+      <h1>@{_('Resend account confirmation instructions')}</h1> @{ form.csrf_token() !!html}
+      @if error:
+      <div class="error">@{ error }</div>
+      @end
+      <fieldset>
+        <div class="pure-control-group">
+          <label for="email">@{_('E-mail address')}</label>
+          @{form.email(required=True)!!html}
+        </div>
+        <div class="pure-controls">
+          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary">@{_('Send email')}</button>
+        </div>
+      </fieldset>
+      <ul class="loginlinklist">
+        <li><a href="@{url_for('auth.login')}">@{_('Log in')}</a></li>
+        <li><a href="@{url_for('auth.register')}">@{_('Sign up')}</a></li>
+        <li><a href="@{url_for('user.password_recovery')}">@{_('Forgot your password?')}</a></li>
+      </ul>
+    </form>
+  </div>
+</div>
+@end

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2236,3 +2236,8 @@ article.text-post.comment.deleted {
   float: right;
   margin-left: 10px;
 }
+
+.loginlinklist {
+  list-style: none;
+  line-height: 1.4;
+}


### PR DESCRIPTION
Add a page that allows a registered user who has lost their email confirmation token, or let it expire, to ask for a new one to be sent.

The set of four pages including this new page, plus login, register and forgot-my-password now all have a list of links at the bottom that allow you to easily get to the other 3 in the set.  If require_valid_emails is not set in the config, then each of login, register and forgot-my-password will have links to the other two.