### PR TITLE
Recommend setting autorollback for Postgres in example config

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -239,9 +239,6 @@ database:
   # For sqlite:
   #database: '/path/to/sqlite.db'
 
-  # Uncomment if using Postgres:
-  #autocommit: True
-
   # Uncomment if using Postgres, to prevent transactions with errors from
   # killing other unrelated transactions.
   #autorollback: True

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -242,6 +242,10 @@ database:
   # Uncomment if using Postgres:
   #autocommit: True
 
+  # Uncomment if using Postgres, to prevent transactions with errors from
+  # killing other unrelated transactions.
+  #autorollback: True
+
   # Uncomment if using MySQL
   #charset: 'utf8mb4'
 


### PR DESCRIPTION
We noticed that sometimes errors arising from database transactions were killing other database transactions with the error message "DatabaseError: current transaction is aborted, commands ignored until end of transaction block".  This happens because Postgres wants you to roll back queries with serious errors before doing anything else.  Peewee can do this automatically if `autorollback` is set in the database config.