### PR TITLE
Fix subscription counts, and other counters vulnerable to race conditions

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -12,7 +12,7 @@ from keycloak.exceptions import KeycloakError, KeycloakGetError
 from peewee import fn
 
 from .config import config
-from .models import User, UserMetadata, UserAuthSource, UserCrypto, SiteMetadata
+from .models import User, UserMetadata, UserAuthSource, UserCrypto, UserStatus, SiteMetadata
 from . import misc
 
 
@@ -83,7 +83,8 @@ class AuthProvider:
                     return None
         return None
 
-    def create_user(self, name, password, email, verified_email=False):
+    def create_user(self, name, password, email, status=UserStatus.OK,
+                    verified_email=False):
         auth_source = getattr(UserAuthSource, self.provider)
 
         if self.provider == 'LOCAL':
@@ -100,7 +101,7 @@ class AuthProvider:
             password = ''
             crypto = UserCrypto.REMOTE
         user = User.create(uid=uid, name=name, crypto=crypto, password=password,
-                           email=email, joindate=datetime.utcnow())
+                           status=status, email=email, joindate=datetime.utcnow())
         self.set_user_auth_source(user, auth_source)
         self._set_email_verified(user, verified_email)
         return user

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,30 @@
+import click
+from flask import current_app
+from flask.cli import AppGroup
+from .models import User, Sub, SubSubscriber
+
+recount = AppGroup('recount')
+
+
+@recount.command()
+@click.option('--save/--dry-run', default=True,
+              help='Use --save (the default) to fix the counts, or --dry-run to just print them.')
+def subscribers(save):
+    """Update subscriber counts for all the subs."""
+    if save:
+        print('Name                             Before   After')
+    else:
+        print('Name                            Current Correct')
+
+    subs = Sub.select(Sub.sid, Sub.name, Sub.subscribers).order_by(Sub.name)
+    for sub in subs:
+        count = SubSubscriber.select().where((SubSubscriber.sid == sub.sid) &
+                                             (SubSubscriber.status == 1)).count()
+        print(f'{sub.name:32}{sub.subscribers:7}{count:8}')
+        if save:
+            Sub.update(subscribers=SubSubscriber.select().where(
+                (SubSubscriber.sid == sub.sid) & (SubSubscriber.status == 1)).count()).where(
+                    Sub.sid == sub.sid).execute()
+
+
+commands = [recount]

--- a/app/misc.py
+++ b/app/misc.py
@@ -643,11 +643,11 @@ def workWithMentions(data, receivedby, post, sub, cid=None, c_user=current_user)
             if user.uid != c_user.uid and user.uid != receivedby:
                 # Checks done. Send our shit
                 if cid:
-                    Notification(type='COMMENT_MENTION', sub=post.sid, post=post.pid, comment=cid,
-                                 sender=c_user.uid, target=user.uid).save()
+                    Notification.create(type='COMMENT_MENTION', sub=post.sid, post=post.pid, comment=cid,
+                                        sender=c_user.uid, target=user.uid)
                 else:
-                    Notification(type='POST_MENTION', sub=post.sid, post=post.pid, comment=cid,
-                                 sender=c_user.uid, target=user.uid).save()
+                    Notification.create(type='POST_MENTION', sub=post.sid, post=post.pid, comment=cid,
+                                        sender=c_user.uid, target=user.uid)
                 socketio.emit('notification',
                               {'count': get_notification_count(user.uid)},
                               namespace='/snt',
@@ -1399,24 +1399,24 @@ LOG_TYPE_ENABLE_CAPTCHAS = 72
 
 
 def create_sitelog(action, uid, comment='', link=''):
-    SiteLog.create(action=action, uid=uid, desc=comment, link=link).save()
+    SiteLog.create(action=action, uid=uid, desc=comment, link=link)
 
 
 # Note: `admin` makes the entry appear on the sitelog. I should rename it
 def create_sublog(action, uid, sid, comment='', link='', admin=False, target=None):
-    SubLog.create(action=action, uid=uid, sid=sid, desc=comment, link=link, admin=admin, target=target).save()
+    SubLog.create(action=action, uid=uid, sid=sid, desc=comment, link=link, admin=admin, target=target)
 
 
 # `id` is the report id
 def create_reportlog(action, uid, id, type='', related=False, original_report='', desc=''):
     if type == 'post' and related == False:
-        PostReportLog.create(action=action, uid=uid, id=id, desc=desc).save()
+        PostReportLog.create(action=action, uid=uid, id=id, desc=desc)
     elif type == 'comment' and related == False:
-        CommentReportLog.create(action=action, uid=uid, id=id, desc=desc).save()
+        CommentReportLog.create(action=action, uid=uid, id=id, desc=desc)
     elif type == 'post' and related == True:
-        PostReportLog.create(action=action, uid=uid, id=id, desc=original_report).save()
+        PostReportLog.create(action=action, uid=uid, id=id, desc=original_report)
     elif type == 'comment' and related == True:
-        CommentReportLog.create(action=action, uid=uid, id=id, desc=original_report).save()
+        CommentReportLog.create(action=action, uid=uid, id=id, desc=original_report)
 
 def is_domain_banned(addr, domain_type):
     if domain_type == 'link':
@@ -1782,8 +1782,6 @@ def cast_vote(uid, target_type, pcid, value):
             sp_vote = SubPostVote.create(pid=pcid, uid=uid, positive=positive, datetime=now)
         else:
             sp_vote = SubPostCommentVote.create(cid=pcid, uid=uid, positive=positive, datetime=now)
-
-        sp_vote.save()
 
         if positive:
             upd_q = target_model.update(score=target_model.score + voteValue, upvotes=target_model.upvotes + 1)

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -448,10 +448,8 @@ def create_wiki():
     form = WikiForm()
 
     if form.validate_on_submit():
-        wiki = Wiki(slug=form.slug.data, title=form.title.data, content=form.content.data)
-        wiki.is_global = True
-        wiki.sub = None
-        wiki.save()
+        wiki = Wiki.create(slug=form.slug.data, title=form.title.data, content=form.content.data,
+                           is_global=True, sub=None)
         return redirect(url_for('admin.wiki'))
     return engine.get_template('admin/createwiki.html').render({'form': form, 'error': misc.get_errors(form, True)})
 

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -419,7 +419,6 @@ def create_comment(sub, pid):
                                     cid=uuid.uuid4(), score=0, upvotes=0, downvotes=0)
 
     SubPost.update(comments=SubPost.comments + 1).where(SubPost.pid == post.pid).execute()
-    comment.save()
 
     socketio.emit('threadcomments', {'pid': post.pid, 'comments': post.comments + 1},
                   namespace='/snt', room=post.pid)

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -290,8 +290,8 @@ def delete_post(sub, pid):
             return jsonify(msg="Cannot delete post without reason"), 400
         post.deleted = 2
         # TODO: Make this a translatable notification
-        Notification(type='POST_DELETE', sub=post.sid, post=post.pid, content='Reason: ' + reason,
-                     sender=uid, target=post.uid).save()
+        Notification.create(type='POST_DELETE', sub=post.sid, post=post.pid, content='Reason: ' + reason,
+                            sender=uid, target=post.uid)
 
         misc.create_sublog(misc.LOG_TYPE_SUB_DELETE_POST, uid, post.sid,
                            comment=reason, link=url_for('site.view_post_inbox', pid=post.pid),
@@ -433,8 +433,8 @@ def create_comment(sub, pid):
         ntype = 'POST_REPLY'
 
     if notif_to != uid and uid not in misc.get_ignores(notif_to):
-        Notification(type=ntype, sub=post.sid, post=post.pid, comment=comment.cid,
-                     sender=uid, target=notif_to).save()
+        Notification.create(type=ntype, sub=post.sid, post=post.pid, comment=comment.cid,
+                            sender=uid, target=notif_to)
         socketio.emit('notification', {'count': misc.get_notification_count(notif_to)},
                       namespace='/snt', room='user' + notif_to)
 

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -14,7 +14,7 @@ from ..auth import normalize_email
 from ..forms import LoginForm, RegistrationForm, ResendConfirmationForm
 from ..misc import engine, send_email, is_domain_banned
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
-from ..models import User, UserMetadata, UserStatus, InviteCode, SubSubscriber, rconn
+from ..models import User, UserMetadata, UserStatus, InviteCode, SubSubscriber, Sub, rconn
 
 bp = Blueprint('auth', __name__)
 
@@ -140,6 +140,8 @@ def register():
     defaults = misc.getDefaultSubs()
     subs = [{'uid': user.uid, 'sid': x['sid'], 'status': 1, 'time': datetime.utcnow()} for x in defaults]
     SubSubscriber.insert_many(subs).execute()
+    Sub.update(subscribers=Sub.subscribers + 1).where(
+        Sub.sid << [x['sid'] for x in defaults]).execute()
 
     if email_validation_is_required():
         send_login_link_email(user)

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -128,8 +128,8 @@ def register():
             return engine.get_template('user/register.html').render(
                 {'error': _("Invalid invite code."), 'regform': form, 'captcha': captcha})
 
-        invcode.uses += 1
-        invcode.save()
+        InviteCode.update(uses=InviteCode.uses + 1).where(
+            InviteCode.code == form.invitecode.data).execute()
 
     status = UserStatus.PROBATION if email_validation_is_required() else UserStatus.OK
     user = auth_provider.create_user(name=form.username.data, password=form.password.data,

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -131,8 +131,9 @@ def register():
         invcode.uses += 1
         invcode.save()
 
+    status = UserStatus.PROBATION if email_validation_is_required() else UserStatus.OK
     user = auth_provider.create_user(name=form.username.data, password=form.password.data,
-                                     email=email, verified_email=False)
+                                     email=email, verified_email=False, status=status)
     if misc.enableInviteCode():
         UserMetadata.create(uid=user.uid, key='invitecode', value=form.invitecode.data)
 
@@ -141,8 +142,6 @@ def register():
     SubSubscriber.insert_many(subs).execute()
 
     if email_validation_is_required():
-        user.status = UserStatus.PROBATION
-        user.save()
         send_login_link_email(user)
         return redirect(url_for('auth.confirm_registration'))
     else:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1104,6 +1104,7 @@ def accept_modinv(sub, user):
 
         if not current_user.has_subscribed(sub.name):
             SubSubscriber.create(uid=current_user.uid, sid=sub.sid, status=1)
+            Sub.update(subscribers=Sub.subscribers + 1).where(Sub.sid == sub.sid).execute()
         return jsonify(status='ok')
     return json.dumps({'status': 'error', 'error': get_errors(form)})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ flask-limiter
 python-keycloak==0.21.0
 itsdangerous
 python-slugify
+click

--- a/throat.py
+++ b/throat.py
@@ -2,8 +2,22 @@
 """ From here we start the app in debug mode. """
 from gevent import monkey
 monkey.patch_all()
+import click
 from app import create_app, socketio  # noqa
+from app.cli import commands
+
 app = create_app()
 
+@click.group(invoke_without_command=True)
+@click.pass_context
+def run(ctx):
+    if ctx.invoked_subcommand is None:
+        socketio.run(app, debug=app.config.get('DEBUG'), host=app.config.get('HOST'))
+
+
+for command in commands:
+    run.add_command(command)
+
+
 if __name__ == "__main__":
-    socketio.run(app, debug=app.config.get('DEBUG'), host=app.config.get('HOST'))
+    run()


### PR DESCRIPTION
Subscriber counts on our instance were off by a huge margin and negative for some subs.  On investigation we spotted this pattern which the peewee docs say specifically to _not_ do:

```
        sub.subscribers += 1
        sub.save()
```
The reason to not do it this way is that it is vulnerable to race conditions if another request is simultaneously subscribing or unsubscribing.

That turned out not to be the main problem with subscription counts, which was that `register` was not updating them when it subscribed new users to the default subs.

This PR:
- Reduces the number of calls to `Model.save`, to simplify code and reduce the number of places that need to be reviewed for possible race conditions.
- Changes all the usages of `save` similar to the example above to use `Model.update`, as recommended by the peewee docs.
- Fixes the `register` bug and a couple of other places where the subscriber count wasn't getting updated.
- Adds the beginning of a command line framework based on `click` and `flask.cli`
- Running `./throat.py` works as before, but now `./throat.py recount subscribers` will recalculate the subscriber counts for all the subs, and it has a `--dry-run` option if you would like to see what it is going to do before it does it.