### PR TITLE
Explicitly manage database connections

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,7 +15,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .config import Config, config
 from .forms import LoginForm, LogOutForm, CreateSubForm
-from .models import db_init_app, rconn, User, db
+from .models import db_init_app, rconn, User
 from .auth import auth_provider, email_validation_is_required
 from .views import do, subs as sub, api3, jwt
 from .views.auth import bp as auth
@@ -144,7 +144,6 @@ def create_app(config=Config('config.yaml')):
             response.response[0] = response.response[0] \
                 .replace(b'__DB_QUERIES__', str(g.pqc).encode())
             response.headers["content-length"] = len(response.response[0])
-        db.close()
         return response
 
     @app.context_processor

--- a/app/config.py
+++ b/app/config.py
@@ -91,7 +91,9 @@ cfg_defaults = {  # key => default value
             "testing": False
         },
         "aws": {},
-        "database": {},
+        "database": {
+            "autoconnect": False
+        },
         "ratelimit": {
             "default": "60/minute"
         },

--- a/app/socketio.py
+++ b/app/socketio.py
@@ -1,7 +1,7 @@
 from flask_socketio import SocketIO, join_room
 from flask_login import current_user
 from flask import request
-from .models import rconn, db
+from .models import rconn
 import json
 from wheezy.html.utils import escape_html
 
@@ -27,7 +27,6 @@ def handle_message():
                                 'ntf': current_user.notifications},
                       namespace='/snt',
                       room='user' + current_user.uid)
-    db.close()
 
 
 @socketio.on('getchatbacklog', namespace='/snt')

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -45,10 +45,9 @@ def app(test_config):
     recursively_update(config, test_config)
 
     app = create_app(config)
-    db.create_tables(BaseModel.__subclasses__())
-
     app_context = app.app_context()
     app_context.push()
+    db.create_tables(BaseModel.__subclasses__())
 
     yield app
 


### PR DESCRIPTION
Fix a database connection leak which would happen while the application was under load.  Peewee's documentation recommends managing database connections explicitly instead of using their autoconnect option, which defaults to True.  Set autoconnect to False, and use the method recommended by the Flask documentation to manage connections.

See:
http://docs.peewee-orm.com/en/latest/peewee/database.html?highlight=connection#using-autoconnect
https://flask.palletsprojects.com/en/1.1.x/appcontext/