### PR TITLE
Support custom hot sort functions defined in SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A phoxy link and discussion aggregator with snek (python3)
 
 ## Dependencies:
 
- - A database server, MySQL, MariaDB and Postres have been tested. Sqlite should work for messing locally
+ - A database server, MySQL, MariaDB and Postgres have been tested. Sqlite should work for messing locally
  - Redis
  - Python >= 3.7
  - A recent node/npm
@@ -39,6 +39,22 @@ To add an admin user to a running docker-compose application:
 `docker exec throat_throat_1 python3 scripts/admins.py --add {{username}}`
 
 If Wheezy templates are not automatically reloading in docker between changes, try `docker restart throat_throat_1`.
+
+## Database Configuration
+
+The default hot sort function is simple for speed, but it does not prioritize new posts over old ones as much as some people prefer.  If you define a function named `hot` in SQL in your database, you can use that instead of the default by setting `custom_hot_sort` to `True` in your `config.yaml`.  The function needs to take two arguments, a post's current score and the date it was posted.  To allow the database to cache the results, the function should only depend on the values of its arguments and should be marked `immutable`.
+
+In addition to defining the function, you should also create an index on it to speed up the hot sort query.  Once that is done, custom functions will be faster than the default hot sort.  To implement Reddit's version of hot sort in Postgres, add the following SQL statements to your database using `psql`:
+
+```
+create or replace function hot(score integer, date double precision) returns numeric as $$
+  select round(cast(log(greatest(abs($1), 1)) * sign($1) + ($2 - 1134028003) / 45000.0 as numeric), 7)
+$$ language sql immutable;
+
+create index on sub_post (hot(score, (EXTRACT(EPOCH FROM sub_post.posted))));
+```
+
+Other databases may require variations in the handling of the date. Custom hot sorts are not supported for Sqlite.
 
 ## Docker Deployments
 

--- a/app/config.py
+++ b/app/config.py
@@ -54,7 +54,8 @@ cfg_defaults = {  # key => default value
             },
 
             "archive_post_after": 60,
-            "trusted_proxy_count": 0
+            "trusted_proxy_count": 0,
+            "custom_hot_sort": False,
         },
         "auth": {
             "provider": 'LOCAL',

--- a/app/misc.py
+++ b/app/misc.py
@@ -910,18 +910,15 @@ def getPostList(baseQuery, sort, page):
     elif sort == "new":
         posts = baseQuery.order_by(SubPost.pid.desc()).paginate(page, 25)
     else:
-        if config.database.engine == "PostgresqlDatabase":
+        if config.site.custom_hot_sort:
+            hot = fn.HOT(SubPost.score, SubPost.posted)
+        elif 'Postgresql' in config.database.engine:
             hot = SubPost.score * 20 + (fn.EXTRACT(NodeList((SQL('EPOCH FROM'), SubPost.posted))) - 1134028003) / 1500
-            posts = baseQuery.order_by(hot.desc()).limit(100).paginate(page, 25)
-        elif config.database.engine == 'SqliteDatabase':
-            posts = baseQuery.order_by(
-                (SubPost.score * 20 + (fn.datetime(SubPost.posted, 'unixepoch') - 1134028003) / 1500).desc()).limit(
-                100).paginate(page, 25)
+        elif 'SqliteDatabase' in config.database.engine:
+            hot = SubPost.score * 20 + (fn.datetime(SubPost.posted, 'unixepoch') - 1134028003) / 1500
         else:
-            posts = baseQuery.order_by(
-                (SubPost.score * 20 + (fn.Unix_Timestamp(SubPost.posted) - 1134028003) / 1500).desc()).limit(
-                100).paginate(page, 25)
-
+            hot = SubPost.score * 20 + (fn.Unix_Timestamp(SubPost.posted) - 1134028003) / 1500
+        posts = baseQuery.order_by(hot.desc()).limit(100).paginate(page, 25)
     return posts
 
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -94,6 +94,12 @@ site:
   # a load balancer, this should be set to 1 or more.
   trusted_proxy_count: 0
 
+  # Use a function defined in the database for hot-sorting posts,
+  # instead of the default.  This option is not supported for Sqlite.
+  # This requires additional database configuration; see README.md for
+  # more information.
+  custom_hot_sort: False
+
 auth:
   # Set to LOCAL to store user authentication in database,
   # or KEYCLOAK to use a Keycloak server to authenticate users.


### PR DESCRIPTION
When an instance has a lot of activity, the default sort of hot posts mostly shows the posts with the highest scores.  This change allows an administrator to load a custom hot sort function defined in SQL into the database and use it for hot-sorting posts. A function defined in SQL will be faster than the default hot sort, because the database will be able to use caching and indexing on the calculated "hot" value.
