### PR TITLE
Make a proxy for the logger to save on typing

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -13,6 +13,7 @@ from peewee import fn
 
 from .config import config
 from .models import User, UserMetadata, UserAuthSource, UserCrypto, UserStatus, SiteMetadata
+from .misc import logger
 from . import misc
 
 
@@ -315,8 +316,8 @@ class AuthProvider:
         elif user.status != 10 and new_status == 5:
             if user.email and self.is_email_verified(user):
                 domain = user.email.split('@')[1]
-                current_app.logger.info('Banned %s; confirmed email on %s',
-                                        user.name, domain)
+                logger.info('Banned %s; confirmed email on %s',
+                            user.name, domain)
 
             payload = {'enabled': False}
         elif user.status != 10 and new_status == 0:

--- a/app/misc.py
+++ b/app/misc.py
@@ -46,6 +46,7 @@ from peewee import JOIN, fn, SQL, NodeList, Value
 import requests
 import logging
 import logging.config
+from werkzeug.local import LocalProxy
 
 from wheezy.template.engine import Engine
 from wheezy.template.ext.core import CoreExtension
@@ -2007,3 +2008,6 @@ def add_context_to_log_records(config):
 
     record_factory.old_factory = old_factory
     logging.setLogRecordFactory(record_factory)
+
+
+logger = LocalProxy(lambda: current_app.logger)

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -1,6 +1,6 @@
 """ Pages to be migrated to a wiki-like system """
 from flask import Blueprint, request, redirect, url_for, jsonify, current_app
-from ..misc import engine
+from ..misc import engine, logger
 from ..forms import LoginForm
 
 bp = Blueprint('errors', __name__)
@@ -46,7 +46,7 @@ def server_error(error):
     import traceback
     import sys
     typ, val, tb = sys.exc_info()
-    current_app.logger.error('EXCEPTION: %s, "%s", %s', typ.__name__, val, traceback.format_tb(tb))
+    logger.error('EXCEPTION: %s, "%s", %s', typ.__name__, val, traceback.format_tb(tb))
     if request.path.startswith('/api'):
         if request.path.startswith('/api/v3'):
             return jsonify(msg="Internal error"), 500


### PR DESCRIPTION
Make it so you can type `logger.debug("...")` instead of `current_app.logger("...")`.