### PR TITLE
Only render execution time and queries in debug mode

### DIFF
--- a/app/html/index.html
+++ b/app/html/index.html
@@ -26,7 +26,7 @@
   <a href="/license">@{_('License')}</a>
   <br>
   @{_('Served by %(host)s', host=hostname)} \
-  @if config.app.debug or current_user.admin:
+  @if config.app.debug:
    | @{_('Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries')}
   @end
 @end

--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -163,7 +163,7 @@
       <a href="/license">@{_('License')}</a>
       <br>
       @{_('Served by %(hostname)s', hostname=hostname)} \
-      @if config.app.debug or current_user.admin:
+      @if config.app.debug:
        | @{_('Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries')}
       @end
     @end

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -165,7 +165,7 @@
       <a href="/license">License</a>
       <br>
       Served by {{hostname}}
-      {%if config.app.debug or current_user.admin%} | Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries{%endif%}
+      {%if config.app.debug%} | Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries{%endif%}
     {% endblock %}
   </div>
   <script src="{{ asset_url_for('main.js') }}"></script>


### PR DESCRIPTION
Make the templates which show execution time and queries only do so in debug mode, to match what `after_request` is doing.