### PR TITLE
Allow websocket connections in the Content Security Policy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,7 +67,14 @@ def create_app(config=Config('config.yaml')):
                                           for url in config.site.expando_sites],
            'img-src':     ['\'self\'', 'data:', 'https:'],
            'media-src':   ['\'self\'', 'https:'],
-           'style-src':   ['\'self\'', '\'unsafe-inline\'']}
+           'style-src':   ['\'self\'', '\'unsafe-inline\''],
+           'connect-src': ['\'self\'']}
+
+    if app.config['SERVER_NAME']:
+        csp['connect-src'] += [f'wss://{app.config["SERVER_NAME"]}']
+        if not config.app.force_https:
+            csp['connect-src'] += [f'ws://{app.config["SERVER_NAME"]}']
+
     talisman.init_app(app, content_security_policy=csp,
                       force_https=config.app.force_https)
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -133,6 +133,11 @@ app:
   # host to pass to SocketIO when we start the application
   host: "localhost"
 
+  # Domain name at which the app is being served.  This must be
+  # configured for websocket support (chat and push new posts) on
+  # Safari and Apple WebKit.  For development, you can omit this.
+  #server_name: "throat.example.com"
+
   # URL to a working redis server.
   # Used for websockets (if enabled)
   redis_url: 'redis://127.0.0.1:6379'


### PR DESCRIPTION
Most browsers interpret `'self'` in the connect-src CSP to allow websocket connections to the same domain, except for Safari and Apple WebKit which require `wss://example.com` in the CSP.  Add this to our CSP, and add Flask's `SERVER_NAME` variable to `example.config.yaml` to make the domain name available to initialize the CSP, which happens outside of a request context.