### PR TITLE
Fix notifications not appearing after password reset

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -879,7 +879,7 @@ def getMessagesIndex(page):
                              Message.subject, Message.content, Message.posted, Message.read, Message.mtype,
                              Message.mlink)
         msg = msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.sentby)).where(Message.mtype == 1).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -892,7 +892,7 @@ def getMentionsIndex(page):
                              Message.subject, Message.content, Message.posted, Message.read, Message.mtype,
                              Message.mlink)
         msg = msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.sentby)).where(Message.mtype == 8).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -904,7 +904,7 @@ def getMessagesSent(page):
         msg = Message.select(Message.mid, Message.sentby, User.name.alias('username'), Message.subject, Message.content,
                              Message.posted, Message.read, Message.mtype, Message.mlink)
         msg = msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.receivedby)).where(Message.mtype == 1).where(
-            Message.sentby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.sentby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -916,7 +916,7 @@ def getMessagesModmail(page):
         msg = Message.select(Message.mid, User.name.alias('username'), Message.receivedby, Message.subject,
                              Message.content, Message.posted, Message.read, Message.mtype, Message.mlink)
         msg = msg.join(User, on=(User.uid == Message.sentby)).where(Message.mtype << [2, 7, 11]).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -928,7 +928,7 @@ def getMessagesSaved(page):
         msg = Message.select(Message.mid, User.name.alias('username'), Message.receivedby, Message.subject,
                              Message.content, Message.posted, Message.read, Message.mtype, Message.mlink)
         msg = msg.join(User, on=(User.uid == Message.sentby)).where(Message.mtype == 9).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -944,9 +944,9 @@ def getMsgCommReplies(page):
                              SubPostComment.score, SubPostCommentVote.positive, Sub.name.alias('sub'))
         msg = msg.join(SubPostComment, on=SubPostComment.cid == Message.mlink).join(SubPost).join(Sub).switch(
             SubPostComment).join(SubPostCommentVote, JOIN.LEFT_OUTER, on=(
-                (SubPostCommentVote.uid == current_user.get_id()) & (SubPostCommentVote.cid == Message.mlink)))
+                (SubPostCommentVote.uid == current_user.uid) & (SubPostCommentVote.cid == Message.mlink)))
         msg = msg.join(User, on=(User.uid == Message.sentby)).where(Message.mtype == 5).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg
@@ -962,9 +962,9 @@ def getMsgPostReplies(page):
                              SubPostComment.score, SubPostComment.content, Sub.name.alias('sub'))
         msg = msg.join(SubPostComment, on=SubPostComment.cid == Message.mlink).join(SubPost).join(Sub).switch(
             SubPostComment).join(SubPostCommentVote, JOIN.LEFT_OUTER, on=(
-                (SubPostCommentVote.uid == current_user.get_id()) & (SubPostCommentVote.cid == Message.mlink)))
+                (SubPostCommentVote.uid == current_user.uid) & (SubPostCommentVote.cid == Message.mlink)))
         msg = msg.join(User, on=(User.uid == Message.sentby)).where(Message.mtype == 4).where(
-            Message.receivedby == current_user.get_id()).order_by(Message.mid.desc()).paginate(page, 20).dicts()
+            Message.receivedby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False
     return msg


### PR DESCRIPTION
`misc.get_id` returns the user's login id, which used to be the same as the user's uid until #85, which made the login id change every time the user does a password reset, in order to invalidate their old login sessions.  The queries that get notifications and messages were using `current_user.get_id()` so they were only working for users who were still using their original password.  Change them to use `current_user.uid`.