### PR TITLE
Move server name configuration from app section to site section

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -70,10 +70,11 @@ def create_app(config=Config('config.yaml')):
            'style-src':   ['\'self\'', '\'unsafe-inline\''],
            'connect-src': ['\'self\'']}
 
-    if app.config['SERVER_NAME']:
-        csp['connect-src'] += [f'wss://{app.config["SERVER_NAME"]}']
+    server_name = config.site.get('server_name')
+    if server_name is not None:
+        csp['connect-src'] += [f'wss://{server_name}']
         if not config.app.force_https:
-            csp['connect-src'] += [f'ws://{app.config["SERVER_NAME"]}']
+            csp['connect-src'] += [f'ws://{server_name}']
 
     talisman.init_app(app, content_security_policy=csp,
                       force_https=config.app.force_https)

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -10,6 +10,11 @@ site:
   # Copyright line shown in the footer
   copyright: 'Umbrella Corp'
 
+  # Domain name at which the app is being served.  This must be
+  # configured for websocket support (chat and push new posts) on
+  # Safari and Apple WebKit.  For development, you can omit this.
+  #server_name: "throat.example.com"
+
   # Name shown when a sub is owned by a deleted account or abandoned
   placeholder_account: 'Site'
 
@@ -132,11 +137,6 @@ auth:
 app:
   # host to pass to SocketIO when we start the application
   host: "localhost"
-
-  # Domain name at which the app is being served.  This must be
-  # configured for websocket support (chat and push new posts) on
-  # Safari and Apple WebKit.  For development, you can omit this.
-  #server_name: "throat.example.com"
 
   # URL to a working redis server.
   # Used for websockets (if enabled)


### PR DESCRIPTION
Values in the app section of `config.yaml` are passed through to Flask, which passes them through to Werkzeug, which complains and refuses to route if you access a server by its IP address when `SERVER_NAME` is defined. 

If a server is behind a load balancer which terminates https, it may always be accessed by its IP address.   

Move the server name to the site section of the config so that the server can know the domain it is serving without confusing Werkzeug.