### PR TITLE
Simplify error templates and cache rendered templates in Redis

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,13 +32,12 @@ from .views.messages import bp as messages
 from . import misc, forms, caching, storage
 from .socketio import socketio
 from .misc import SiteAnon, engine, engine_init_app, re_amention, mail, talisman, limiter
-from .misc import logging_init_app
+from .misc import logging_init_app, get_locale, babel
 
 # /!\ FOR DEBUGGING ONLY /!\
 # from werkzeug.middleware.profiler import ProfilerMiddleware
 
 webpack = Webpack()
-babel = Babel()
 login_manager = LoginManager()
 login_manager.anonymous_user = SiteAnon
 login_manager.login_view = 'auth.login'
@@ -168,13 +167,6 @@ def create_app(config=Config('config.yaml')):
                 'func': misc, 'time': time, 'conf': app.config, '_': _, 'locale': get_locale}
 
     return app
-
-
-@babel.localeselector
-def get_locale():
-    if current_user.language:
-        return current_user.language
-    return request.accept_languages.best_match(config.app.languages, config.app.fallback_language)
 
 
 @login_manager.user_loader

--- a/app/html/errors/403.html
+++ b/app/html/errors/403.html
@@ -1,5 +1,4 @@
-@extends("shared/layout.html")
-@require(loginform)
+@extends("errors/layout.html")
 @def title():
   @{_('Error 403 - Forbidden')} |\
 @end
@@ -11,29 +10,6 @@
       <p>
         @{_('It seems that you\'re trying to get to the depths of the throat.')}
       </p>
-      @if current_user.is_anonymous:
-        <hr/>
-        <form method="POST" class="pure-form pure-form-aligned">
-          <h2>@{_('Login')}</h2> @{ loginform.csrf_token()!!html}
-          <fieldset>
-            <div class="pure-control-group">
-              <label for="username">@{_('Username')}</label>
-              @{loginform.username(placeholder=loginform.username.label.text, required=True, pattern="[a-zA-Z0-9_-]+", title=_('Alphanumeric characters plus \'-\' and \'_\''))!!html}
-            </div>
-            <div class="pure-control-group">
-              <label for="password">@{_('Password')}</label>
-              @{loginform.password(placeholder=loginform.password.label.text, required=True)!!html}
-            </div>
-            <a href="/recover">@{_('Forgot your password?')}</a>
-            <div class="pure-controls">
-              <label for="remember" class="pure-checkbox">
-                @{loginform.remember()!!html} @{_('Remember me')}
-              </label>
-              <button type="submit" class="pure-button pure-button-primary">@{_('Log in')}</button>
-            </div>
-          </fieldset>
-        </form>
-      @end
     </div>
   </div>
 @end

--- a/app/html/errors/404.html
+++ b/app/html/errors/404.html
@@ -1,4 +1,4 @@
-@extends("shared/layout.html")
+@extends("errors/layout.html")
 
 @def title():
   @{_('Error 404 - Not found')} |\

--- a/app/html/errors/418.html
+++ b/app/html/errors/418.html
@@ -1,4 +1,4 @@
-@extends("shared/layout.html")
+@extends("errors/layout.html")
 
 @def title():
   @{_('Error 418 - I\'m a teapot')} |\

--- a/app/html/errors/429.html
+++ b/app/html/errors/429.html
@@ -1,4 +1,4 @@
-@extends("shared/layout.html")
+@extends("errors/layout.html")
 
 @def title():
 @{_('Too many requests')} |\

--- a/app/html/errors/500.html
+++ b/app/html/errors/500.html
@@ -1,4 +1,4 @@
-@extends("shared/layout.html")
+@extends("errors/layout.html")
 
 @def title():
   @{_('Internal error')} |\

--- a/app/html/errors/layout.html
+++ b/app/html/errors/layout.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="@{get_locale()}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="keywords" content="forum, vote, comment, submit, throat, phuks, phuks.co"/>
+    <meta name="referrer" content="always"/>
+    @def meta_description():
+    <meta name="description" content="@{config.site.lema}"/>
+    @end
+    @{meta_description()!!html}
+    <meta name="robots" content="index, follow"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <!-- mobile stuff -->
+    <meta name="theme-color" content="white"/>
+    <meta name="msapplication-navbutton-color" content="white"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="white-translucent"/>
+
+    <link rel="icon" href="@{url_for('static', filename='img/icon.png') }">
+
+    <title> \
+      @def title():
+      @end
+      @{title()!!html} \
+      @def lema():
+      @#
+      @{config.site.lema} \
+      @end
+      @{lema()!!html} \
+    </title>
+
+    <link rel="stylesheet" type="text/css" href="@{asset_url_for('main.css') }">
+  </head>
+
+  <body class="@{(request.cookies.get( "dayNight")=="dank") and 'dark dank' or ''} @{(request.cookies.get( "dayNight")=="dark") and 'dark' or ''}">
+    <div class="th-subbar pure-u-1">
+      <ul id="topbar">
+        <li><a href="/all">@{_('all')}</a></li>
+        <li><a href="/all/new">@{_('new')}</a></li>
+        <li>|</li>
+      </ul>
+    </div>
+
+    <div id="menu" class="th-navbar pure-g">
+      <div class="cw-brand pure-u-1 pure-u-md-3-24"> <!-- logo -->
+        <div class="pure-menu">
+          <a class="logocont" href="@{url_for('home.index')}">
+            <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1325.5153 622.69177"><path class="th-l-fill th-l-phox" fill="#fff" fill-rule="evenodd" stroke="#fff" d="M148.3 428.5l43 9-12.7-50.4-26.6 13zm167.2-43l27.8 13.7 6 27.3-43 9.6H304zM212 581l35.8-22.7 34.4 25.3-33.4 29.2zM13 22l185.8 149-86.3-14.7zm285.3 147l83.4-10.7 96-133z"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="20" d="M11 18.4L204 173l44.3 15 47.5-18 187-150.6L436 288l30.5 121L323 537.7l-41.3 45.6-33 29.5-34.7-29.5-39.4-43.6L30 409.3 59.5 287z"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="15" d="M9.6 17l103.6 139 42.8 82.8 22.6 144.7 13.7 52.6 10.6 54 11 88 34-19.3 33 20 11-86.3 11-55.3 13.5-51.7 23-149 43-81 99.6-136"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="20" d="M30.3 409.3l88 11.4 33.3 9.8 97 18.4L377 422l89.7-13"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="15" d="M174 537l28.5-48.5L248 451l45.2 38.3 28.6 49.2"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="13" d="M147.8 428.5l3.5-27.8 28.3-15.6 68-189L317 386l27.2 14 4.5 28.3"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="20" d="M436 288.5l-54.5-131-89 13.5m-233 116L114 155.8l90.3 17"></path><path class="th-l-stroke th-l-phox" fill="none" stroke="#fff" stroke-width="13" d="M59 288l68 60.2 52 37.4m137 1l51-37.4 69.2-58.6"></path><path class="th-l-fill th-l-text" fill="#fff" d="M522 223.2h69.6q27.8 0 43 13.5Q650 250.2 650 275q0 24.7-15.4 38.5-15.5 13.7-43 13.7h-49.2v72.3H522V223.2zm67.6 87q40.3 0 40.3-35.2 0-34.8-41-34.8h-47v70h47zm219.2-87H829v176.3h-20.2v-80.8H703.3v80.8H683V223.2h20.3v78h105.5v-78zm132.4 178.3q-34.5 0-52.2-18-17.8-18-17.8-53V223.2h20.3v109q0 25.8 12.5 38.8 12.7 13 37.2 13 24.5 0 37-13t12.5-38.8v-109h20.5v107.3q0 34.7-18 53-17.7 18-52 18zm250.2-2H1165l-91-83.8v83.8h-20.4V223.2h20.5v81l87-81h26l-92 85.8 97 90.5zm69 2q-41 0-66-22.3l8-15.7q13 11 26.6 15.7 13.8 4.8 31.8 4.8 21.2 0 32.7-8.3 11.5-8.2 11.5-23.2 0-8.8-5.5-14.3t-14.5-8.7q-9-3.3-24.2-6.8-20.5-4.7-33.8-10-13-5.2-21.2-15-8-9.7-8-25.5 0-15 7.7-26.5 8-11.7 22.5-18 14.8-6.5 34-6.5 18.3 0 34 5.8 16 5.7 27 16.5l-7.7 15.7q-12.5-10.7-25.5-15.5-12.8-5-27.8-5-20.5 0-32.2 8.8-11.5 8.5-11.5 24 0 13.2 10.2 20 10.3 6.7 31 11.5 22.8 5.5 35.8 10.2 13 4.5 21.5 13.8 8.7 9.2 8.7 24.7 0 15-8 26.3-7.7 11.2-22.5 17.5-14.7 6-34.5 6z" ></path></svg>
+          </a>
+          <span class="motto">@{func.get_motto()}</span>
+          <a href="/submit/text@{(request.view_args and request.view_args.get('sub')) and ('/' + request.view_args['sub']) or ''}"><span id="createPostIcon" class="p-icon" data-icon="edit"></span></a>
+          <a id="toggle" href="#" class="th-toggle">
+            <s class="bar"></s>
+            <s class="bar"></s>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    @def content():
+    @end
+    @{content()!!html}
+
+    <div class="footer">
+      @def footer():
+      &copy;@{config.site.copyright}
+      <br>
+      @for text,link in config.site.footer.links.items():
+      <a href="@{link}">@{text}</a> |
+      @end
+      <a href="/license">@{_('License')}</a>
+      <br>
+      @{_('Served by %(hostname)s', hostname=hostname)} \
+      @if config.app.debug:
+      | @{_('Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries')}
+      @end
+      @end
+      @{footer()!!html}
+    </div>
+    <script src="@{ asset_url_for('main.js') }"></script>
+  </body>
+</html>

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -29,7 +29,7 @@ from ..forms import EditSubLinkPostForm, SearchForm, EditMod2Form
 from ..forms import DeleteSubFlair, BanDomainForm, DeleteSubRule, CreateReportNote
 from ..forms import UseInviteCodeForm, SecurityQuestionForm
 from ..badges import badges
-from ..misc import cache, send_email, allowedNames, get_errors, engine
+from ..misc import cache, send_email, allowedNames, get_errors, engine, ensure_locale_loaded
 from ..misc import ratelimit, POSTING_LIMIT, AUTH_LIMIT, is_domain_banned
 from ..models import SubPost, SubPostComment, Sub, Message, User, UserIgnores, SubMetadata, UserSaved
 from ..models import SubMod, SubBan, SubPostCommentHistory, InviteCode, Notification, SubPostContentHistory, SubPostTitleHistory
@@ -46,6 +46,7 @@ do = Blueprint('do', __name__)
 
 @do.errorhandler(429)
 def ratelimit_handler(e):
+    ensure_locale_loaded()
     return jsonify(status='error',
                    error=[_('Whoa, calm down and wait a bit, then try again.')]), 200
 
@@ -180,6 +181,7 @@ def edit_user():
 
         usr = User.get(User.uid == current_user.uid)
         usr.language = form.language.data
+        session['language'] = form.language.data
         usr.save()
         current_user.update_prefs('labrat', form.experimental.data)
         current_user.update_prefs('nostyles', form.disable_sub_style.data)

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -15,7 +15,7 @@ def unauthorized(error):
 @bp.app_errorhandler(403)
 def forbidden_error(error):
     """ 403 Forbidden """
-    return engine.get_template('errors/403.html').render({'loginform': LoginForm()}), 403
+    return engine.get_template('errors/403.html').render(), 403
 
 
 @bp.app_errorhandler(404)

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -1,7 +1,8 @@
 """ Pages to be migrated to a wiki-like system """
 from flask import Blueprint, request, redirect, url_for, jsonify, current_app
-from ..misc import engine, logger
+from ..misc import engine, logger, ensure_locale_loaded, get_locale
 from ..forms import LoginForm
+from ..caching import cache
 
 bp = Blueprint('errors', __name__)
 
@@ -15,7 +16,7 @@ def unauthorized(error):
 @bp.app_errorhandler(403)
 def forbidden_error(error):
     """ 403 Forbidden """
-    return engine.get_template('errors/403.html').render(), 403
+    return render_error_template('errors/403.html'), 403
 
 
 @bp.app_errorhandler(404)
@@ -25,19 +26,19 @@ def not_found(error):
         if request.path.startswith('/api/v3'):
             return jsonify(msg="Method not found or not implemented"), 404
         return jsonify(status='error', error='Method not found or not implemented'), 404
-    return engine.get_template('errors/404.html').render({}), 404
+    return render_error_template('errors/404.html'), 404
 
 
 @bp.app_errorhandler(417)
 def forbidden_error(error):
     """ 418 I'm a teapot """
-    return engine.get_template('errors/417.html').render({}), 418
+    return render_error_template('errors/417.html'), 418
 
 
 @bp.app_errorhandler(429)
 def too_many_requests_error(error):
     """ 429 Too many requests """
-    return engine.get_template('errors/429.html').render({}), 429
+    return render_error_template('errors/429.html'), 429
 
 
 @bp.app_errorhandler(500)
@@ -52,4 +53,16 @@ def server_error(error):
             return jsonify(msg="Internal error"), 500
         return jsonify(status='error', error='Internal error'), 500
 
-    return engine.get_template('errors/500.html').render({}), 500
+    return render_error_template('errors/500.html'), 500
+
+
+def render_error_template(template):
+    ensure_locale_loaded()
+    lang = get_locale()
+    daynight_cookie = request.cookies.get("dayNight")
+    return _render_error_template(template, lang, daynight_cookie)
+
+
+@cache.memoize(300)
+def _render_error_template(template, lang, daynight_cookie):
+    return engine.get_template(template).render({})


### PR DESCRIPTION
If a server is under heavy load or under attack, requiring it to access the database in order to give error responses is only going to make the problem worse.  Simplify the error templates so database access is not required, cache the user's locale in the session to make it available without database access, and then cache the results of rendering the error templates in Redis.

This fixes #115 by removing the Log in button from the 404 page.  It also removes the login form from the 403, but a better solution than having a login form on the 403 is protecting the route that leads to the 403 with `login_required`, which most of the routes which use `abort(403)` do already.