### PR TITLE
Cleanup Layout

### DIFF
--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -131,9 +131,12 @@
       </div>
     </div>
   </div>
+  
   @def content():
   <div class="pure-g">
-    <div class="pure-u-1 pure-u-md-18-24"> <!-- main -->
+    @def sidebar():
+    @end
+    <div class="pure-u-1 @{ sidebar() and 'pure-u-md-18-24' or '' }"> <!-- main -->
       @for err in get_flashed_messages(category_filter=["error"]):
         <div class="error" style="margin-top: 2em;">@{ err }</div>
       @end
@@ -144,11 +147,11 @@
       @end
       @{main()!!html}
     </div>
-    <div class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->
-      @def sidebar():
-      @end
-      @{sidebar()!!html}
-    </div>
+    @if sidebar(): 
+      <div class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->  
+        @{sidebar()!!html}
+      </div>
+    @end
   </div>
   @end
   @{content()!!html}

--- a/app/html/user/register.html
+++ b/app/html/user/register.html
@@ -15,16 +15,17 @@
             @{ regform.csrf_token()!!html }
             <h1>@{_('Register')}</h1>
             <fieldset>
-                <div class="pure-control-group">
-                    <label for="username">@{regform.username.label.text}</label>
-                    @{regform.username(required=True, pattern="[a-zA-Z0-9_-]+", title=_('Alphanumeric characters plus \'-\' and \'_\''))!!html}
-                </div>
                 @if func.enableInviteCode():
                 <div class="pure-control-group">
                     <label for="invitecode">@{regform.invitecode.label.text}</label>
                     @{regform.invitecode(autocomplete="off", required=True)!!html}
                 </div>
                 @end
+                <div class="pure-control-group">
+                    <label for="username">@{regform.username.label.text}</label>
+                    @{regform.username(required=True, pattern="[a-zA-Z0-9_-]+", title=_('Alphanumeric characters plus \'-\' and \'_\''))!!html}
+                </div>
+                
                 <div class="pure-control-group">
                     <label for="password">@{regform.password.label.text}</label>
                     @{regform.password(autocomplete="off", required=True)!!html}


### PR DESCRIPTION
For pages with no sidebar, allow page content to be centered and remove vestigial sidebar "line" and spacing.

Additionally reorder registration for better information architecture.