### PR TITLE
Submit comment improvements

### DIFF
--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -655,11 +655,13 @@ u.addEventForChild(document, 'click', '.btn-postcomment', function (e, qelem) {
     if(pcid[0] == '-') pcid = 0;
     u.post('/do/sendcomment/' + pid, {parent: pcid, post: pid, comment: content},
         function (data) {
+            const errorNode = qelem.parentNode.querySelector('.error');
             if (data.status != "ok") {
-                qelem.parentNode.querySelector('.error').style.display = 'block';
-                qelem.parentNode.querySelector('.error').innerHTML = data.error;
+                errorNode.style.display = 'block';
+                errorNode.innerHTML = data.error;
                 qelem.removeAttribute('disabled');
             } else {
+                errorNode.style.display = 'none';
                 const cmtcount = document.getElementById('cmnts');
                 window.sending = false;
                 if(!cmtcount) {

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -643,7 +643,13 @@ u.addEventForChild(document, 'click', '.btn-postcomment', function (e, qelem) {
     const pid = qelem.getAttribute('data-pid');
     const content = document.querySelector('#rcomm-' + cid + ' textarea').value;
     qelem.setAttribute('disabled', true);
-    qelem.parentNode.removeChild(qelem.parentNode.querySelector('.cmpreview'));
+
+    const previewChild = qelem.parentNode.querySelector('.cmpreview');
+    previewChild.insertAdjacentHTML('afterend', '<div class="cmpreview canclose" style="display:none;"><h4>' +
+                                    _('Comment preview') + '</h4><span class="closemsg">&times;</span>' +
+                                    '<div class="cpreview-content"></div></div>');
+    qelem.parentNode.removeChild(previewChild);
+
     window.sending = true;
     let pcid = cid;
     if(pcid[0] == '-') pcid = 0;


### PR DESCRIPTION
After submitting a first top-level comment, the Submit Comment and Preview buttons would stop working.  Fix this by inserting a new blank comment preview element before deleting the old one.

Once that was fixed, trying to submit a blank comment produced an error message, which would persist even after successfully submitting a non-blank comment.  Fix that by hiding the error element on a successful submission.