### PR TITLE
Refactor EXIF stripping for images

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -8,9 +8,7 @@ import gevent
 import libcloud.storage.types
 import magic
 from mutagen.mp4 import MP4
-import gi
-gi.require_version('GExiv2', '0.10')  # noqa
-from gi.repository import GExiv2
+from PIL import Image
 from contextlib import ExitStack
 import hashlib
 import jinja2
@@ -131,10 +129,8 @@ def thumbnail_url(name):
 
 def clear_metadata(path: str, mime_type: str):
     if mime_type in ('image/jpeg', 'image/png'):
-        exif = GExiv2.Metadata()
-        exif.open_path(path)
-        exif.clear()
-        exif.save_file(path)
+        image = Image.open(path)
+        image.save(path)
     elif mime_type == 'video/mp4':
         video = MP4(path)
         video.clear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ pyyaml
 email_validator
 feedgen
 pyOpenSSL
-pygobject
 mutagen
 flask-mail
 flask-limiter


### PR DESCRIPTION
**Context for change:** I got really annoyed with the trouble involved in installing one of the `pygobject` subdependencies, so I spitefully refactored the code it was used in to do away with `pygobject` and use `pillow`, which was already in the requirements list. That happened to be the function that strips EXIF data from images.

**Test steps**

1. Upload test image containing verified EXIF data to dev server
1. Check EXIF data in image saved in `/stor`
1. Verify that image served by dev site is browsable and also contains no EXIF data when downloaded
