### PR TITLE
Allow admins to ban users who haven't confirmed their emails yet

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -247,7 +247,7 @@ class AuthProvider:
         try:
             umd = UserMetadata.get((UserMetadata.uid == user.uid) &
                                    (UserMetadata.key == "email_verified"))
-            return bool(umd.value)
+            return umd.value == '1'
         except UserMetadata.DoesNotExist:
             return False
 
@@ -324,6 +324,10 @@ class AuthProvider:
             payload = {'enabled': True}
         else:
             raise RuntimeError("Invalid user status")
+
+        if (new_status == 0 and email_validation_is_required() and
+                not self.is_email_verified(user)):
+            new_status = 1
 
         if user.crypto == UserCrypto.REMOTE:
             if (self.get_user_auth_source(user) == UserAuthSource.KEYCLOAK and

--- a/app/html/shared/sidebar/user.html
+++ b/app/html/shared/sidebar/user.html
@@ -1,6 +1,6 @@
 @require(user)
 
-@if current_user.is_admin() and user.status == 0 and user.name != current_user.name:
+@if current_user.is_admin() and (user.status == 0 or user.status == 1) and user.name != current_user.name:
     <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=user.name)}">
         @{form.DummyForm().csrf_token()!!html}
       <a id="banuser-button" class="sbm-post pure-button pure-button-primary">@{_('Ban user')}</a>

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -184,7 +184,8 @@ def login_with_token(token):
     if current_user.is_authenticated:
         return redirect(url_for('home.index'))
     user = user_from_login_token(token)
-    if user is None:
+    if (user is None or user.status == UserStatus.BANNED
+            or user.status == UserStatus.DELETED):
         flash(_('The link you used is invalid or has expired.'), 'error')
         return redirect(url_for('auth.resend_confirmation_email'))
     elif user.status == UserStatus.PROBATION:


### PR DESCRIPTION
If an invite code gets into the wrong hands and turns into a swarm of trolls on the site, the admin can ban them from the invite code page, except for the ones who haven't confirmed their emails yet.  

Change the user page to show the ban button to admins for users with unconfirmed emails, change  `unban_user` to set the user's status correctly for users with unconfirmed emails, change `login_with_token` to refuse to work for banned users, and fix `is_email_verified` to not always return `True`.