### PR TITLE
Invite code interface improvements

### DIFF
--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -13,7 +13,8 @@ from .sub import CreateSubFlair, DeleteSubFlair, VoteForm, DeleteCommentForm, Cr
 from .sub import UndeleteCommentForm, CreateReportNote
 from .admin import EditModForm
 from .admin import BanDomainForm, UseInviteCodeForm, AssignUserBadgeForm
-from .admin import SecurityQuestionForm, TOTPForm, WikiForm, CreateInviteCodeForm
+from .admin import SecurityQuestionForm, TOTPForm, WikiForm
+from .admin import CreateInviteCodeForm, UpdateInviteCodeForm
 
 
 class DummyForm(FlaskForm):

--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -2,7 +2,7 @@
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField, TextAreaField
-from wtforms import IntegerField
+from wtforms import IntegerField, RadioField, FieldList
 from wtforms.validators import DataRequired, Length, Regexp
 from flask_babel import lazy_gettext as _l
 
@@ -39,6 +39,16 @@ class UseInviteCodeForm(FlaskForm):
     enableinvitecode = BooleanField(_l('Enable invite code to register'))
     minlevel = IntegerField(_l("Minimum level to create invite codes"))
     maxcodes = IntegerField(_l("Max amount of invites per user"))
+
+
+class UpdateInviteCodeForm(FlaskForm):
+    """ Update the expiration dates of selected invitecodes. """
+    codes = FieldList(BooleanField(default=False))
+    etype = RadioField(_l('Change selected codes to expire:'),
+                       choices=[('never', _l('Never')), ('now', _l('Now')), ('at', _l('At:'))],
+                       default='now',
+                       validators=[DataRequired()])
+    expires = StringField(_l("Expiration date"))
 
 
 class TOTPForm(FlaskForm):

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2280,3 +2280,9 @@ article.text-post.comment.deleted {
     min-width: 100%;
     border: 1px solid #ccc;
 }
+
+.invitecode-users {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -482,6 +482,20 @@ u.ready(function(){
   });
 })
 
+u.ready(function(){
+  u.each('*[data-timefmt]', function(el,i) {
+    var fmt = el.getAttribute('data-timefmt');
+    if (el.innerHTML == 'None') {
+      el.innerHTML = _("Never");
+    } else {
+      var d = new Date(el.innerHTML);
+      if (fmt == 'datetime') {
+        el.innerHTML = d.toLocaleString();
+      }
+    }
+  })
+});
+
 new Konami(function() {
   var d = new Date();
   d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000)); //365 days

--- a/app/templates/admin/invitecodes.html
+++ b/app/templates/admin/invitecodes.html
@@ -51,21 +51,26 @@
     <hr>
     <div class="admin section invitecodes_table">
       <h2>Invite Codes</h2>
-      <table class="sortable pure-table invitecodes">
-        <thead>
-          <tr>
-            <th>Code</th>
-            <th>Created By</th>
-            <th>Created On</th>
-            <th>Expires</th>
-            <th>Uses</th>
-            <th>Max Uses</th>
-            <th>Used By</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for code in invite_codes %}
+      <form method="POST" class="pure-form">
+        <table class="sortable pure-table invitecodes">
+          <thead>
             <tr>
+              <th></th>
+              <th>Code</th>
+              <th>Created By</th>
+              <th>Created On</th>
+              <th>Expires</th>
+              <th>Uses</th>
+              <th>Max Uses</th>
+              <th>Used By</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for code in invite_codes %}
+            <tr>
+              <td>
+                <input id="codes-{{loop.index0}}" name="codes-{{loop.index0}}" type="checkbox">
+              </td>
               <td class="{{code.style}}">
                 {{code.code}}
               </td>
@@ -82,9 +87,22 @@
                 </ul>
               </td>
             </tr>
-          {% endfor %}
+            {% endfor %}
         </tbody>
       </table>
+        {{ update_form.csrf_token() }}
+        <p>{{ update_form.etype.label }}</p>
+        <tr>
+          {% for subfield in update_form.etype %}
+            <td>{{ subfield }}</td>
+            <td>{{ subfield.label }}</td>
+          {% endfor %}
+          <td><input name="expires" type="text" class="date-picker-future" placeholder="Expiration"> </td>
+          </tr>
+        <p>
+          <button type="submit" class="pure-button pure-button-primary">Change Expiration</button>
+        </p>
+      </form>
       {% if page > 1 %}
         <a href="{{url_for('admin.invitecodes', page=(page-1))}}" class="pure-button">Previous Page</a>
       {% endif %}

--- a/app/templates/admin/invitecodes.html
+++ b/app/templates/admin/invitecodes.html
@@ -80,9 +80,23 @@
               <td>{{code.uses}}</td>
               <td>{{code.max_uses}}</td>
               <td>
-                <ul>
-                {% for user in code.used_by %}
-                  <li><a href="{{url_for('user.view', user=user)}}">{{user}}</a></li>
+                <ul class="invitecode-users">
+                  {% for user in code.used_by %}
+                  <li>
+                    {% if user[1] == 10 %}
+                      {{user[0]}}&nbsp;({{_('Deleted')}})
+                    {% else %}
+                    <a href="{{url_for('user.view', user=user[0])}}">
+                      {% if user[1] == 1 %}
+                        {{user[0]}} ({{_('Pending')}})
+                      {% elif user[1] == 5 %}
+                        {{user[0]}} ({{_('Banned')}})
+                      {% else %}
+                        {{user[0]}}
+                      {% endif %}
+                    </a>
+                    {% endif %}
+                  </li>
                 {% endfor %}
                 </ul>
               </td>

--- a/app/templates/admin/invitecodes.html
+++ b/app/templates/admin/invitecodes.html
@@ -70,8 +70,8 @@
                 {{code.code}}
               </td>
               <td><a href="{{url_for('user.view', user=code.created_by)}}">{{code.created_by}}</a></td>
-              <td>{{code.created}}</td>
-              <td>{{code.expires}}</td>
+              <td data-timefmt="datetime">{{code.created}}</td>
+              <td data-timefmt="datetime">{{code.expires}}</td>
               <td>{{code.uses}}</td>
               <td>{{code.max_uses}}</td>
               <td>

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -184,6 +184,9 @@ def invitecodes(page, error=None):
     for code in invite_codes:
         code['style'] = map_style(code)
         code['used_by'] = used_by.get(code['code'], [])
+        code['created'] = code['created'].strftime("%Y-%m-%dT%H:%M:%SZ")
+        if code['expires'] is not None:
+            code['expires'] = code['expires'].strftime("%Y-%m-%dT%H:%M:%SZ")
 
     invite_form = UseInviteCodeForm()
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -172,7 +172,8 @@ def invitecodes(page, error=None):
         InviteCode.max_uses,
     ).join(User).order_by(InviteCode.uses.desc(), InviteCode.created.desc()).paginate(page, 50).dicts()
 
-    code_users = UserMetadata.select(User.name.alias('used_by'), UserMetadata.value.alias("code")).where(
+    code_users = UserMetadata.select(User.name.alias('used_by'), User.status,
+                                     UserMetadata.value.alias("code")).where(
             (UserMetadata.key == 'invitecode') & 
                 (UserMetadata.value << set([x['code'] for x in invite_codes]))).join(User).dicts()
 
@@ -180,7 +181,7 @@ def invitecodes(page, error=None):
     for user in code_users:
         if not user['code'] in used_by:
             used_by[user['code']] = []
-        used_by[user['code']].append(user['used_by'])
+        used_by[user['code']].append((user['used_by'], user['status']))
 
     update_form = UpdateInviteCodeForm()
 


### PR DESCRIPTION
Add checkboxes to the invite code table for each code, and a form at the bottom to let the admin change the expiration date of the checked code.  This can be used by an admin to disable a code which is letting in trolls, or to extend one which didn't get communicated to its intended recipients before it expired.

While I was at it, I made the code creation and expiration times appear in the user's time zone, and added an indication of user status to the list of users for each code.
