### PR TITLE
Restrict pm ability

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,8 @@ cfg_defaults = {  # key => default value
             "edit_history": False,
             "anonymous_modding": False,
 
+            "send_pm_to_user_min_level": 3,
+
             "daily_sub_posting_limit": 10,
             "daily_site_posting_limit": 25,
 

--- a/app/html/user/profile.html
+++ b/app/html/user/profile.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(user, level, progress, postCount, commentCount, givenScore, invitecodeinfo, badges, owns, mods, habits, msgform)
+@require(user, level, progress, postCount, commentCount, givenScore, invitecodeinfo, badges, owns, mods, habits, msgform, target_user_is_admin)
 
 @def title():
 /u/@{user.name} |\
@@ -9,11 +9,13 @@
 
     @if user.status != 10:
         @include('shared/sidebar/user.html')
-        @if current_user.is_authenticated and current_user.uid != user.uid:
-            <hr>
-            <div class="pmessage">
-                <a href="#msg-form" data-replyto='@{user.name}' data-replytitle='' class="formpopmsg sbm-post pure-button">@{_('Send a message')}</a>
-            </div>
+        @if current_user.is_authenticated and current_user.uid != user.uid: 
+            @if target_user_is_admin or current_user.can_pm_users() or current_user.is_admin():
+                <hr>
+                <div class="pmessage">
+                    <a href="#msg-form" data-replyto='@{user.name}' data-replytitle='' class="formpopmsg sbm-post pure-button">@{_('Send a message')}</a>
+                </div>
+            @end
         @end
     @end
 @end

--- a/app/misc.py
+++ b/app/misc.py
@@ -154,6 +154,9 @@ class SiteUser(object):
         elif config.site.allow_uploads and (config.site.upload_min_level <= get_user_level(self.uid, self.score)[0]):
             self.canupload = True
 
+    def can_pm_users(self):
+        return config.site.send_pm_to_user_min_level <= get_user_level(self.uid, self.score)[0] or self.admin
+
     def __repr__(self):
         return "<SiteUser {0}>".format(self.uid)
 
@@ -249,6 +252,7 @@ class SiteUser(object):
         except UserMetadata.DoesNotExist:
             UserMetadata.create(uid=self.uid, key=key, value=value)
 
+
     @cache.memoize(30)
     def get_global_stylesheet(self):
         if self.subtheme:
@@ -259,6 +263,13 @@ class SiteUser(object):
             return css.content
         return ''
 
+
+def is_target_user_admin(uid):
+    try:
+        check_admin = UserMetadata.get((UserMetadata.uid == uid) & (UserMetadata.key == 'admin') & (UserMetadata.value == '1'))
+        return True
+    except UserMetadata.DoesNotExist:
+        return False
 
 class SiteAnon(AnonymousUserMixin):
     """ A subclass of AnonymousUserMixin. Used for logged out users. """
@@ -284,6 +295,11 @@ class SiteAnon(AnonymousUserMixin):
     @classmethod
     def is_admin(cls):
         """ Anons are not admins. """
+        return False
+
+    @classmethod
+    def can_pm_users(cls):
+        """ Anons may never PM users. """
         return False
 
     @classmethod

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -8,7 +8,7 @@ from .do import send_password_recovery_email, uid_from_recovery_token
 from .do import info_from_email_confirmation_token
 from .. import misc, config
 from ..auth import auth_provider, email_validation_is_required, AuthError, normalize_email
-from ..misc import engine, send_email
+from ..misc import engine, send_email, is_target_user_admin
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import EditUserForm, CreateUserMessageForm, EditAccountForm, DeleteAccountForm, PasswordRecoveryForm
 from ..forms import PasswordResetForm
@@ -37,7 +37,7 @@ def view(user):
     badges = misc.getUserBadges(user.uid)
     pcount = SubPost.select().where(SubPost.uid == user.uid).count()
     ccount = SubPostComment.select().where(SubPostComment.uid == user.uid).count()
-
+    user_is_admin = misc.is_target_user_admin(user.uid)
     habit = Sub.select(Sub.name, fn.Count(SubPost.pid).alias('count')).join(SubPost, JOIN.LEFT_OUTER,
                                                                             on=(SubPost.sid == Sub.sid))
     habit = habit.where(SubPost.uid == user.uid).group_by(Sub.sid).order_by(fn.Count(SubPost.pid).desc()).limit(10)
@@ -57,7 +57,7 @@ def view(user):
 
     return engine.get_template('user/profile.html').render(
         {'user': user, 'level': level, 'progress': progress, 'postCount': pcount, 'commentCount': ccount,
-         'givenScore': givenScore, 'invitecodeinfo': invitecodeinfo, 'badges': badges, 'owns': owns, 'mods': mods, 'habits': habit,
+         'givenScore': givenScore, 'invitecodeinfo': invitecodeinfo, 'badges': badges, 'owns': owns, 'mods': mods, 'habits': habit, 'target_user_is_admin': user_is_admin,
          'msgform': CreateUserMessageForm()})
 
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -64,6 +64,15 @@ site:
   # Set to zero to disable sub creation level limits
   sub_creation_min_level: 2
 
+  # Minimum level required for a user to be permitted to private message nonprivileged users.
+  # Set to zero to allow users of all levels to PM other users.
+  # Users of any level may PM site admins.
+  send_pm_to_user_min_level: 3
+
+  # Minimum level a user must have before being able to create a sub.
+  # Set to zero to disable sub creation level limits
+  sub_creation_min_level: 2
+
   # Allows Sub Mods and Admins to view the edit history of posts
   edit_history: False
 


### PR DESCRIPTION
Tests

1. - [x] Log in as nonprivileged user under level 3
    1. - [x] Visit nonprivileged user profile and confirm there is **no** option to PM them
    1. - [x] Visit an administrator user profile and confirm there **is** an option to PM them
1. - [x] As nonprivileged user **above** level 3, confirm:
    1. - [x] I can PM other users
    1. - [x] I can PM administrators
1. - [x] As admin user, visit nonprivileged user profile and admin profiles, confirm:
    1. - [x] I can PM a nonprivileged user
    1. - [x] I can PM other admins

Admin users should be able to receive PMs from and send PMs to any user.