### PR TITLE
Move viewing user uploads onto the user page sidebar

### DIFF
--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -54,9 +54,6 @@
     <ul id="topbar">
       <li><a href="/all">@{_('all')}</a></li>
       <li><a href="/all/new">@{_('new')}</a></li>
-      @if current_user.canupload:
-        <li><a href="@{url_for('home.view_user_uploads')}">@{_('uploads')}</a></li>
-      @end
       @if current_user.can_admin:
         <li><a href="@{url_for('admin.index')}">@{_('admin')}</a></li>
       @end

--- a/app/html/shared/sidebar/user.html
+++ b/app/html/shared/sidebar/user.html
@@ -34,5 +34,8 @@
 <a href="@{url_for('user.view_user_posts', user=user.name)}" class="sbm-post pure-button @{(request.endpoint == 'user.view_user_posts') and 'pure-button-primary' or ''}">@{_('View posts')}</a>
 <a href="@{url_for('user.view_user_comments', user=user.name)}" class="sbm-post pure-button @{(request.endpoint == 'user.view_user_comments') and 'pure-button-primary' or ''}" >@{_('View comments')}</a>
 @if user.uid == current_user.uid:
-    <a href="@{url_for('user.view_user_savedposts', user=user.name)}" class="sbm-post pure-button @{(request.endpoint == 'user.view_user_savedposts') and 'pure-button-primary' or ''}">@{_('View saved posts')}</a>
+  @if current_user.canupload:
+    <a href="@{url_for('user.view_user_uploads')}" class="sbm-post pure-button @{(request.endpoint == 'user.view_user_uploads') and 'pure-button-primary' or ''}">@{_('View uploads')}</a>
+  @end
+  <a href="@{url_for('user.view_user_savedposts', user=user.name)}" class="sbm-post pure-button @{(request.endpoint == 'user.view_user_savedposts') and 'pure-button-primary' or ''}">@{_('View saved posts')}</a>
 @end

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -44,9 +44,6 @@
     <ul id="topbar">
       <li><a href="/all">all</a></li>
       <li><a href="/all/new">new</a></li>
-      {% if current_user.canupload %}
-        <li><a href="{{url_for('home.view_user_uploads')}}">uploads</a></li>
-      {% endif %}
       {% if current_user.can_admin %}
         <li><a href="{{url_for('admin.index')}}">admin</a></li>
       {% endif %}

--- a/app/templates/uploads.html
+++ b/app/templates/uploads.html
@@ -1,6 +1,14 @@
 {% extends "layout.html" %}
 {% block title %}Uploads | {{config.site.lema}}{% endblock %}
 
+{% block sidebar %}
+{{ super() }}
+<a href="{{url_for('user.view', user=current_user.name)}}" class="sbm-post pure-button">{{current_user.name}}</a>
+<a href="{{url_for('user.view_user_posts', user=current_user.name)}}" class="sbm-post pure-button">View posts</a>
+<a href="{{url_for('user.view_user_comments', user=current_user.name)}}" class="sbm-post pure-button">View comments</a>
+<a href="{{url_for('user.view_user_uploads')}}" class="sbm-post pure-button">View uploads</a>
+<a href="{{url_for('user.view_user_savedposts', user=current_user.name)}}" class="sbm-post pure-button">View saved posts</a>
+{% endblock %}
 
 {% block content %}
 {{ super() }}
@@ -30,10 +38,10 @@
 </div>
 <div class="col-12">
   {% if page > 1 %}
-  <a href="{{url_for('home.view_user_uploads', page=(page-1))}}" class="pure-button">prev</a>
+  <a href="{{url_for('user.view_user_uploads', page=(page-1))}}" class="pure-button">prev</a>
   {% endif %}
   {% if subs|length == 30 %}
-  <a href="{{url_for('home.view_user_uploads', page=(page+1))}}" class="pure-button">next</a>
+  <a href="{{url_for('user.view_user_uploads', page=(page+1))}}" class="pure-button">next</a>
   {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -7,7 +7,10 @@
 <a href="{{url_for('user.view', user=user.name)}}" class="sbm-post pure-button">{{user.name}}</a>
 <a href="{{url_for('user.view_user_posts', user=user.name)}}" class="sbm-post pure-button">View posts</a>
 <a href="{{url_for('user.view_user_comments', user=user.name)}}" class="sbm-post pure-button">View comments</a>
-{% if user.uid == session['user_id'] %}
+{% if user.uid == current_user.uid %}
+  {% if current_user.canupload %}
+    <a href="{{url_for('user.view_user_uploads')}}" class="sbm-post pure-button">View uploads</a>
+  {% endif %}
   <a href="{{url_for('user.view_user_savedposts', user=user.name)}}" class="sbm-post pure-button">View saved posts</a>
 {% endif %}
 {% endblock %}

--- a/app/templates/userposts.html
+++ b/app/templates/userposts.html
@@ -7,6 +7,9 @@
 <a href="{{url_for('user.view_user_posts', user=user.name)}}" class="sbm-post pure-button">View posts</a>
 <a href="{{url_for('user.view_user_comments', user=user.name)}}" class="sbm-post pure-button">View comments</a>
 {% if user.uid == current_user.uid %}
+  {% if current_user.canupload %}
+    <a href="{{url_for('user.view_user_uploads')}}" class="sbm-post pure-button">View uploads</a>
+  {% endif %}
   <a href="{{url_for('user.view_user_savedposts', user=user.name)}}" class="sbm-post pure-button">View saved posts</a>
 {% endif %}
 {% endblock %}

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -6,7 +6,7 @@ from flask_login import login_required, current_user
 from .. import misc
 from ..misc import engine
 from ..misc import ratelimit, POSTING_LIMIT
-from ..models import SubPost, UserUploads, Sub
+from ..models import SubPost, Sub
 
 bp = Blueprint('home', __name__)
 
@@ -160,15 +160,6 @@ def all_hot(page):
 
 
 # Note for future self: I rewrote until this part. You should do the rest.
-
-@bp.route("/uploads", defaults={'page': 1})
-@bp.route("/uploads/<int:page>")
-@login_required
-def view_user_uploads(page):
-    """ View user uploads """
-    uploads = UserUploads.select().where(UserUploads.uid == current_user.uid).paginate(page, 30)
-    return render_template('uploads.html', page=page, uploads=uploads)
-
 
 @bp.route("/subs", defaults={'page': 1, 'sort': 'name_asc'})
 @bp.route("/subs/<sort>", defaults={'page': 1})

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -12,7 +12,7 @@ from ..misc import engine, send_email
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import EditUserForm, CreateUserMessageForm, EditAccountForm, DeleteAccountForm, PasswordRecoveryForm
 from ..forms import PasswordResetForm
-from ..models import User, UserStatus, UserMetadata
+from ..models import User, UserStatus, UserMetadata, UserUploads
 from ..models import Sub, SubMod, SubPost, SubPostComment, UserSaved, InviteCode
 
 bp = Blueprint('user', __name__)
@@ -113,6 +113,13 @@ def view_user_comments(user, page):
     comments = misc.getUserComments(user.uid, page)
     return render_template('usercomments.html', user=user, page=page, comments=comments)
 
+@bp.route("/uploads", defaults={'page': 1})
+@bp.route("/uploads/<int:page>")
+@login_required
+def view_user_uploads(page):
+    """ View user uploads """
+    uploads = UserUploads.select().where(UserUploads.uid == current_user.uid).paginate(page, 30)
+    return render_template('uploads.html', page=page, uploads=uploads)
 
 @bp.route("/settings/invite")
 @login_required


### PR DESCRIPTION
Fix #205 by moving the uploads link onto the sidebar visible when a user is looking at their profile, posts or comments.  I also noticed that the uploads page didn't have a sidebar, so I gave it one.