### PR TITLE
Fix invite code check

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -703,7 +703,7 @@ class InviteCode(BaseModel):
         return InviteCode.select()\
             .where(InviteCode.code == invite_code)\
             .where(InviteCode.expires.is_null() | (InviteCode.expires > datetime.datetime.utcnow()))\
-            .where(InviteCode.max_uses < InviteCode.uses)
+            .where(InviteCode.max_uses > InviteCode.uses).get()
 
     def __repr__(self):
         return f'<InviteCode {self.code}>'

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -1,24 +1,13 @@
 import json
 import pytest
 
-from peewee import fn
 from flask import url_for
 from app import mail
 
 from pytest_flask.fixtures import client
 from test.fixtures import*
-from test.utilities import csrf_token, pp
+from test.utilities import csrf_token, pp, promote_user_to_admin
 from test.utilities import register_user, log_in_user, log_out_current_user
-
-def promote_user_to_admin(client, user_info):
-    """Assuming user_info is the info for the logged-in user, promote them
-    to admin and leave them logged in.
-    """
-    log_out_current_user(client)
-    admin = User.get(fn.Lower(User.name) == user_info['username'])
-    UserMetadata.create(uid=admin.uid, key='admin', value='1')
-    log_in_user(client, user_info)
-
 
 def test_admin_can_ban_and_unban_user(client, user_info, user2_info):
     register_user(client, user_info)


### PR DESCRIPTION
Fix the check for a valid invite code, which has been broken since 6e582f0.  Add a regression test.

During the past week we had some users register with made up invite codes or invite codes with typos, and those users would get a 500 error on their user page because `getInviteCodeInfo` couldn't find the invite code.  This problem can be solved from the admin interface by adding a new invite code to match the one that the user used to register.