### PR TITLE
Only show the sidebar on mobile when the menu is open

### DIFF
--- a/app/html/index.html
+++ b/app/html/index.html
@@ -18,17 +18,19 @@
 @include('shared/sidebar/home.html')
 @if current_user.likes_scroll() and sort_type != 'home.search':
   <hr />
-  &copy;@{config.site.copyright}
-  <br>
-  @for text,link in config.site.footer.links.items():
-    <a href="@{link}">@{text}</a> |
-  @end
-  <a href="/license">@{_('License')}</a>
-  <br>
-  @{_('Served by %(host)s', host=hostname)} \
-  @if config.app.debug:
-   | @{_('Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries')}
-  @end
+  <div class="footer">
+    &copy;@{config.site.copyright}
+    <br>
+    @for text,link in config.site.footer.links.items():
+      <a href="@{link}">@{text}</a> |
+    @end
+    <a href="/license">@{_('License')}</a>
+    <br>
+    @{_('Served by %(host)s', host=hostname)} \
+    @if config.app.debug:
+      | @{_('Page generated in __EXECUTION_TIME__ms with __DB_QUERIES__ queries')}
+    @end
+  </div>
 @end
 @end
 

--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -130,7 +130,7 @@
   </div>
   
   @def content():
-  <div class="pure-g">
+  <div class="th-body pure-g">
     @def sidebar():
     @end
     <div class="pure-u-1 @{ sidebar() and 'pure-u-md-18-24' or '' }"> <!-- main -->
@@ -145,7 +145,7 @@
       @{main()!!html}
     </div>
     @if sidebar(): 
-      <div class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->  
+      <div id="sidebar" class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->
         @{sidebar()!!html}
       </div>
     @end

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -82,6 +82,13 @@ body.dark .th-navbar {
   box-shadow: 0 3px 5px 0 rgba(0,0,0,0.75);
 }
 
+body.dark .th-navbar.open {
+  background-color: #000;
+    -webkit-box-shadow: 0 2px 3px 0 #aa4509;
+    -moz-box-shadow: 0 2px 3px 0 #aa4509;
+    box-shadow: 0 2px 3px 0 #aa4509;
+}
+
 /* Sub bar */
 
 body.dark .th-subbar{

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -76,7 +76,10 @@ blockquote{
 }
 
 .th-navbar.open {
-    height: 8em;
+    height: 6.5em;
+    -webkit-box-shadow: 0 2px 3px 0 #ab4409;
+    -moz-box-shadow: 0 2px 3px 0 #ab4409;
+    box-shadow: 0 2px 3px 0 #ab4409;
 }
 
 #th-uinfo {
@@ -137,6 +140,20 @@ blockquote{
   }
   .th-toggle {
       display: block;
+  }
+  div.sidebar {
+      position: absolute;
+      background-color: white;
+      display: none;
+      -webkit-box-shadow: 0 3px 5px 0 #ab4409;
+      -moz-box-shadow: 0 3px 5px 0 #ab4409;
+      box-shadow: 0 3px 5px 0 #ab4409;
+  }
+  div.sidebar.open {
+      display: block;
+  }
+  .th-body {
+      position: relative;
   }
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -348,6 +348,7 @@ if(document.querySelector('button.removebanneddomain')){
 /* purecss*/
 var menu = document.getElementById('menu'),
     WINDOW_CHANGE_EVENT = ('onorientationchange' in window) ? 'orientationchange':'resize';
+var sidebar = document.getElementById('sidebar');
 
 function toggleHorizontal() {
     [].forEach.call(
@@ -368,6 +369,7 @@ function toggleMenu() {
         toggleHorizontal();
     }
     menu.classList.toggle('open');
+    sidebar.classList.toggle('open')
     document.getElementById('toggle').classList.toggle('x');
 };
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -125,7 +125,7 @@
     </div>
   </div>
 
-  <div class="pure-g">
+  <div class="th-body pure-g">
     <div class="pure-u-1 pure-u-md-18-24"> <!-- main -->
       {% with errors = get_flashed_messages(category_filter=["error"]) %}
         {% if errors %}
@@ -145,7 +145,7 @@
         <div id="container">{% block content %}{% endblock %}</div>
       {% endblock %}
     </div>
-    <div class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->
+    <div id="sidebar" class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->
       {% block sidebar %}
 
       {%endblock%}


### PR DESCRIPTION
On mobile only, hide the sidebar unless the menu is toggled open, and then show the sidebar on top of the page content instead of below it.

On both mobile and desktop, make the copyright, site links and "served by" always appear in the sidebar, instead of just being there when the user has infinite scroll enabled.

I gave some color to the shadow at the bottom of the mobile sidebar to help differentiate it from the page content in dark mode, but I like how that looks in light mode too.