### PR TITLE
Fix the post title length checks to match the database field length

### DIFF
--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -107,7 +107,7 @@ class EditMod2Form(FlaskForm):
 class CreateSubPostForm(FlaskForm):
     """ Sub content submission form """
     sub = StringField(_l('Sub'), validators=[DataRequired(), Length(min=2, max=32)])
-    title = StringField(_l('Post title'), validators=[DataRequired(), Length(min=3, max=350)])
+    title = StringField(_l('Post title'), validators=[DataRequired(), Length(min=3, max=255)])
     content = TextAreaField(_l('Post content'), validators=[Length(max=16384)])
     link = StringField(_l('Post link'), validators=[Length(min=10, max=255), Optional(), URL(require_tld=True)])
     ptype = RadioField(_l('Post type'),

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -771,7 +771,7 @@ def create_post():
     if len(title.strip(misc.WHITESPACE)) < 3:
         return jsonify(msg='Post title is too short'), 400
 
-    if len(title) > 350:
+    if len(title) > 255:
         return jsonify(msg='Post title is too long'), 400
 
     if misc.get_user_level(uid)[0] < 7:


### PR DESCRIPTION
If you submit a post with a title between 256 and 349 characters in length, you'll get a 500 because the post title field is only 255 characters long.  Fix the length check in the form and in the api to match the length in the field's creation in `migrations/001_initial.py`.