### PR TITLE
Give moderators control of the types of posts in their subs

### DIFF
--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -114,7 +114,8 @@ class CreateSubPostForm(FlaskForm):
     content = TextAreaField(_l('Post content'), validators=[Length(max=16384)])
     link = StringField(_l('Post link'), validators=[Length(min=10, max=255), Optional(), URL(require_tld=True)])
     ptype = RadioField(_l('Post type'),
-                       choices=[('link', _l('Link post')), ('text', _l('Text post'))],
+                       choices=[('link', _l('Link post')), ('text', _l('Text post')),
+                                ('upload', _l('Upload file')), ('poll', _l('Poll'))],
                        validators=[DataRequired()])
     nsfw = BooleanField(_l('NSFW?'))
     # for polls.

--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -87,7 +87,10 @@ class EditSubForm(FlaskForm):
     nsfw = BooleanField(_l('Sub is NSFW'))
     restricted = BooleanField(_l('Only mods can post'))
     usercanflair = BooleanField(_l('Allow users to flair their own posts'))
-    polling = BooleanField(_l('Enable polls'))
+    allow_text_posts = BooleanField(_l('Enable text posts'))
+    allow_link_posts = BooleanField(_l('Enable link posts'))
+    allow_upload_posts = BooleanField(_l('Enable upload posts'))
+    allow_polls = BooleanField(_l('Enable polls'))
     subsort = RadioField(_l('Default sub page post sorting'),
                          choices=[('v', _l('Hot')), ('v_two', _l('New')),
                                   ('v_three', _l('Top'))],

--- a/app/html/sub/createpost.html
+++ b/app/html/sub/createpost.html
@@ -95,8 +95,7 @@
 
                 <div class="pure-control-group pocont" style="display:none">
                     <label for="closetime">@{_('Close the poll at...')}</label><input id="closetime" name="closetime_chk" type="checkbox" value="">
-                    <input id="closetime_date" name="closetime" type="text" class="date-picker-future" disabled>
-                    <i>(local time)</i>
+                    <input id="closetime_date" name="closetime" type="text" class="date-picker-future" style="display:none" disabled>
                 </div>
 
                 @if not sub or (sub and not sub.nsfw):

--- a/app/html/sub/createpost.html
+++ b/app/html/sub/createpost.html
@@ -13,16 +13,19 @@
             @if error:
             <div class="error">@{ error }</div>
             @end
+            <div id="onlyuploads" class="error" style="display:none">
+              @{_("This sub only allows upload posts, and you don't have permission to upload files yet.")}
+            </div>
             <fieldset>
                 <div class="pure-control-group">
                     <span class="sub">
-                        @{form.sub.label()!!html}@{ form.sub(required=True, class_="sub_autocomplete", autocomplete="off", placeholder=_('Find a sub...')) !!html }
+                        @{form.sub.label()!!html}@{ form.sub(required=True, class_="sub_autocomplete sub_submitpost", autocomplete="off", placeholder=_('Find a sub...')) !!html }
                     </span>
                 </div>
 
                 <div class="pure-controls post-types-opts">
                     @for kl in form.ptype:
-                    <div class="pure-control-group">
+                    <div class="pure-control-group" style="display:none">
                         @{kl(style="")!!html}
                         <label for="@{kl.id}" class="pure-radio" style="text-align: left; display: initial;">
                             @{kl.label.text}
@@ -35,20 +38,20 @@
                     @{form.title.label()!!html}@{ form.title(required=True) !!html}
                 </div>
 
-                <div class="pure-control-group txcont" style="@{form.ptype.data != 'text' and 'display:none' or ''}">
+                <div class="pure-control-group txcont" style="display:none">
                     @{form.content.label()!!html}<div class="markdown-editor">
                         @{form.content(class_="exalert", placeholder=_('(Optional) Write your post content here. Styling with Markdown format is supported.'), rows="10", style="width: 100%")!!html}
                     </div>
                 </div>
 
-                <div class="pure-control-group pocont" style="@{form.ptype.data != 'poll' and 'display:none' or ''}">
+                <div class="pure-control-group pocont" style="display:none">
                     <label for="op1">@{_('Options')}</label>
                     <div id="sbm-poll-opts">
                         <div id="poll-opts">
                             @if len(form.options.data) != 0:
                                 @for i,op in enumerate(form.options):
                                     <div class="pure-control-group">
-                                        <label>@{i+1}</label><input type="text" id="op1" name="@{op.name}" value="@{op.data}" @{form.ptype.data == 'poll' and 'required' or ''} class="reqpoll sbm-poll-opt fixed">
+                                        <label>@{i+1}</label><input type="text" id="op1" name="@{op.name}" value="@{op.data}" class="reqpoll sbm-poll-opt fixed">
                                             @if i > 1:
                                             <a class="poll-del-opt" cursor: pointer;">@{_('remove')}</a>
                                             @end
@@ -56,10 +59,10 @@
                                 @end
                             @else:
                             <div class="pure-control-group">
-                                <label>1</label><input type="text" id="op1" name="options-0" @{form.ptype.data == 'poll' and 'required' or ''} class="reqpoll sbm-poll-opt fixed">
+                                <label>1</label><input type="text" id="op1" name="options-0" class="reqpoll sbm-poll-opt fixed">
                             </div>
                             <div class="pure-control-group">
-                                <label>2</label><input type="text" name="options-1" @{form.ptype.data == 'poll' and 'required' or ''} class="reqpoll sbm-poll-opt fixed">
+                                <label>2</label><input type="text" name="options-1" class="reqpoll sbm-poll-opt fixed">
                             </div>
                             @end
                         </div>
@@ -71,29 +74,26 @@
                     </div>
                 </div>
 
-                <div class="pure-control-group ulcont pure-u-sm-20-24"
-                     style="@{form.ptype.data != 'upload' and 'display:none' or ''}">
+                <div class="pure-control-group ulcont pure-u-sm-20-24" style="display:none">
                     @if current_user.canupload:
-                    <label for="files">@{_('File')}</label><input type="file" name="files" @{form.ptype.data == 'upload' and 'required' or ''} class="requpload"
+                    <label for="files">@{_('File')}</label><input type="file" name="files" class="requpload"
                            data-max="@{ config.app.max_content_length }" placeholder="@{_('Upload a file!')}"/>
                     @end
                 </div>
 
-                <div class="pure-control-group lnicont pure-u-sm-20-24"
-                     style="@{form.ptype.data != 'link' and 'display:none' or ''}">
-                    <label for="link">@{_('Link')}</label>@{form.link(class_="reqlink", type="url", pattern="https?://.+", required=form.ptype.data == 'link', placeholder=_('URL'))!!html}
+                <div class="pure-control-group lnicont pure-u-sm-20-24" style="display:none">
+                    <label for="link">@{_('Link')}</label>@{form.link(class_="reqlink", type="url", pattern="https?://.+", placeholder=_('URL'))!!html}
                 </div>
 
-                <div class="pure-control-group pure-u-sm-3-24 lnicont"
-                     style="@{form.ptype.data != 'link' and 'display:none' or ''}">
+                <div class="pure-control-group pure-u-sm-3-24 lnicont" style="display:none">
                     <button id="graburl" class="pure-button">@{_('Grab title')}</button>
                 </div>
 
-                <div class="pure-control-group pocont" style="@{form.ptype.data != 'poll' and 'display:none' or ''}">
+                <div class="pure-control-group pocont" style="display:none">
                     <label for="hideresults">@{_('Hide poll results until poll closes')}</label><input id="hideresults" name="hideresults" type="checkbox" value="y">
                 </div>
 
-                <div class="pure-control-group pocont" style="@{form.ptype.data != 'poll' and 'display:none' or ''}">
+                <div class="pure-control-group pocont" style="display:none">
                     <label for="closetime">@{_('Close the poll at...')}</label><input id="closetime" name="closetime_chk" type="checkbox" value="">
                     <input id="closetime_date" name="closetime" type="text" class="date-picker-future" disabled>
                     <i>(local time)</i>
@@ -120,7 +120,7 @@
                     </button>
 
                     <button type="button" data-pvid="ncme" class="pure-button btn-preview txicont" data-txid="content"
-                            style="@{form.ptype.data != 'text' and 'display:none' or ''}">
+                            style="display:none">
                         @{_('Preview')}
                     </button>
                     <div class="cmpreview canclose" style="display:none;">

--- a/app/html/sub/settings.html
+++ b/app/html/sub/settings.html
@@ -44,9 +44,30 @@
         </div>
 
         <div class="pure-control-group">
-          <label for="polling" class="pure-checkbox">
-            @{editsubform.polling(checked=True if metadata.get('allow_polls') else False)!!html}
-            @{editsubform.polling.label.text}
+          <label for="text_posts" class="pure-checkbox">
+            @{editsubform.allow_text_posts(checked=True if metadata.get('allow_text_posts') else False)!!html}
+            @{editsubform.allow_text_posts.label.text}
+          </label>
+        </div>
+
+        <div class="pure-control-group">
+          <label for="link_posts" class="pure-checkbox">
+            @{editsubform.allow_link_posts(checked=True if metadata.get('allow_link_posts') else False)!!html}
+            @{editsubform.allow_link_posts.label.text}
+          </label>
+        </div>
+
+        <div class="pure-control-group">
+          <label for="upload_posts" class="pure-checkbox">
+            @{editsubform.allow_upload_posts(checked=True if metadata.get('allow_upload_posts') else False)!!html}
+            @{editsubform.allow_upload_posts.label.text}
+          </label>
+        </div>
+
+        <div class="pure-control-group">
+          <label for="allow_polls" class="pure-checkbox">
+            @{editsubform.allow_polls(checked=True if metadata.get('allow_polls') else False)!!html}
+            @{editsubform.allow_polls.label.text}
           </label>
         </div>
 

--- a/app/html/sub/settings.html
+++ b/app/html/sub/settings.html
@@ -44,21 +44,21 @@
         </div>
 
         <div class="pure-control-group">
-          <label for="text_posts" class="pure-checkbox">
+          <label for="allow_text_posts" class="pure-checkbox">
             @{editsubform.allow_text_posts(checked=True if metadata.get('allow_text_posts') else False)!!html}
             @{editsubform.allow_text_posts.label.text}
           </label>
         </div>
 
         <div class="pure-control-group">
-          <label for="link_posts" class="pure-checkbox">
+          <label for="allow_link_posts" class="pure-checkbox">
             @{editsubform.allow_link_posts(checked=True if metadata.get('allow_link_posts') else False)!!html}
             @{editsubform.allow_link_posts.label.text}
           </label>
         </div>
 
         <div class="pure-control-group">
-          <label for="upload_posts" class="pure-checkbox">
+          <label for="allow_upload_posts" class="pure-checkbox">
             @{editsubform.allow_upload_posts(checked=True if metadata.get('allow_upload_posts') else False)!!html}
             @{editsubform.allow_upload_posts.label.text}
           </label>

--- a/app/misc.py
+++ b/app/misc.py
@@ -1376,13 +1376,6 @@ def validate_captcha(token, response):
     return False
 
 
-def get_all_subs():
-    """ Temporary function until we work out a better autocomplete
-    for createpost """
-    # TODO
-    return [x.name for x in Sub.select(Sub.name)]
-
-
 def get_comment_tree(comments, root=None, only_after=None, uid=None, provide_context=True, include_history=False):
     """ Returns a fully paginated and expanded comment tree.
 

--- a/app/misc.py
+++ b/app/misc.py
@@ -1049,6 +1049,14 @@ def getSubMods(sid):
     return {'owners': owner, 'mods': mods, 'janitors': janitors, 'all': owner_uids + janitor_uids + mod_uids}
 
 
+# Relationship between the post type values in the CreateSubPost form
+# and the SubMetadata keys that allow those post values.
+ptype_names = {'link': 'allow_link_posts',
+               'text': 'allow_text_posts',
+               'upload': 'allow_upload_posts',
+               'poll': 'allow_polls'}
+
+
 def getSubData(sid, simple=False, extra=False):
     sdata = SubMetadata.select().where(SubMetadata.sid == sid)
     data = {'xmod2': [], 'sticky': []}

--- a/app/static/js/Poll.js
+++ b/app/static/js/Poll.js
@@ -45,10 +45,12 @@ u.addEventForChild(document, 'click', '.poll-del-opt', function(e, qelem){
 u.sub('#closetime', 'click', function(e){
     if(this.checked){
         document.getElementById('closetime_date').removeAttribute('disabled');
+        document.getElementById('closetime_date').nextElementSibling.style.display = '';
         document.querySelector('.date-picker-future.input').removeAttribute('disabled');
         document.querySelector('.date-picker-future.flatpickr-mobile').removeAttribute('disabled');
     }else{
         document.getElementById('closetime_date').setAttribute('disabled', true);
+        document.getElementById('closetime_date').nextElementSibling.style.display = 'none';
         document.querySelector('.date-picker-future.input').setAttribute('disabled', true);
         document.querySelector('.date-picker-future.flatpickr-mobile').setAttribute('disabled', true);
         document.getElementById('closetime_date').value = '';

--- a/app/static/js/Sub.js
+++ b/app/static/js/Sub.js
@@ -1,6 +1,8 @@
 import u from './Util';
 import TextConfirm from  './utils/TextConfirm';
 import _ from './utils/I18n';
+import 'autocompleter/autocomplete.css';
+import autocomplete from 'autocompleter';
 
 u.sub('.revoke-mod2inv', 'click', function(e){
   var user=this.getAttribute('data-user');
@@ -97,8 +99,10 @@ u.sub('#ban_timepick', 'change', function(e){
   }
 });
 
-u.sub('input[name="ptype"]', 'change', function (e) {
-  const newVal = e.target.value;
+// Changing the visibility of fields in Submit a Post based on the
+// selected radio button.
+function onPtypeChange(e) {
+  const newVal = e.value;
   u.each('.lncont', function (e) {
     e.style.display = newVal == 'link' ? 'block' : 'none';
   });
@@ -146,4 +150,140 @@ u.sub('input[name="ptype"]', 'change', function (e) {
       e.removeAttribute('required');
     }
   });
+}
+
+u.sub('input[name="ptype"]', 'change', function (e) {
+  onPtypeChange(e.target);
 });
+
+// List of suggestions for sub names, fetched from server.
+var suggestions = null;
+
+// Map radio button names to sub permission flag names.
+var ptypeNames = {
+  link: 'allow_link_posts',
+  text: 'allow_text_posts',
+  upload: 'allow_upload_posts',
+  poll: 'allow_polls'
+};
+
+// Show or hide the radio buttons in Submit a Post based
+// on what's allowed for the selected sub.
+function updateSubmitPostForm(ptypes) {
+  var radioButtons = document.querySelectorAll('input[name="ptype"]');
+  var onlyUploads = document.getElementById('onlyuploads');
+  var currentlySet = null;
+  var firstVisible = null;
+  for (var i = 0; i < radioButtons.length; i++) {
+    var e = radioButtons[i];
+    if (e.checked) {
+      currentlySet = e;
+    }
+    if (ptypes.includes(ptypeNames[e.value])) {
+      e.parentNode.style.display = '';
+      if (!firstVisible) {
+        firstVisible = e;
+      }
+    } else {
+      e.parentNode.style.display = 'none';
+    }
+  }
+
+  // Make sure a visible radio button is selected.
+  if (!firstVisible) {
+    // No radio buttons are visible, and that can only happen if the
+    // sub is uploads-only and the user can't upload.
+    // There's a message for that, so display it.
+    onlyUploads.style.display = '';
+  } else if (!ptypes.includes(ptypeNames[currentlySet.value])) {
+    currentlySet.checked = false;
+    firstVisible.checked = true;
+    onPtypeChange(firstVisible);
+    onlyUploads.style.display = 'none';
+  } else {
+      // Make sure the right fields are shown on initial load of page.
+      onPtypeChange(currentlySet);
+  }
+}
+
+// When the sub name in Submit a Post is changed, get the types of
+// posts permitted and update which radio buttons are visible
+// accordingly.
+function onSubmitPostSubChange(e) {
+  if (e.classList.contains('sub_submitpost')) {
+    var name = e.value.toLowerCase();
+    var ptypes = null;
+    const defaults = ['allow_link_posts',
+                      'allow_text_posts',
+                      'allow_upload_posts']
+    // An earlier AJAX call for autocomplete may have fetched
+    // the ptypes for the sub already.
+    if (suggestions) {
+      suggestions.forEach(function (elem) {
+        if (name == elem.name.toLowerCase()) {
+          ptypes = elem.ptypes;
+        }});
+    }
+
+    if (ptypes != null) {
+      updateSubmitPostForm(ptypes)
+    } else if (e.value == '') {
+      // No sub given, so show the defaults.
+      updateSubmitPostForm(defaults);
+    } else {
+      u.get('/api/v3/sub?query=' + name, function(data) {
+        if (data.results) {
+          data.results.forEach(function(elem) {
+            if (name == elem.name.toLowerCase())
+              ptypes = elem.ptypes;
+          });
+        }
+        if (ptypes != null) {
+          updateSubmitPostForm(ptypes)
+        } else {
+          // This sub doesn't exist, so show the defaults.
+          updateSubmitPostForm(defaults);
+        }
+      });
+    }
+  }
+}
+
+u.ready(function () {
+  var sub = document.getElementById('sub');
+  if (sub) {
+    onSubmitPostSubChange(sub);
+  }
+})
+
+u.sub('#sub', 'change', function(e) {
+  onSubmitPostSubChange(e.target)});
+
+// SUB autocomplete
+const sa = document.querySelector('.sub_autocomplete');
+if(sa){
+  autocomplete({
+    minLength: 3,
+    debounceWaitMs: 200,
+    input: sa,
+    fetch: function(text, update) {
+        text = text.toLowerCase();
+        u.get('/api/v3/sub?query=' + text, function(data){
+          suggestions = data.results;
+          update(suggestions);
+        })
+    },
+    onSelect: function(item) {
+        sa.value = item.name;
+        if (sa.id == 'sub') {
+          onSubmitPostSubChange(sa);
+        }
+    },
+    render: function(item, currentValue) {
+      var div = document.createElement("div");
+      div.textContent = item.name;
+      return div;
+    },
+    emptyMsg: _('No subs found')
+  });
+}

--- a/app/static/js/Sub.js
+++ b/app/static/js/Sub.js
@@ -63,32 +63,6 @@ u.sub('.revoke-ban', 'click', function(e){
   });
 });
 
-u.sub('#ptoggle', 'click', function(e){
-  var oval = document.getElementById('ptypeval').value;
-  document.getElementById('ptypeval').value = (document.getElementById('ptypeval').value == 'text') ? 'link' : 'text' ;
-  if(document.getElementById('ptypeval').value == 'text'){
-    this.innerHTML = _('Change to link post');
-  }else{
-    this.innerHTML = _('Change to text post');
-  }
-  var val = document.getElementById('ptypeval').value;
-  document.getElementById('ptype').innerHTML = val;
-  if(val=='text'){
-    if(document.getElementById('link').getAttribute('required') === ''){
-      window.rReq = true;
-      document.getElementById('link').removeAttribute('required');
-    }
-    u.each('.lncont', function(e){e.style.display='none';});
-    u.each('.txcont', function(e){e.style.display=(e.type == "button") ? 'inline-block' : 'block';});
-  }else{
-    if(window.rReq){
-      document.getElementById('link').setAttribute('required', true);
-    }
-    u.each('.lncont', function(e){e.style.display=(e.type == "button") ? 'inline-block' : 'block';});
-    u.each('.txcont', function(e){e.style.display='none';});
-  }
-});
-
 u.sub('button.blk,button.unblk,button.sub,button.unsub', 'click', function(e){
   var sid=this.parentNode.getAttribute('data-sid');
   var act=this.getAttribute('data-ac')

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -9,10 +9,7 @@ import 'tingle.js/dist/tingle.css';
 import 'time-elements';
 //import 'flatpickr/dist/flatpickr.css';
 import 'flatpickr/dist/themes/dark.css';
-import 'autocompleter/autocomplete.css';
 
-
-import autocomplete from 'autocompleter';
 import u from './Util';
 import Konami from './ext/konami';
 import Sortable from 'sortablejs';
@@ -105,34 +102,6 @@ function vote(obj, how, comment){
   }, function(err){
     //TODO: show errors
   })
-}
-
-// sub autocomplete
-const sa = document.querySelector('.sub_autocomplete');
-if(sa){
-  autocomplete({
-    minLength: 3,
-    debounceWaitMs: 200,
-    input: sa,
-    fetch: function(text, update) {
-        text = text.toLowerCase();
-        // you can also use AJAX requests instead of preloaded data
-        u.get('/api/v3/sub?query=' + text, function(data){
-          console.log(data.results)
-          var suggestions = data.results
-          update(suggestions);
-        })
-    },
-    onSelect: function(item) {
-        sa.value = item.name;
-    },
-    render: function(item, currentValue) {
-      var div = document.createElement("div");
-      div.textContent = item.name;
-      return div;
-    },
-    emptyMsg: _('No subs found')
-  });
 }
 
 // up/downvote buttons.

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -140,6 +140,12 @@ u.ready(function() {
     altFormat: 'Y-m-d H:i',
     time_24hr: true,
   });
+  // Hide the Submit a post poll flatpickr initially.
+  var cb = document.getElementById('closetime_date');
+  if (cb && cb.nextElementSibling) {
+    cb.nextElementSibling.style.display = 'none';
+  }
+
   // for the top bar sorts
   var list = document.getElementById("subsort");
   if(list){

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -352,6 +352,11 @@ def edit_sub(sub):
     if current_user.is_mod(sub.sid, 1) or current_user.is_admin():
         form = EditSubForm()
         if form.validate():
+            if not (form.allow_text_posts.data or form.allow_link_posts.data or
+                    form.allow_upload_posts.data or form.allow_polls.data):
+                return (json.dumps({
+                    'status': 'error',
+                    'error': [_('At least one kind of post must be permitted')]}))
             sub.title = form.title.data
             sub.sidebar = form.sidebar.data
             sub.nsfw = form.nsfw.data
@@ -359,7 +364,10 @@ def edit_sub(sub):
 
             sub.update_metadata('restricted', form.restricted.data)
             sub.update_metadata('ucf', form.usercanflair.data)
-            sub.update_metadata('allow_polls', form.polling.data)
+            sub.update_metadata('allow_text_posts', form.allow_text_posts.data)
+            sub.update_metadata('allow_link_posts', form.allow_link_posts.data)
+            sub.update_metadata('allow_upload_posts', form.allow_upload_posts.data)
+            sub.update_metadata('allow_polls', form.allow_polls.data)
             sub.update_metadata('sublog_private', form.sublogprivate.data)
             sub.update_metadata('sub_banned_users_private', form.subbannedusersprivate.data)
 

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -18,14 +18,6 @@ from ..tasks import create_thumbnail, create_thumbnail_external
 bp = Blueprint('subs', __name__)
 
 
-def post_over_limit():
-    captcha = None
-    if misc.get_user_level(current_user.uid)[0] <= 4:
-        captcha = misc.create_captcha()
-    form = CreateSubPostForm()
-    return engine.get_template('sub/createpost.html').render({'error': _('Wait a bit before posting.'), 'form': form, 'sub': None, 'captcha': captcha})
-
-
 @bp.route("/submit/<ptype>", defaults={'sub': ''}, methods=['GET'])
 @bp.route("/submit/<ptype>/<sub>", methods=['GET'])
 @login_required

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -328,7 +328,12 @@ def create_sub():
                  'csubform': form})
 
     sub = Sub.create(sid=uuid.uuid4(), name=form.subname.data, title=form.title.data)
-    SubMetadata.create(sid=sub.sid, key='mod', value=current_user.uid)
+
+    smd = [dict(sid=sub.sid, key='mod', value=current_user.uid)]
+    for key in ['allow_text_posts', 'allow_link_posts', 'allow_upload_posts']:
+        smd.append(dict(sid=sub.sid, key=key, value='1'))
+    SubMetadata.insert_many(smd).execute()
+
     SubMod.create(sid=sub.sid, uid=current_user.uid, power_level=0)
     SubStylesheet.create(sid=sub.sid, content='', source='/* CSS here */')
 

--- a/migrations/021_submetadata_allowposts.py
+++ b/migrations/021_submetadata_allowposts.py
@@ -1,0 +1,55 @@
+"""Peewee migrations -- 021_subpostpermissions.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    Sub = migrator.orm['sub']
+    SubMetadata = migrator.orm['sub_metadata']
+
+    for sub in Sub.select():
+        SubMetadata.create(key='allow_text_posts', value='1', sid=sub.sid)
+        SubMetadata.create(key='allow_link_posts', value='1', sid=sub.sid)
+        SubMetadata.create(key='allow_upload_posts', value='1', sid=sub.sid)
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    SubMetadata = migrator.orm['sub_metadata']
+    SubMetadata.delete().where(
+        SubMetadata.key == 'allow_text_posts').execute()
+    SubMetadata.delete().where(
+        SubMetadata.key == 'allow_link_posts').execute()
+    SubMetadata.delete().where(
+        SubMetadata.key == 'allow_upload_posts').execute()


### PR DESCRIPTION
We have some subs that would like to be memes-only and some that would like to be text-only.  Add new sub settings to give moderators finer control over what kinds of posts to allow in their subs.

The Submit a Post form was already problematic because if you navigated to it from the home page and then typed in the name of a sub that allowed polls, you wouldn't see the poll option, and if you navigated to it from a sub that allowed polls and typed in the name of a sub that didn't allow polls, it would allow you to create a poll anyway. Adding more options made this worse, so I redid it to have the JS fetch the types of posts possible for each sub when it fetches the sub name suggestions, and to show and hide the radio buttons accordingly.  The logic for showing and hiding form components based on the selected radio button was duplicated in the template and in the JS, so I simplified the template by making the JS logic run when the form is loaded.