### PR TITLE
Fix post score css so it can fit more than two digits on mobile

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -710,7 +710,9 @@ iframe {
 .c-upvote, .c-downvote, .upvote, .downvote {
   height: 20px;
   width: 18px;
-  display: inline-block;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
   cursor: pointer;
 }
 
@@ -723,22 +725,19 @@ iframe {
 }
 
 .misctainer {
-  padding-left: .6em;
   padding-right: .4em;
 }
 
 .votebuttons {
   height: 100%;
-  min-width: 1em;
   max-height: 70px;
-  padding: .15em .2em 0 .2em;
+  padding-top: .15em;
   float: left;
-  margin-right: 8px;
-  max-width: 2.2em;
+  width: 35px;
 }
 
 .score {
-  font-size: 17px;
+  font-size: 15px;
   margin: 5px 0 5px 0;
   text-align: center;
   letter-spacing: normal;


### PR DESCRIPTION
Fix #210. The calculation of width for the voting widget, thumbnail and the rest of a post listing was in a mix of `px` and `em` units.  I changed it to use just `px`, and that made the layout stop breaking on mobile.  To make larger numbers look better I used a slightly smaller font, and removed margins and padding in favor of telling the up and down arrows and the numbers to center themselves in a wider space.  The result looks good with 1, 2 or 3 digits, legible but tight with 4 digits, and at 5 digits there starts to be a collision between the number and the thumbnail, but the layout doesn't break.