### PR TITLE
Start saving comment history again

### DIFF
--- a/app/views/do.py
+++ b/app/views/do.py
@@ -30,7 +30,7 @@ from ..badges import badges
 from ..misc import cache, send_email, allowedNames, get_errors, engine, ensure_locale_loaded
 from ..misc import ratelimit, POSTING_LIMIT, AUTH_LIMIT, is_domain_banned
 from ..models import SubPost, SubPostComment, Sub, Message, User, UserIgnores, SubMetadata, UserSaved
-from ..models import SubMod, SubBan, InviteCode, Notification, SubPostContentHistory, SubPostTitleHistory
+from ..models import SubMod, SubBan, SubPostCommentHistory, InviteCode, Notification, SubPostContentHistory, SubPostTitleHistory
 from ..models import SubStylesheet, SubSubscriber, SubUploads, UserUploads, SiteMetadata, SubPostMetadata, SubPostReport
 from ..models import SubPostVote, SubPostCommentVote, UserMetadata, SubFlair, SubPostPollOption, SubPostPollVote, SubPostCommentReport, SubRule
 from ..models import rconn, UserStatus
@@ -1837,6 +1837,8 @@ def edit_comment():
             return jsonify(status='error', error=_("Post is archived"))
 
         dt = datetime.datetime.utcnow()
+        spm = SubPostCommentHistory.create(cid=comment.cid, content=comment.content,
+                                           datetime=(comment.lastedit or comment.time))
         comment.content = form.text.data
         comment.lastedit = dt
         comment.save()


### PR DESCRIPTION
Showing the comment edit history had stopped working, and the reason was that the line of code that creates the `SubPostCommentHistory` entry was inadvertently deleted in 41cedb2f (#152).  While I was at it I noticed there were two previous versions of that line of code, which set the time of the history record to different things, neither one of which seemed right, so I made it use the time that matches when the content in the record was entered.  The edit history time is not currently shown in the user interface.