### PR TITLE
Fix the sub rule text length limit to match the database

### DIFF
--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -65,7 +65,7 @@ class DeleteSubFlair(FlaskForm):
 
 class CreateSubRule(FlaskForm):
     """ Creates a rule """
-    text = StringField(_l('Rule text'), validators=[DataRequired(), Length(max=25)])
+    text = StringField(_l('Rule text'), validators=[DataRequired(), Length(max=255)])
 
 
 class EditSubRule(FlaskForm):


### PR DESCRIPTION
The sub rule creation form is enforcing a 25 character length limit, which is probably a typo.  Change the limit to 255 to match the length of the database field.