### PR TITLE
Check for too-long comment and post report reasons

### DIFF
--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2488,6 +2488,8 @@ def report():
 
         if len(form.reason.data) < 2:
             return jsonify(status='error', error=_('Report reason too short.'))
+        elif len(form.reason.data) > 128:
+            return jsonify(status='error', error=_('Report reason too long.'))
 
         if not form.send_to_admin.data and misc.is_sub_banned(post['sid'], uid=current_user.uid):
             return jsonify(status='error', error=_('You are banned from this sub.'))
@@ -2534,6 +2536,8 @@ def report_comment():
 
         if len(form.reason.data) < 2:
             return jsonify(status='error', error=_('Report reason too short.'))
+        elif len(form.reason.data) > 128:
+            return jsonify(status='error', error=_('Report reason too long.'))
 
         if not form.send_to_admin.data and misc.is_sub_banned(comm.pid.sid, uid=current_user.uid):
             return jsonify(status='error', error=_('You are banned from this sub.'))


### PR DESCRIPTION
Choosing "Other" as a reason when reporting a post or comment, and then entering more than 128 characters of text causes an exception on the server and shows the user an "Error contacting the server" message.  Fix this by checking the length of the input text and returning an error message if it is too long.