### PR TITLE
Fix migration problems

### DIFF
--- a/migrations/003_submod.py
+++ b/migrations/003_submod.py
@@ -46,17 +46,18 @@ def migrate(migrator, database, fake=False, **kwargs):
 
         class Meta:
             table_name = "sub_mod"
-    
-    SubMod._meta.database = migrator.database
-    SubMod.create_table(True)
 
-    SubMetadata = migrator.orm['sub_metadata']
+    if not fake:
+        SubMod._meta.database = migrator.database
+        SubMod.create_table(True)
 
-    for xm in SubMetadata.select().where(SubMetadata.key == 'mod1'):
-        SubMod.create(uid=xm.value, sid=xm.sid, power_level=0)
+        SubMetadata = migrator.orm['sub_metadata']
 
-    for xm in SubMetadata.select().where(SubMetadata.key == 'mod2'):
-        SubMod.create(uid=xm.value, sid=xm.sid, power_level=1)
+        for xm in SubMetadata.select().where(SubMetadata.key == 'mod1'):
+            SubMod.create(uid=xm.value, sid=xm.sid, power_level=0)
+
+        for xm in SubMetadata.select().where(SubMetadata.key == 'mod2'):
+            SubMod.create(uid=xm.value, sid=xm.sid, power_level=1)
 
 
 

--- a/migrations/004_subban.py
+++ b/migrations/004_subban.py
@@ -50,17 +50,18 @@ def migrate(migrator, database, fake=False, **kwargs):
 
         class Meta:
             table_name = "sub_ban"
-    
-    migrator.run()
 
-    SubMetadata = migrator.orm['sub_metadata']
-    SubBan = migrator.orm['sub_ban']
+    if not fake:
+        migrator.run()
 
-    for xm in SubMetadata.select().where(SubMetadata.key == 'ban'):
-        SubBan.create(uid=xm.value, sid=xm.sid, effective=True, reason='', created=None)
+        SubMetadata = migrator.orm['sub_metadata']
+        SubBan = migrator.orm['sub_ban']
 
-    for xm in SubMetadata.select().where(SubMetadata.key == 'xban'):
-        SubBan.create(uid=xm.value, sid=xm.sid, effective=False, reason='', created=None)
+        for xm in SubMetadata.select().where(SubMetadata.key == 'ban'):
+            SubBan.create(uid=xm.value, sid=xm.sid, effective=True, reason='', created=None)
+
+        for xm in SubMetadata.select().where(SubMetadata.key == 'xban'):
+            SubBan.create(uid=xm.value, sid=xm.sid, effective=False, reason='', created=None)
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/migrations/013_defaultwikis.py
+++ b/migrations/013_defaultwikis.py
@@ -37,17 +37,18 @@ def migrate(migrator, database, fake=False, **kwargs):
     """Write your migrations here."""
     Wiki = migrator.orm['wiki']
 
-    tos = Wiki(is_global=True, slug="tos", title="Terms of Service", content="Put your terms of service here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
-    tos.save()
+    if not fake:
+        tos = Wiki(is_global=True, slug="tos", title="Terms of Service", content="Put your terms of service here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
+        tos.save()
 
-    privacy = Wiki(is_global=True, slug="privacy", title="Privacy Policy", content="Put your privacy policy here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
-    privacy.save()
+        privacy = Wiki(is_global=True, slug="privacy", title="Privacy Policy", content="Put your privacy policy here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
+        privacy.save()
 
-    canary = Wiki(is_global=True, slug="canary", title="Warrant canary", content="Put your canary here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
-    canary.save()
+        canary = Wiki(is_global=True, slug="canary", title="Warrant canary", content="Put your canary here", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
+        canary.save()
 
-    donate = Wiki(is_global=True, slug="donate", title="Donate", content="Donation info goes here!", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
-    donate.save()
+        donate = Wiki(is_global=True, slug="donate", title="Donate", content="Donation info goes here!", created=dt.datetime.utcnow(), updated=dt.datetime.utcnow())
+        donate.save()
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/migrations/021_submetadata_allowposts.py
+++ b/migrations/021_submetadata_allowposts.py
@@ -38,18 +38,20 @@ def migrate(migrator, database, fake=False, **kwargs):
     Sub = migrator.orm['sub']
     SubMetadata = migrator.orm['sub_metadata']
 
-    for sub in Sub.select():
-        SubMetadata.create(key='allow_text_posts', value='1', sid=sub.sid)
-        SubMetadata.create(key='allow_link_posts', value='1', sid=sub.sid)
-        SubMetadata.create(key='allow_upload_posts', value='1', sid=sub.sid)
+    if not fake:
+        for sub in Sub.select():
+            SubMetadata.create(key='allow_text_posts', value='1', sid=sub.sid)
+            SubMetadata.create(key='allow_link_posts', value='1', sid=sub.sid)
+            SubMetadata.create(key='allow_upload_posts', value='1', sid=sub.sid)
 
 
 def rollback(migrator, database, fake=False, **kwargs):
     """Write your rollback migrations here."""
-    SubMetadata = migrator.orm['sub_metadata']
-    SubMetadata.delete().where(
-        SubMetadata.key == 'allow_text_posts').execute()
-    SubMetadata.delete().where(
-        SubMetadata.key == 'allow_link_posts').execute()
-    SubMetadata.delete().where(
-        SubMetadata.key == 'allow_upload_posts').execute()
+    if not fake:
+        SubMetadata = migrator.orm['sub_metadata']
+        SubMetadata.delete().where(
+            SubMetadata.key == 'allow_text_posts').execute()
+        SubMetadata.delete().where(
+            SubMetadata.key == 'allow_link_posts').execute()
+        SubMetadata.delete().where(
+            SubMetadata.key == 'allow_upload_posts').execute()

--- a/migrations/022_fixcommentreportlog1.py
+++ b/migrations/022_fixcommentreportlog1.py
@@ -1,0 +1,57 @@
+"""Peewee migrations -- 022_fixcommentreportlog1.py.
+
+Migration 014_createreportlogs.py erroneously created the
+comment_report_log table with a foreign key constraint linked to
+sub_post_report instead of sub_post_comment_report.  Fix that by
+deleting and recreating the table.  This needs to be done in two
+migrations because the new table cannot be created until the old one
+is fully deleted, which happens after the migrate function is run.
+
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    @migrator.create_model
+    class CommentReportLogSave(pw.Model):
+        rid = pw.ForeignKeyField(db_column='id', model=migrator.orm['sub_post_comment_report'], field='id')
+        action = pw.IntegerField(null=True)
+        desc = pw.CharField(null=True)
+        lid = pw.PrimaryKeyField()
+        link = pw.CharField(null=True)
+        time = pw.DateTimeField()
+        uid = pw.ForeignKeyField(db_column='uid', null=True, model=migrator.orm['user'], field='uid')
+        target = pw.ForeignKeyField(db_column='target_uid', null=True, model=migrator.orm['user'], field='uid')
+
+        def __repr__(self):
+            return f'<CommentReportLogSave action={self.action}>'
+
+        class Meta:
+            table_name = 'comment_report_log_save'
+
+    if not fake:
+        CommentReportLog = migrator.orm['comment_report_log']
+        CommentReportLogSave.create_table(True)
+        records = list(CommentReportLog.select().dicts())
+        for r in records:
+            r.pop("lid")
+        CommentReportLogSave.insert_many(records).execute()
+
+    migrator.remove_model("comment_report_log")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    # This migration and the next one delete and recreate
+    # CommentReportLog so a rollback is not necessary.

--- a/migrations/023_fixcommentreportlog2.py
+++ b/migrations/023_fixcommentreportlog2.py
@@ -1,0 +1,51 @@
+"""Peewee migrations -- 023_fixcommentreportlog2.py.
+
+Part 2 of a 2 part migration.  See 022_fixcommentreportlog1.py.
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    @migrator.create_model
+    class CommentReportLog(pw.Model):
+        rid = pw.ForeignKeyField(db_column='id', model=migrator.orm['sub_post_comment_report'], field='id')
+        action = pw.IntegerField(null=True)
+        desc = pw.CharField(null=True)
+        lid = pw.PrimaryKeyField()
+        link = pw.CharField(null=True)
+        time = pw.DateTimeField()
+        uid = pw.ForeignKeyField(db_column='uid', null=True, model=migrator.orm['user'], field='uid')
+        target = pw.ForeignKeyField(db_column='target_uid', null=True, model=migrator.orm['user'], field='uid')
+
+        def __repr__(self):
+            return f'<CommentReportLog action={self.action}>'
+
+        class Meta:
+            table_name = 'comment_report_log'
+
+    if not fake:
+        CommentReportLogSave = migrator.orm['comment_report_log_save']
+        CommentReportLog.create_table(True)
+        records = list(CommentReportLogSave.select().dicts())
+        for r in records:
+            r.pop("lid")
+        CommentReportLog.insert_many(records).execute()
+
+    migrator.remove_model("comment_report_log_save")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    # This migration and the previous one delete and recreate
+    # CommentReportLog so a rollback is not necessary.


### PR DESCRIPTION
We have a broken migration in the migration chain, `014_createreportlogs.py` which was intended to create the tables for `PostReportLog` and `CommentReportLog`, the only difference between the two being the type of foreign key (`sub_post_report` vs `sub_post_comment_report`).  In that migration, the table name for both tables is set to `comment_report_log`, so only one table gets created.  A later migration creates the missing table but doesn't do anything to the existing one, which has its foreign key pointing to the wrong table.

This incorrect foreign key causes an "Unable to contact the server" error message if you try to add a note to a comment report when the index of that comment report is not a valid index into the post report table (as is likely for a recent comment report when the number of comment reports is greater than the number of post reports).  Here's a backtrace from that event:

```
Traceback (most recent call last):
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 3099, in execute_sql
cursor.execute(sql, params or ())
psycopg2.errors.ForeignKeyViolation: insert or update on table "comment_report_log" violates foreign key constraint "comment_report_log_id_fkey"
DETAIL: Key (id)=(234) is not present in table "sub_post_report".
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2447, in wsgi_app
response = self.full_dispatch_request()
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1952, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1821, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 39, in reraise
raise value
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1950, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1936, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/usr/local/lib/python3.7/dist-packages/flask_login/utils.py", line 272, in decorated_view
return func(*args, **kwargs)
File "/throat/app/views/do.py", line 2660, in close_comment_report
misc.create_reportlog(misc.LOG_TYPE_REPORT_CLOSE, current_user.uid, id, type='comment')
File "/throat/app/misc.py", line 1450, in create_reportlog
CommentReportLog.create(action=action, uid=uid, id=id, desc=desc)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 6292, in create
inst.save(force_insert=True)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 6499, in save
pk = self.insert(**field_dict).execute()
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 1886, in inner
return method(self, database, *args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 1957, in execute
return self._execute(database)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 2707, in _execute
return super(Insert, self)._execute(database)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 2440, in _execute
cursor = self.execute_returning(database)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 2447, in execute_returning
cursor = database.execute(self)
File "/throat/app/models.py", line 94, in peewee_count_queries
return dex (*args, **kwargs)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 3112, in execute
return self.execute_sql(sql, params, commit=commit)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 3106, in execute_sql
self.commit()
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 2873, in __exit__
reraise(new_type, new_type(exc_value, *exc_args), traceback)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 183, in reraise
raise value.with_traceback(tb)
File "/usr/local/lib/python3.7/dist-packages/peewee.py", line 3099, in execute_sql
cursor.execute(sql, params or ())
peewee.IntegrityError: insert or update on table "comment_report_log" violates foreign key constraint "comment_report_log_id_fkey"
DETAIL: Key (id)=(234) is not present in table "sub_post_report".
```

Fix this by adding two migrations to delete the `comment_report_log` table and recreate it, copying the data in and out of a temporary table.

In the process of working on this, I noticed that I had about 50 default wikis in my dev database.  It turns out that our migration library runs all the old `migrate` functions with `fake=True` whenever you run a new migration or roll back a migration.  I went through all the migrations and added checks so that they only do direct database operations when `fake` is not `True`.