### PR TITLE
Fix the delete private message button

### DIFF
--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -44,7 +44,7 @@ u.sub('.savemsg', 'click', function(e){
 // Delete notification.
 u.sub('.deletemsg', 'click', function(e){
   const mid = this.getAttribute('data-mid'), obj = this;
-  u.post('/messages/notifications/delete/'+mid, {},
+  u.post('/do/delete_pm/'+mid, {},
   function(data){
     if (data.status == "ok") {
       obj.innerHTML = _('deleted');


### PR DESCRIPTION
The delete button for inbox messages was inadvertently changed in 4d576e0012 to use the delete path for notifications instead of messages.  Make it use the correct path.  Fixes #242.
