### PR TITLE
Include messages saved or deleted by the recipient in Sent Messages

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -979,7 +979,7 @@ def getMessagesSent(page):
     try:
         msg = Message.select(Message.mid, Message.sentby, User.name.alias('username'), Message.subject, Message.content,
                              Message.posted, Message.read, Message.mtype, Message.mlink)
-        msg = msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.receivedby)).where(Message.mtype == 1).where(
+        msg = msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.receivedby)).where(Message.mtype << [1, 6, 9, 41]).where(
             Message.sentby == current_user.uid).order_by(Message.mid.desc()).paginate(page, 20).dicts()
     except Message.DoesNotExist:
         return False


### PR DESCRIPTION
Change the query that fetches a user's sent messages to include messages that have been saved, deleted or blocked by the recipient.  Fixes #241.