### PR TITLE
Ignore vote button clicks while a previous vote is being processed

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -88,20 +88,25 @@ function vote(obj, how, comment){
     var unid = obj.getAttribute('data-pid');
     var count = obj.parentNode.querySelector('.score');
   }
-  u.post('/do/' + kl + '/'+ unid + '/' + how, {}, function(data){
-    console.log(obj.classList)
-    if(!data.rm){
-      obj.classList.add((how == 'up') ? 'upvoted' : 'downvoted');
-      if(obj.parentNode.querySelector((how == 'up') ? '.downvoted' : '.upvoted')){
-        obj.parentNode.querySelector((how == 'up') ? '.downvoted' : '.upvoted').classList.remove((how == 'up') ? 'downvoted' : 'upvoted')
+  if (!obj.getAttribute('data-in-progress')) {
+    obj.setAttribute('data-in-progress', true);
+    u.post('/do/' + kl + '/'+ unid + '/' + how, {}, function(data){
+      obj.removeAttribute('data-in-progress');
+      console.log(obj.classList)
+      if(!data.rm){
+        obj.classList.add((how == 'up') ? 'upvoted' : 'downvoted');
+        if(obj.parentNode.querySelector((how == 'up') ? '.downvoted' : '.upvoted')){
+          obj.parentNode.querySelector((how == 'up') ? '.downvoted' : '.upvoted').classList.remove((how == 'up') ? 'downvoted' : 'upvoted')
+        }
+      }else{
+        obj.classList.remove((how == 'up') ? 'upvoted' : 'downvoted');
       }
-    }else{
-      obj.classList.remove((how == 'up') ? 'upvoted' : 'downvoted');
-    }
-    count.innerHTML = data.score;
-  }, function(err){
-    //TODO: show errors
-  })
+      count.innerHTML = data.score;
+    }, function(err){
+      obj.removeAttribute('data-in-progress');
+      //TODO: show errors
+    })
+  }
 }
 
 // up/downvote buttons.


### PR DESCRIPTION
Make the race condition described in #250 less likely by changing the JS code which handles clicks on the upvote and downvote buttons to not send a new post request before the previous one has completed.  

I was able to reproduce the race condition on my dev server after adding 5 calls to `gevent.sleep(0.1)` sprinkled throughout `cast_vote` in `misc.py`.  I tested this change against the modified `cast_vote` and could not reproduce the vote counting error.