### PR TITLE
Drop comment report log entries with invalid rid's

### DIFF
--- a/migrations/022_fixcommentreportlog1.py
+++ b/migrations/022_fixcommentreportlog1.py
@@ -42,8 +42,11 @@ def migrate(migrator, database, fake=False, **kwargs):
 
     if not fake:
         CommentReportLog = migrator.orm['comment_report_log']
+        SubPostCommentReport = migrator.orm['sub_post_comment_report']
         CommentReportLogSave.create_table(True)
-        records = list(CommentReportLog.select().dicts())
+        valid_ids = list((rep.id for rep in SubPostCommentReport.select()))
+        records = list(CommentReportLog.select().
+                       where(CommentReportLog.rid << valid_ids).dicts())
         for r in records:
             r.pop("lid")
         CommentReportLogSave.insert_many(records).execute()


### PR DESCRIPTION
On our test server we found that we have a few `CommentReportLog` records whose `rid` is not a valid index into the `SubPostCommentReport` table.  The foreign key constraint on the `rid` was broken until recently which permitted the invalid entries to be inserted.  I haven't been able to figure out where in current or past versions of the code an invalid `rid` could be inserted.  

Our production database does not contain any invalid `rid`s.

The invalid `rid`s caused the migration from #247 to fail when run on our test server.  This change fixes the failing migration by dropping any records from the `CommentReportLog` table with an invalid `rid`.