### PR TITLE
Allow mods to lock posts to new comments

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -229,6 +229,11 @@
                 <li><a class="sort-comments">@{_('sort by new')}</a></li>
               @end
             @end
+            @if postmeta.get('lock-comments'):
+              <li><a class="lock-comments">@{_('unlock comments')}</a></li>
+            @else:
+              <li><a class="lock-comments">@{_('lock comments')}</a></li>
+            @end
           @end
           @if post['uid'] != current_user.uid:
           <li><a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a></li>
@@ -309,7 +314,7 @@
   @end
   </div>
 
-  @if current_user.is_authenticated and post['deleted'] == 0 and not current_user.is_subban(sub):
+  @if current_user.is_authenticated and post['deleted'] == 0 and not current_user.is_subban(sub) and not postmeta.get('lock-comments'):
   <form data-reset="true" data-redir="true" action="@{url_for('do.create_comment', pid=post['pid'])}" id="rcomm-0" class="comment-form ajaxform static pure-form">
     @{commentform.csrf_token()!!html}
     @{commentform.post(value=post['pid'])!!html}
@@ -326,6 +331,10 @@
       <div class="cpreview-content"></div>
     </div>
   </form>
+  @elif current_user.is_authenticated and post['deleted'] == 0 and postmeta.get('lock-comments'):
+  <div class="comments-locked">
+    <h4>@{_('This post is closed to new comments.')}</h4>
+  </div>
   @end
 
   @if len(comments) == 0:
@@ -362,7 +371,7 @@
           </li>
         </ul>
       </div>
-      @{pcomm.renderComments(post, subInfo, subMods, comments, highlight, sort)!!html}
+      @{pcomm.renderComments(post, postmeta, subInfo, subMods, comments, highlight, sort)!!html}
     </div>
   @end
 

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -1,5 +1,5 @@
-@require(post, comments, subInfo, subMods, highlight, sort)
-@def renderComments(post, subInfo, subMods, comments, highlight='', sort='top'):
+@require(post, postmeta, comments, subInfo, subMods, highlight, sort)
+@def renderComments(post, postmeta, subInfo, subMods, comments, highlight='', sort='top'):
   @#ignore
   @for comment in comments:
     @if comment['cid']:
@@ -79,7 +79,7 @@
               <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
             @end
             <ul class="bottombar links @{(comment['visibility'] != '') and 'hidden' or ''}">
-              @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']):
+              @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']) and not postmeta.get('lock-comments'):
                 <li><a class="reply-comment" data-pid="@{comment['pid']}" data-to="@{comment['cid']}">@{_('reply')}</a></li>
               @end
               <li><a href="@{url_for('sub.view_perm', sub=post['sub'], cid=comment['cid'], pid=post['pid'], slug=post['slug'])}#comment-@{comment['cid']}">@{_('permalink')}</a></li>
@@ -106,7 +106,7 @@
         </div>
         <div id="child-@{comment['cid']}" class="pchild@{(comment['visibility'] != '') and ' hidden' or ''}">
           @if comment['children']:
-            @{renderComments(post, subInfo, subMods, comment['children'], highlight)!!html}
+            @{renderComments(post, postmeta, subInfo, subMods, comment['children'], highlight)!!html}
           @end
         </div>
       </article>
@@ -122,4 +122,4 @@
   @end
 @end
 
-@{renderComments(post, subInfo, subMods, comments, highlight)!!html}
+@{renderComments(post, postmeta, subInfo, subMods, comments, highlight)!!html}

--- a/app/html/user/messages/notifications.html
+++ b/app/html/user/messages/notifications.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(notifications)
+@require(notifications, postmeta)
 @import 'shared/sidebar/messages.html' as sb
 @def sidebar():
   @{sb.render_sidebar('notifications')!!html}
@@ -92,7 +92,9 @@
             <div class="container">@{markdown(msg['comment_content'])!!html}</div>
             <ul class="bottombar links">
               <li><a href="@{url_for('sub.view_perm', sub=msg['sub_name'], cid=msg['cid'], pid=msg['pid'])}#comment-@{msg['cid']}">@{_('permalink')}</a></li>
-              <li><a class="reply-comment" data-pid="@{msg['pid']}" data-to="@{msg['cid']}">@{_('reply')}</a></li>
+              @if not postmeta[msg['pid']].get('lock-comments') and not msg['archived']:
+                <li><a class="reply-comment" data-pid="@{msg['pid']}" data-to="@{msg['cid']}">@{_('reply')}</a></li>
+              @end
               <li><a class="deletenotif" data-mid="@{msg['id']}">@{_('delete notification')}</a></li>
               <li><a class="block" data-uid="@{msg['senderuid']}">
                 @if msg['ignored']:
@@ -110,7 +112,9 @@
             <div class="container">@{markdown(msg['post_content'])!!html}</div>
             <ul class="bottombar links">
               <li><a href="@{url_for('sub.view_post', sub=msg['sub_name'], pid=msg['pid'])}">@{_('permalink')}</a></li>
-              <li><a class="reply-comment" data-pid="@{msg['pid']}" data-to="-@{msg['pid']}">@{_('reply')}</a></li>
+              @if not postmeta[msg['pid']].get('lock-comments') and not msg['archived']:
+                <li><a class="reply-comment" data-pid="@{msg['pid']}" data-to="-@{msg['pid']}">@{_('reply')}</a></li>
+              @end
               <li><a class="deletenotif" data-mid="@{msg['id']}">@{_('delete notification')}</a></li>
               <li><a class="block" data-uid="@{msg['senderuid']}">
                 @if msg['ignored']:

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1003,6 +1003,10 @@ a.slink {
   display: none;
 }
 
+.comments-locked {
+  margin-left: 1em;
+}
+
 .comments {
   margin-left: 1em;
 }

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -175,6 +175,23 @@ u.addEventForChild(document, 'click', '.sort-comments', function (e, qelem) {
     });
 });
 
+// Lock comments on post.
+u.addEventForChild(document, 'click', '.lock-comments', function (e, qelem) {
+    const parent = qelem.parentNode.parentNode;
+    const pid = qelem.parentNode.parentNode.getAttribute('data-pid'), tg = e.currentTarget;
+    TextConfirm(qelem, function () {
+        u.post('/do/lock_comments/' + pid, {post: document.getElementById('postinfo').getAttribute('pid')},
+            function (data) {
+                if (data.status != "ok") {
+                    alert(data.error);
+                } else {
+                    tg.innerHTML = _('Done');
+                    document.location.reload();
+                }
+            });
+    });
+});
+
 // Wiki post
 u.addEventForChild(document, 'click', '.wiki-post', function (e, qelem) {
     const pid = qelem.parentNode.parentNode.getAttribute('data-pid'), tg = e.currentTarget;

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -54,7 +54,9 @@
                 <!-- TODO needs peewee <li><a href="{# url_for('sub.view_perm', sub=sub.name, cid=comment.cid, pid=post.pid) #}">permalink</a></li>-->
                 <li><a href="{{url_for('sub.view_perm', sub=comment.sub, pid=comment.pid, cid=comment.cid)}}">permalink</a></li>
                 {%if current_user.is_authenticated%}
-                  <li><a class="reply-comment" data-pid="{{comment.pid}}" data-to="{{comment.cid}}">reply</a></li>
+                  {%if not postmeta[comment.pid].get('lock-comments') and not comment.archived %}
+                    <li><a class="reply-comment" data-pid="{{comment.pid}}" data-to="{{comment.cid}}">reply</a></li>
+                  {%endif%}
                   {% if (comment.uid == session['user_id'] or current_user.is_admin()) %}
                     <li><a class="edit-comment" data-cid="{{comment.cid}}">edit</a></li>
                     <li><a class="delete-comment" data-cid="{{comment.cid}}">delete</a></li>

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -16,6 +16,7 @@ from ..socketio import socketio
 from ..misc import ratelimit, POSTING_LIMIT, AUTH_LIMIT, captchas_required
 from ..models import Sub, User, SubPost, SubPostComment, SubMetadata, SubPostCommentVote, SubPostVote, SubSubscriber
 from ..models import SiteMetadata, UserMetadata, Message, SubRule, Notification, SubMod, InviteCode, UserStatus
+from ..models import SubPostMetadata
 from ..caching import cache
 from ..config import config
 
@@ -488,6 +489,10 @@ def create_comment(sub, pid):
 
     if (datetime.datetime.utcnow() - post.posted.replace(tzinfo=None)) > datetime.timedelta(days=config.site.archive_post_after):
         return jsonify(msg="Post is archived"), 403
+
+    postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == pid))
+    if postmeta.get('lock-comments'):
+        return jsonify(msg="Comments are closed on this post."), 403
 
     try:
         SubMetadata.get((SubMetadata.sid == post.sid) & (SubMetadata.key == "ban") & (SubMetadata.value == user.uid))

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -704,6 +704,30 @@ def distinguish():
     return jsonify(status='ok')
 
 
+@do.route("/do/lock_comments/<int:post>", methods=['POST'])
+@login_required
+def toggle_lock_comments(post):
+    """ Allows a mod or admin to lock a post to new comments. """
+    try:
+        post = SubPost.get(SubPost.pid == post)
+    except SubPost.DoesNotExist:
+        return jsonify(status='error', error=_('Post does not exist'))
+
+    if not current_user.is_mod(post.sid_id):
+        abort(403)
+
+    form = DeletePost()
+
+    if form.validate():
+        try:
+            smd = SubPostMetadata.select().where((SubPostMetadata.key == 'lock-comments') &
+                                                 (SubPostMetadata.pid == post.pid)).get()
+            smd.value = '0' if smd.value == '1' else '1'
+            smd.save()
+        except SubPostMetadata.DoesNotExist:
+            smd = SubPostMetadata.create(pid=post.pid, key='lock-comments', value='1')
+
+    return jsonify(status='ok')
 
 
 @do.route("/do/edit_txtpost/<pid>", methods=['POST'])
@@ -769,6 +793,10 @@ def create_comment(pid):
         if (datetime.datetime.utcnow() - post.posted.replace(tzinfo=None)) > datetime.timedelta(days=config.site.archive_post_after):
             return jsonify(status='error', error=[_("Post is archived")]), 400
 
+        postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == pid))
+        if postmeta.get('lock-comments'):
+            return jsonify(status='error', error=[_("Comments are closed on this post.")]), 400
+
         try:
             sub = Sub.get(Sub.sid == post.sid_id)
         except Sub.DoesNotExist:
@@ -832,6 +860,7 @@ def create_comment(pid):
         misc.workWithMentions(form.comment.data, to, post, sub, cid=comment.cid)
         renderedComment = engine.get_template('sub/postcomments.html').render({
             'post': misc.getSinglePost(post.pid),
+            'postmeta': misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == post.pid)),
             'comments': misc.get_comment_tree([{'cid': str(comment.cid), 'parentcid': None}], uid=current_user.uid, include_history=include_history),
             'subInfo': misc.getSubData(sub.sid),
             'subMods': subMods,
@@ -1967,14 +1996,16 @@ def get_sibling(pid, cid, lim):
             return jsonify(status='ok', posts=[])
 
     comments = SubPostComment.select(SubPostComment.cid, SubPostComment.parentcid).where(SubPostComment.pid == pid)
+    postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == post.pid)),
     if sort == "new":
         comments = comments.order_by(SubPostComment.time.desc()).dicts()
     elif sort == "top":
         comments = comments.order_by(SubPostComment.score.desc()).dicts()
 
     if not comments.count():
-        return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': [], 'subInfo': {}, 'highlight': '',
-                                                                    'sort': sort})
+        return engine.get_template('sub/postcomments.html').render(
+            {'post': post, 'postmeta': postmeta,
+             'comments': [], 'subInfo': {}, 'highlight': '', 'sort': sort})
 
     include_history = current_user.is_mod(post['sid'], 1) or current_user.is_admin()
 
@@ -1983,16 +2014,18 @@ def get_sibling(pid, cid, lim):
     elif cid != '0':
         comment_tree = misc.get_comment_tree(comments, cid, provide_context=False, uid=current_user.uid, include_history=include_history)
     else:
-        return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': [], 'subInfo': {}, 'highlight': '',
-                                                                    'sort': sort})
+        return engine.get_template('sub/postcomments.html').render(
+            {'post': post, 'postmeta': postmeta,
+             'comments': [], 'subInfo': {}, 'highlight': '', 'sort': sort})
 
     if len(comment_tree) > 0 and cid != '0':
         comment_tree = comment_tree[0].get('children', [])
     subInfo = misc.getSubData(post['sid'])
     subMods = misc.getSubMods(post['sid'])
 
-    return engine.get_template('sub/postcomments.html').render({'post': post, 'comments': comment_tree, 'subInfo': subInfo, 'subMods': subMods, 'highlight': '',
-                                                                'sort': sort})
+    return engine.get_template('sub/postcomments.html').render(
+        {'post': post, 'postmeta': postmeta,
+         'comments': comment_tree, 'subInfo': subInfo, 'subMods': subMods, 'highlight': '', 'sort': sort})
 
 
 @do.route('/do/preview', methods=['POST'])

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -380,10 +380,10 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
     if post['userstatus'] == 10 and post['deleted'] == 1:
         post['visibility'] = 'none'
 
+    postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == pid))
+
     pollData = {'has_voted': False}
-    postmeta = {}
     if post['ptype'] == 3:
-        postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == pid))
         # poll. grab options and votes.
         options = SubPostPollOption.select(SubPostPollOption.id, SubPostPollOption.text, fn.Count(SubPostPollVote.id).alias('votecount'))
         options = options.join(SubPostPollVote, JOIN.LEFT_OUTER, on=(SubPostPollVote.vid == SubPostPollOption.id))

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -111,7 +111,9 @@ def view_user_comments(user, page):
         abort(404)
 
     comments = misc.getUserComments(user.uid, page)
-    return render_template('usercomments.html', user=user, page=page, comments=comments)
+    postmeta = misc.get_postmeta_dicts((c['pid'] for c in comments))
+    return render_template('usercomments.html', user=user, page=page,
+                           comments=comments, postmeta=postmeta)
 
 @bp.route("/uploads", defaults={'page': 1})
 @bp.route("/uploads/<int:page>")


### PR DESCRIPTION
Add an post option that allows sub mods to lock or unlock comments on that post.  When a post is locked to commenting, replace the comment reply box with a notice that comments are closed, remove the reply link from the post's comments, as well as from the user comment list and from notifications, and refuse to create any new comments at the comment creation endpoints.  

While I was at it I also removed the reply link from archived posts when those show up in a user's comment list or notifications.