### PR TITLE
Allow mods to sticky a comment to the top of the comments

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(post, sub, is_saved, subInfo, pollData, commentform, comments, postmeta, subMods, highlight, content_history, title_history, open_reports, sort, sticky_sort)
+@require(post, sub, is_saved, subInfo, pollData, commentform, comments, postmeta, subMods, highlight, content_history, title_history, open_reports, sort, sticky_sort, stuck_comment)
 @import "sub/postcomments.html" as pcomm
 @import "sub/postpoll.html" as polls
 
@@ -371,7 +371,7 @@
           </li>
         </ul>
       </div>
-      @{pcomm.renderComments(post, postmeta, subInfo, subMods, comments, highlight, sort)!!html}
+      @{pcomm.renderComments(post, postmeta, subInfo, subMods, comments, highlight, sort, stuck_comment)!!html}
     </div>
   @end
 

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -1,123 +1,141 @@
 @require(post, postmeta, comments, subInfo, subMods, highlight, sort)
-@def renderComments(post, postmeta, subInfo, subMods, comments, highlight='', sort='top'):
+
+@def renderComment(post, postmeta, subInfo, subMods, comment, highlight, sort, isSticky):
   @#ignore
-  @for comment in comments:
-    @if comment['cid']:
-      <article id="@{comment['cid']}" data-cid="@{comment['cid']}" class="commentrow @{(comment['cid'] == highlight) and 'highlight ' or ''}@{(comment.get('hl')) and 'active' or ''}@{((comment['visibility'] != '') and (comment['visibility'] != 'none')) and 'deleted ' or ''} text-post no-padding comment @{(comment['distinguish'] == 1) and 'mod' or ''} @{(comment['distinguish'] == 2) and 'admin' or ''}">
-        <div id="comment-@{comment['cid']}">
-          @if comment['userstatus'] != 10:
-            <div class="pull left votecomment">
-                @if comment['visibility'] == '':
-                <div title="@{_('Upvote')}" class="c-upvote @{(comment.get('positive') == True) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
-                <div title="@{_('Downvote')}" class="c-downvote @{(comment.get('positive') == False) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>
-                @end
-            </div>
-          @end
-          <div class="commblock">
-            <div class="commenthead">
-              <a class="togglecomment @{(comment['visibility'] != '') and 'expand' or 'collapse'}" data-cid="@{comment['cid']}">
-                @{(comment['visibility'] != '') and '[+]' or '[–]'} \
-              </a>
-              @if comment['visibility'] == 'none':
-                  <a class="poster deleted">@{_('[Deleted]')}</a>
-              @else:
-                <a href="/u/@{comment['user']}" class="poster">
-                  @{comment['user']}
-                  @if comment['distinguish']:
-                    <span class="speaking-tag">@{(comment['distinguish'] == 1) and _(' [speaking as mod]') or ''} @{(comment['distinguish'] == 2) and _(' [speaking as admin]') or ''}</span>
-                  @end
-                  @if comment['user'] == post['user']:
-                    <span class="op-tag">@{_('[OP]')}</span>
-                  @end
-                </a>
-              @end
-              <b>@{_('<span class="cscore">%(score)i</span> points</b> (+<b>%(upvotes)i</b>|-<b>%(downvotes)i</b>)', score=comment['score'], upvotes=comment['upvotes'], downvotes=comment['downvotes'])!!html}
-              <span class="time ">
-                  <time-ago datetime="@{comment['time'].isoformat()}Z"></time-ago>
-              </span>
-              @if comment['lastedit'] and comment['visibility'] != 'none':
-                <span class="time edited">
-                  @{_('Edited %(timeago)s', timeago='<time-ago datetime="' + comment['lastedit'].isoformat() + 'Z"></time-ago>')!!html}<br/>
-                </span>
-              @end
-            </div>
-
-            <div class="content  @{(comment['visibility'] != '') and 'hidden' or ''}" id="content-@{comment['cid']}">
-              @if comment['visibility'] == 'none':
-                @{_('[Deleted]')} \
-              @elif comment['visibility'] == 'admin-self-del':
-                <p class="helper-text">@{_('[post deleted by user]')}</p>
-                <span class="current history" data-id="0">@{comment['content']!!html}</span>
-              @elif comment['visibility'] == 'mod-self-del':
-                <p class="helper-text">@{_('[post deleted by user]')}</p>
-              @elif comment['visibility'] == 'mod-del':
-                <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
-                <span class="current history" data-id="0">@{comment['content']!!html}</span>
-              @else:
-                <span class="current history" data-id="0">@{comment['content']!!html}</span>
-              @end
-              @if comment['history'] and (comment['visibility'] != 'none' and  comment['visibility'] != 'mod-self-del'):
-                  @for count, history in enumerate(comment['history']):
-                  <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
-                      @{history['content']!!html}
-                  </span>
-                  @end
-                  <div>
-                    <button class="browse-history back" data-action="back">←</button>
-                    <button class="browse-history forward disabled" action="forward">→</button>
-                    <span class="history-meta">
-                      @{_('Viewing edit history:')}
-                        <span class="history-version">
-                          1/@{1 + len(comment['history'])!!s}
-                        </span>
-                    </span>
-                  </div>
-              @end
-            </div>
-
-            @if comment['visibility'] != 'none':
-              <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
-            @end
-            <ul class="bottombar links @{(comment['visibility'] != '') and 'hidden' or ''}">
-              @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']) and not postmeta.get('lock-comments'):
-                <li><a class="reply-comment" data-pid="@{comment['pid']}" data-to="@{comment['cid']}">@{_('reply')}</a></li>
-              @end
-              <li><a href="@{url_for('sub.view_perm', sub=post['sub'], cid=comment['cid'], pid=post['pid'], slug=post['slug'])}#comment-@{comment['cid']}">@{_('permalink')}</a></li>
+  @if comment['cid']:
+    <article id="@{comment['cid']}" data-cid="@{comment['cid']}" class="commentrow @{(comment['cid'] == highlight) and 'highlight ' or ''}@{(comment.get('hl')) and 'active' or ''}@{((comment['visibility'] != '') and (comment['visibility'] != 'none')) and 'deleted ' or ''} text-post no-padding comment @{(comment['distinguish'] == 1) and 'mod' or ''} @{(comment['distinguish'] == 2) and 'admin' or ''}">
+      <div id="comment-@{comment['cid']}">
+        @if comment['userstatus'] != 10:
+          <div class="pull left votecomment">
               @if comment['visibility'] == '':
-                <li><a class="comment-source" data-cid="@{comment['cid']}">@{_('source')}</a></li>
+              <div title="@{_('Upvote')}" class="c-upvote @{(comment.get('positive') == True) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
+              <div title="@{_('Downvote')}" class="c-downvote @{(comment.get('positive') == False) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>
               @end
-              @if current_user.is_authenticated and comment['visibility'] == '' and comment['visibility'] == '' and comment['uid'] != current_user.uid:
-                <a data-ac="report" data-pid="@{comment['pid']}" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
-              @end
-              @if current_user.is_authenticated and comment['visibility'] == '' and comment['uid'] == current_user.uid and comment['visibility'] == '':
-                <li><a class="edit-comment" data-cid="@{comment['cid']}">@{_('edit')}</a></li>
-              @end
-              @if current_user.is_authenticated and comment['visibility'] == '' and (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']) and comment['visibility'] == '':
-                <li><a @{(comment['uid'] == current_user.uid) and 'selfdel="true"' or ''!!html} class="delete-comment" data-cid="@{comment['cid']}">@{_('delete')}</a></li>
-              @end
-              @if (current_user.is_admin() and comment['status'] == 2):
-                <li><a class="undelete-comment" data-cid="@{comment['cid']}">@{_('un-delete')}</a></li>
-              @end
-              @if (current_user.uid == comment['uid'] and (current_user.is_admin() or current_user.uid in subMods['all'])):
-                <li><a class="distinguish" data-cid="@{comment['cid']}">@{comment['distinguish'] and _('undistinguish') or _('distinguish')}</a></li>
-              @end
-            </ul>
           </div>
-        </div>
-        <div id="child-@{comment['cid']}" class="pchild@{(comment['visibility'] != '') and ' hidden' or ''}">
-          @if comment['children']:
-            @{renderComments(post, postmeta, subInfo, subMods, comment['children'], highlight)!!html}
-          @end
-        </div>
-      </article>
-    @else:
-        <a href="#" class="loadsibling" data-pid="@{post['pid']}" data-key="@{comment.get('key', '')}" data-pcid="@{comment['pcid']}" data-sort="@{sort}">
-        @if comment['more'] > 1:
-          @{_('Load more (%(amt)i comments)', amt=comment['more'])}
-        @else:
-          @{_('Load more (1 comment)')}
         @end
-        </a>
+        <div class="commblock">
+          <div class="commenthead">
+            <a class="togglecomment @{(comment['visibility'] != '') and 'expand' or 'collapse'}" data-cid="@{comment['cid']}">
+              @{(comment['visibility'] != '') and '[+]' or '[–]'} \
+            </a>
+            @if comment['visibility'] == 'none':
+                <a class="poster deleted">@{_('[Deleted]')}</a>
+            @else:
+              <a href="/u/@{comment['user']}" class="poster">
+                @{comment['user']}
+                @if comment['distinguish']:
+                  <span class="speaking-tag">@{(comment['distinguish'] == 1) and _(' [speaking as mod]') or ''} @{(comment['distinguish'] == 2) and _(' [speaking as admin]') or ''}</span>
+                @end
+                @if comment['user'] == post['user']:
+                  <span class="op-tag">@{_('[OP]')}</span>
+                @end
+              </a>
+            @end
+            <b>@{_('<span class="cscore">%(score)i</span> points</b> (+<b>%(upvotes)i</b>|-<b>%(downvotes)i</b>)', score=comment['score'], upvotes=comment['upvotes'], downvotes=comment['downvotes'])!!html}
+            <span class="time ">
+                <time-ago datetime="@{comment['time'].isoformat()}Z"></time-ago>
+            </span>
+            @if comment['lastedit'] and comment['visibility'] != 'none':
+              <span class="time edited">
+                @{_('Edited %(timeago)s', timeago='<time-ago datetime="' + comment['lastedit'].isoformat() + 'Z"></time-ago>')!!html}
+              </span>
+            @end
+            @if isSticky:
+              - <span class="stick">sticky</span>
+            @end
+            <br/>
+          </div>
+
+          <div class="content  @{(comment['visibility'] != '') and 'hidden' or ''}" id="content-@{comment['cid']}">
+            @if comment['visibility'] == 'none':
+              @{_('[Deleted]')} \
+            @elif comment['visibility'] == 'admin-self-del':
+              <p class="helper-text">@{_('[post deleted by user]')}</p>
+              <span class="current history" data-id="0">@{comment['content']!!html}</span>
+            @elif comment['visibility'] == 'mod-self-del':
+              <p class="helper-text">@{_('[post deleted by user]')}</p>
+            @elif comment['visibility'] == 'mod-del':
+              <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
+              <span class="current history" data-id="0">@{comment['content']!!html}</span>
+            @else:
+              <span class="current history" data-id="0">@{comment['content']!!html}</span>
+            @end
+            @if comment['history'] and (comment['visibility'] != 'none' and  comment['visibility'] != 'mod-self-del'):
+                @for count, history in enumerate(comment['history']):
+                <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
+                    @{history['content']!!html}
+                </span>
+                @end
+                <div>
+                  <button class="browse-history back" data-action="back">←</button>
+                  <button class="browse-history forward disabled" action="forward">→</button>
+                  <span class="history-meta">
+                    @{_('Viewing edit history:')}
+                      <span class="history-version">
+                        1/@{1 + len(comment['history'])!!s}
+                      </span>
+                  </span>
+                </div>
+            @end
+          </div>
+
+          @if comment['visibility'] != 'none':
+            <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
+          @end
+          <ul class="bottombar links @{(comment['visibility'] != '') and 'hidden' or ''}">
+            @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']) and not postmeta.get('lock-comments'):
+              <li><a class="reply-comment" data-pid="@{comment['pid']}" data-to="@{comment['cid']}">@{_('reply')}</a></li>
+            @end
+            <li><a href="@{url_for('sub.view_perm', sub=post['sub'], cid=comment['cid'], pid=post['pid'], slug=post['slug'])}#comment-@{comment['cid']}">@{_('permalink')}</a></li>
+            @if comment['visibility'] == '':
+              <li><a class="comment-source" data-cid="@{comment['cid']}">@{_('source')}</a></li>
+            @end
+            @if current_user.is_authenticated and comment['visibility'] == '' and comment['visibility'] == '' and comment['uid'] != current_user.uid:
+              <a data-ac="report" data-pid="@{comment['pid']}" cid="@{comment['cid']}" class="report-comment">@{_('report')}</a>
+            @end
+            @if current_user.is_authenticated and comment['visibility'] == '' and comment['uid'] == current_user.uid and comment['visibility'] == '':
+              <li><a class="edit-comment" data-cid="@{comment['cid']}">@{_('edit')}</a></li>
+            @end
+            @if current_user.is_authenticated and comment['visibility'] == '' and (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']) and comment['visibility'] == '':
+              <li><a @{(comment['uid'] == current_user.uid) and 'selfdel="true"' or ''!!html} class="delete-comment" data-cid="@{comment['cid']}">@{_('delete')}</a></li>
+            @end
+            @if (current_user.is_admin() and comment['status'] == 2):
+              <li><a class="undelete-comment" data-cid="@{comment['cid']}">@{_('un-delete')}</a></li>
+            @end
+            @if (current_user.uid == comment['uid'] and (current_user.is_admin() or current_user.uid in subMods['all'])):
+              <li><a class="distinguish" data-cid="@{comment['cid']}">@{comment['distinguish'] and _('undistinguish') or _('distinguish')}</a></li>
+            @end
+            @if (comment['parentcid'] is None and current_user.uid in subMods['all'] and current_user.uid == comment['uid']):
+              <li><a class="stick-comment" data-cid="@{comment['cid']}">@{isSticky and _('unstick') or _('make sticky')}</a></li>
+            @end
+          </ul>
+        </div>
+      </div>
+      <div id="child-@{comment['cid']}" class="pchild@{(comment['visibility'] != '') and ' hidden' or ''}">
+        @if comment['children']:
+          @{renderComments(post, postmeta, subInfo, subMods, comment['children'], highlight)!!html}
+        @end
+      </div>
+    </article>
+  @else:
+      <a href="#" class="loadsibling" data-pid="@{post['pid']}" data-key="@{comment.get('key', '')}" data-pcid="@{comment['pcid']}" data-sort="@{sort}">
+      @if comment['more'] > 1:
+        @{_('Load more (%(amt)i comments)', amt=comment['more'])}
+      @else:
+        @{_('Load more (1 comment)')}
+      @end
+      </a>
+  @end
+@end
+
+@def renderComments(post, postmeta, subInfo, subMods, comments, highlight='', sort='top', stuck_comment=None):
+  @#ignore
+  @if stuck_comment is not None:
+    @{renderComment(post, postmeta, subInfo, subMods, stuck_comment, highlight, sort, True)!!html}
+  @end
+  @for comment in comments:
+    @if comment is not stuck_comment:
+      @{renderComment(post, postmeta, subInfo, subMods, comment, highlight, sort, False)!!html}
     @end
   @end
 @end

--- a/app/misc.py
+++ b/app/misc.py
@@ -1568,7 +1568,7 @@ def get_comment_tree(comments, root=None, only_after=None, uid=None, provide_con
     # 4 - Populate the tree (get all the data and cram it into the tree)
     expcomms = SubPostComment.select(SubPostComment.cid, SubPostComment.content, SubPostComment.lastedit,
                                      SubPostComment.score, SubPostComment.status, SubPostComment.time,
-                                     SubPostComment.pid, SubPostComment.distinguish,
+                                     SubPostComment.pid, SubPostComment.distinguish, SubPostComment.parentcid,
                                      User.name.alias('user'), *(
             [SubPostCommentVote.positive, SubPostComment.uid] if uid else [SubPostComment.uid]),  # silly hack
                                      User.status.alias('userstatus'), SubPostComment.upvotes, SubPostComment.downvotes)

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -158,6 +158,19 @@ u.addEventForChild(document, 'click', '.stick-post', function (e, qelem) {
     });
 });
 
+// Stick comment
+u.addEventForChild(document, 'click', '.stick-comment', function (e, qelem) {
+    u.post('/do/stick_comment/' + qelem.getAttribute('data-cid'),
+           {post: document.getElementById('postinfo').getAttribute('pid')},
+           function (data) {
+               if (data.status != "ok") {
+                   qelem.innerHTML = data.error;
+               } else {
+                   document.location.reload();
+               }
+           });
+})
+
 // Sticky post default comment sort
 u.addEventForChild(document, 'click', '.sort-comments', function (e, qelem) {
     const parent = qelem.parentNode.parentNode;

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -307,14 +307,11 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
 
     sub = Sub.select().where(fn.Lower(Sub.name) == sub.lower()).dicts().get()
     subInfo = misc.getSubData(sub['sid'])
+    postmeta = misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == pid))
 
     sticky_sort = 'top'
     if str(pid) in subInfo['sticky']:
-        try:
-            sticky_sort = SubPostMetadata.select().where((SubPostMetadata.key == 'sort') &
-                                                          (SubPostMetadata.pid == pid)).get().value
-        except SubPostMetadata.DoesNotExist:
-            pass
+        sticky_sort = postmeta.get('sort', sticky_sort)
 
     if sort is None:
         sort = sticky_sort
@@ -333,6 +330,7 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
     except UserSaved.DoesNotExist:
         is_saved = False
 
+    stuck_comment = None
     if not comments:
         comments = SubPostComment.select(SubPostComment.cid, SubPostComment.parentcid).where(SubPostComment.pid == post['pid'])
         if sort == "new":
@@ -345,6 +343,9 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
             comments = []
         else:
             comments = misc.get_comment_tree(comments, uid=current_user.uid, include_history=include_history)
+            stuck_comment = postmeta.get('sticky_cid')
+            if stuck_comment is not None:
+                stuck_comment = next((com for com in comments if com['cid'] == stuck_comment))
 
     if config.site.edit_history and include_history:
         try:
@@ -416,7 +417,7 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
                                                         'comments': comments,'subMods': subMods, 'highlight': highlight,
                                                         'content_history': content_history, 'title_history': title_history,
                                                         'open_reports': open_reports, 'sort': sort,
-                                                        'sticky_sort': sticky_sort})
+                                                        'sticky_sort': sticky_sort, 'stuck_comment': stuck_comment})
 
 
 @blueprint.route("/<sub>/<int:pid>/_/<cid>", defaults={'slug': '_'})


### PR DESCRIPTION
Allow a mod to place a comment at the top of the list of comments for a post, to explain why comments are locked (#253) or to set expectations for the discussion.  Mods can only stick their own comments to the top of the list, and the comment will automatically be marked as distinguished with the "speaking as mod" tag (though it doesn't stop them from un-distinguishing it afterwards if they choose.)  Only one comment can be stuck to the top at a time and a new stuck comment will unstick an older one.

When someone makes a new comment on a post that has a sticky comment, it will be inserted before the sticky comment.  This is odd but not that much odder than what we already do (inserting new comments at the beginning when after a refresh they will appear at the end), and the alternative of inserting the new comment after the sticky comment might place the new one out of view if the sticky comment is long or has many replies.