### PR TITLE
Unstick sticky posts when they are deleted

### DIFF
--- a/app/views/do.py
+++ b/app/views/do.py
@@ -249,6 +249,16 @@ def delete_post():
         except SiteMetadata.DoesNotExist:
             pass
 
+        # Check if the post is sticky.  Unstick if so.
+        try:
+            is_sticky = SubMetadata.get((SubMetadata.sid == post.sid_id) & (SubMetadata.key == 'sticky') &
+                                        (SubMetadata.value == post.pid))
+            is_sticky.delete_instance()
+            misc.create_sublog(misc.LOG_TYPE_SUB_STICKY_DEL, current_user.uid, post.sid,
+                               link=url_for('sub.view_post', sub=post.sid.name, pid=post.pid))
+        except SubMetadata.DoesNotExist:
+            pass
+
         Sub.update(posts=Sub.posts - 1).where(Sub.sid == post.sid).execute()
 
         post.deleted = deletion

--- a/migrations/024_unstick_deleted_posts.py
+++ b/migrations/024_unstick_deleted_posts.py
@@ -1,0 +1,33 @@
+"""Peewee migrations -- 024_unstick_deleted_posts.py.
+
+Remove 'sticky' metadata from deleted posts.
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+
+    SubMetadata = migrator.orm['sub_metadata']
+    SubPost = migrator.orm['sub_post']
+
+    if not fake:
+        sticky = (SubMetadata.select()
+                  .join(SubPost, pw.JOIN.LEFT_OUTER, on=(SubPost.pid == SubMetadata.value.cast('int')))
+                  .where((SubMetadata.key == 'sticky') & (SubPost.deleted != 0)))
+        SubMetadata.delete().where(SubMetadata.xid << [smd.xid for smd in sticky]).execute()
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    pass


### PR DESCRIPTION
If a mod deleted a sticky post, the post would remain sticky even though deleted, and count against the sub's limit of 3 sticky posts.  Fix this by unsticking sticky posts when they are deleted, and add a migration to look for sticky deleted posts and unstick them.