### PR TITLE
Add front_page_submit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ thumbs
 
 manifest.json
 node_modules/
+node_modules
 package-lock.json
 
 # vscode settings

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,7 @@ cfg_defaults = {  # key => default value
             "enable_chat": True,
             "sitelog_public": True,
             "force_sublog_public": True,
+            "front_page_submit": True,
 
             "changelog_sub": None,
             "btc_address": None,

--- a/app/html/shared/sidebar/home.html
+++ b/app/html/shared/sidebar/home.html
@@ -5,8 +5,10 @@
 </form>
 
 @if current_user.is_authenticated:
+@if config['site'].front_page_submit:
 <a href="@{url_for('subs.submit', ptype='link', sub='')}" class="sbm-post pure-button">@{_('Submit a post')}</a>
 <hr>
+@end
 <a href="@{url_for('home.view_subs')}" class="sbm-post pure-button">@{_('View all subs')}</a>
 <a href="@{url_for('subs.random_sub')}" class="sbm-post pure-button">@{_('Go to random sub')}</a>
 @end


### PR DESCRIPTION
This allows you to turn off the front page submit button in the case
that your moderators are complaining about people not posting to the
right places, or not reading the rules before they post.