### PR TITLE
Fix the error handling in view_comment_inbox

### DIFF
--- a/app/views/site.py
+++ b/app/views/site.py
@@ -56,7 +56,7 @@ def view_comment_inbox(cid):
     """ Gets route to post from just cid """
     try:
         comm = SubPostComment.get(SubPostComment.cid == cid)
-    except SubPost.DoesNotExist:
+    except SubPostComment.DoesNotExist:
         return abort(404)
     return redirect(url_for('sub.view_perm', sub=comm.pid.sid.name, pid=comm.pid_id, cid=comm.cid))
 


### PR DESCRIPTION
Navigating to `/c/not-a-valid-cid` results in a 500, due to some copypasta.  Fix it to give a 404 instead.