### PR TITLE
Stop querying the database for every comment in get_comment_tree

### DIFF
--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -457,7 +457,7 @@ def get_post_comments(sub, pid):
     if not comments.count():
         return jsonify(comments=[])
 
-    comment_tree = misc.get_comment_tree(post.pid, comments, uid=current_user)
+    comment_tree = misc.get_comment_tree(post.pid, post.sid.get_id(), comments, uid=current_user)
     return jsonify(comments=comment_tree)
 
 
@@ -681,9 +681,9 @@ def get_post_comment_children(sub, pid, cid):
     if lim:
         if cid == '0':
             cid = None
-        comment_tree = misc.get_comment_tree(pid, comments, cid, lim)
+        comment_tree = misc.get_comment_tree(pid, post.sid.get_id(), comments, cid, lim)
     elif cid != '0':
-        comment_tree = misc.get_comment_tree(pid, comments, cid)
+        comment_tree = misc.get_comment_tree(pid, post.sid.get_id(), comments, cid)
     else:
         return jsonify(msg='Illegal comment id'), 400
     return jsonify(comments=comment_tree)

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -871,7 +871,7 @@ def create_comment(pid):
         renderedComment = engine.get_template('sub/postcomments.html').render({
             'post': misc.getSinglePost(post.pid),
             'postmeta': misc.metadata_to_dict(SubPostMetadata.select().where(SubPostMetadata.pid == post.pid)),
-            'comments': misc.get_comment_tree(post.pid, [{'cid': str(comment.cid), 'parentcid': None}], uid=current_user.uid, include_history=include_history),
+            'comments': misc.get_comment_tree(post.pid, sub.sid, [{'cid': str(comment.cid), 'parentcid': None}], uid=current_user.uid, include_history=include_history),
             'subInfo': misc.getSubData(sub.sid),
             'subMods': subMods,
             'highlight': str(comment.cid),
@@ -2059,10 +2059,10 @@ def get_sibling(pid, cid, lim):
     include_history = current_user.is_mod(post['sid'], 1) or current_user.is_admin()
 
     if lim:
-        comment_tree = misc.get_comment_tree(pid, comments, cid if cid != '0' else None, lim, provide_context=False,
+        comment_tree = misc.get_comment_tree(pid, post['sid'], comments, cid if cid != '0' else None, lim, provide_context=False,
                                              uid=current_user.uid, include_history=include_history, postmeta=postmeta)
     elif cid != '0':
-        comment_tree = misc.get_comment_tree(pid, comments, cid, provide_context=False, uid=current_user.uid,
+        comment_tree = misc.get_comment_tree(pid, post['sid'], comments, cid, provide_context=False, uid=current_user.uid,
                                              include_history=include_history, postmeta=postmeta)
     else:
         return engine.get_template('sub/postcomments.html').render(

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -341,7 +341,7 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
         if not comments.count():
             comments = []
         else:
-            comments = misc.get_comment_tree(post['pid'], comments, uid=current_user.uid,
+            comments = misc.get_comment_tree(post['pid'], sub['sid'], comments, uid=current_user.uid,
                                              include_history=include_history, postmeta=postmeta)
 
     if config.site.edit_history and include_history:
@@ -433,5 +433,5 @@ def view_perm(sub, pid, slug, cid):
     include_history = current_user.is_mod(sub['sid'], 1) or current_user.is_admin()
 
     comments = SubPostComment.select(SubPostComment.cid, SubPostComment.parentcid).where(SubPostComment.pid == pid).order_by(SubPostComment.score.desc()).dicts()
-    comment_tree = misc.get_comment_tree(pid, comments, cid, uid=current_user.uid, include_history=include_history)
+    comment_tree = misc.get_comment_tree(pid, sub['sid'], comments, cid, uid=current_user.uid, include_history=include_history)
     return view_post(sub['name'], pid, slug, comment_tree, cid)


### PR DESCRIPTION
I noticed that one of our posts with a deeply nested discussion in the comments was reporting 154 queries to construct the response to `view_post`, which seemed excessive.  I tracked it down to a query added by #75 to the loop in `get_comment_tree`.  The query is called for every comment in the tree, and its only purpose is to get the `sid`, and since all the callers of `get_comment_tree` already know the `sid`, I was able to add it as a new argument and remove the query entirely.