### PR TITLE
Stop Werkzeug from using the wrong url scheme in Location headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from flask_webpack import Webpack
 from flask_babel import Babel, _
 from wheezy.html.utils import escape_html
 from werkzeug.middleware.proxy_fix import ProxyFix
+from werkzeug.wrappers import BaseResponse
 
 from .config import Config, config
 from .forms import LoginForm, LogOutForm, CreateSubForm
@@ -123,6 +124,11 @@ def create_app(config=Config('config.yaml')):
 
     if config.site.trusted_proxy_count != 0:
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=config.site.trusted_proxy_count)
+
+    # Don't let Werkzeug make the Location header into a full URL, because relative
+    # paths are legal in Location and because Werkzeug gets it wrong if the app is
+    # behind a load balancer which terminates SSL.
+    BaseResponse.autocorrect_location_header = False
 
     @app.before_request
     def before_request():


### PR DESCRIPTION
A Chrome update this week started giving our users warnings saying "The information you are about to submit is not secure" when they did something that caused the browser to make a POST request.  It turned out that Chrome was complaining about the redirect following the POST being http instead of https.  Our code creates a relative `Location` header for the redirect ([which is permissable according to RFC 7231](https://tools.ietf.org/html/rfc7231#section-7.1.2)) and then Werkzeug "helpfully" makes an absolute url out of it using the url scheme that Werkzeug sees, which is http instead of https if you run the app behind nginx or a load balancer.

Werkzeug has several settings to control the behavior of responses, including one to turn off rewriting the `Location` header, and doing that fixed the Chrome warning.