### PR TITLE
Raise the character limit for a sub post to 65,535

### DIFF
--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -111,7 +111,7 @@ class CreateSubPostForm(FlaskForm):
     """ Sub content submission form """
     sub = StringField(_l('Sub'), validators=[DataRequired(), Length(min=2, max=32)])
     title = StringField(_l('Post title'), validators=[DataRequired(), Length(min=3, max=255)])
-    content = TextAreaField(_l('Post content'), validators=[Length(max=16384)])
+    content = TextAreaField(_l('Post content'), validators=[Length(max=65535)])
     link = StringField(_l('Post link'), validators=[Length(min=10, max=255), Optional(), URL(require_tld=True)])
     ptype = RadioField(_l('Post type'),
                        choices=[('link', _l('Link post')), ('text', _l('Text post')),
@@ -129,7 +129,7 @@ class CreateSubPostForm(FlaskForm):
 
 class EditSubTextPostForm(FlaskForm):
     """ Sub content edit form """
-    content = TextAreaField(_l('Post content'), validators=[DataRequired(), Length(min=1, max=16384)])
+    content = TextAreaField(_l('Post content'), validators=[DataRequired(), Length(min=1, max=65535)])
 
 
 class EditSubLinkPostForm(FlaskForm):


### PR DESCRIPTION
We have some subs where they want to be able to post long essays, and the current size limit for posts is 16,384 characters, which is smaller than Reddit's limit of 40,000 and therefore too small.  Raise it to 65,535 characters which is the maximum permitted in a MySQL text field (Postgres and SQLite allow a gigabyte).