### PR TITLE
Allow users to see their own deleted content

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -97,7 +97,7 @@
             <a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
               @if (post['visibility'] == ''):
                 @{post['title']}
-              @elif (post['visibility'] == 'admin-self-del'):
+              @elif (post['visibility'] == 'admin-self-del') or (post['visibility'] == 'user-self-del'):
                 @{_('[Deleted by User]')} @{post['title']}
               @elif (post['visibility'] == 'mod-self-del'):
                 @{_('[Deleted by User]')}
@@ -116,8 +116,8 @@
             <a rel="nofollow ugc @{(post['visibility'] == 'none') and 'noopener ' or ''}" href="@{(post['visibility'] != 'none') and post['link'] or '#'}" class="title">
               @if (post['visibility'] == ''):
                 @{post['title']}
-              @elif (post['visibility'] == 'admin-self-del'):
-              @{_('[Deleted by User]')} @{post['title']}
+              @elif (post['visibility'] == 'admin-self-del') or (post['visibility'] == 'user-self-del'):
+                @{_('[Deleted by User]')} @{post['title']}
               @elif (post['visibility'] == 'mod-self-del'):
                 @{_('[Deleted by User]')}
               @elif (post['visibility'] == 'mod-del'):
@@ -273,7 +273,7 @@
     </div>
   @end
 
-  @if (post['ptype'] == 3) and (post['deleted'] == 0 or post['visibility'] == 'admin-self-del' or post['visibility'] == 'mod-del'):
+  @if (post['ptype'] == 3) and (post['deleted'] == 0 or post['visibility'] == 'admin-self-del' or post['visibility'] == 'mod-del' or post['visibility'] == 'user-self-del'):
     @{polls.renderPoll(pollData, postmeta, post)!!html}
   @end
   <div>
@@ -289,7 +289,7 @@
         <div id="postcontent" class="post-content-container @{(post['visibility'] == 'mod-self-del') and 'deleted ' or ''}">
           @{_('[deleted]')}
         </div>
-      @elif ((post['visibility'] == 'admin-self-del') or (post['visibility'] == 'mod-del')):
+      @elif ((post['visibility'] == 'admin-self-del') or (post['visibility'] == 'mod-del') or (post['visibility'] == 'user-self-del')):
         <span class="current history" data-id="0">
           <div id="postcontent" class="post-content-container deleted">@{markdown(post['content'])!!html}</div>
         </span>

--- a/app/misc.py
+++ b/app/misc.py
@@ -969,7 +969,7 @@ def postListQueryBase(
     nofilter=False,
     noAllFilter=False,
     noDetail=False,
-    adminDetail=False,
+    include_deleted_posts=False,
     isSubMod=False,
 ):
     reports = (
@@ -1067,7 +1067,7 @@ def postListQueryBase(
             on=((SubUserFlair.sub == Sub.sid) & (SubUserFlair.user == SubPost.uid)),
         )
     )
-    if not adminDetail:
+    if not include_deleted_posts:
         posts = posts.where(SubPost.deleted == 0)
     if not noAllFilter and not nofilter:
         if current_user.is_authenticated and current_user.blocksid:
@@ -1551,35 +1551,33 @@ def getMsgPostReplies(page):
 # user comments
 
 
-def getUserComments(uid, page):
+def getUserComments(uid, page, include_deleted_comments=False):
     """ Returns comments for a user """
     try:
-        com = SubPostComment.select(
-            Sub.name.alias("sub"),
-            SubPost.title,
-            SubPostComment.cid,
-            SubPostComment.pid,
-            SubPostComment.uid,
-            SubPostComment.time,
-            SubPostComment.lastedit,
-            SubPostComment.content,
-            SubPostComment.status,
-            SubPostComment.score,
-            SubPostComment.parentcid,
-            SubPost.posted,
-        )
         com = (
-            com.join(SubPost)
+            SubPostComment.select(
+                Sub.name.alias("sub"),
+                SubPost.title,
+                SubPostComment.cid,
+                SubPostComment.pid,
+                SubPostComment.uid,
+                SubPostComment.time,
+                SubPostComment.lastedit,
+                SubPostComment.content,
+                SubPostComment.status,
+                SubPostComment.score,
+                SubPostComment.parentcid,
+                SubPost.posted,
+            )
+            .join(SubPost)
             .switch(SubPostComment)
             .join(Sub, on=(Sub.sid == SubPost.sid))
+            .where(SubPostComment.uid == uid)
         )
-        com = (
-            com.where(SubPostComment.uid == uid)
-            .where(SubPostComment.status.is_null())
-            .order_by(SubPostComment.time.desc())
-            .paginate(page, 20)
-            .dicts()
-        )
+        if not include_deleted_comments:
+            com = com.where(SubPostComment.status.is_null())
+
+        com = com.order_by(SubPostComment.time.desc()).paginate(page, 20).dicts()
     except SubPostComment.DoesNotExist:
         return False
 

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2197,7 +2197,7 @@ table td {
 
 /* admin */
 
-tr.deletedrow, .deletedpost {
+tr.deletedrow, .deletedpost, .deletedcomment {
   background: hsla(0, 100%, 51%, 0.2)!important;
 }
 

--- a/app/templates/indexpost.html
+++ b/app/templates/indexpost.html
@@ -35,10 +35,25 @@
         {%endif%}
         {% if post.flair %}<span class="postflair">{{post.flair}}</span>{% endif %}
         {% if post.link == None %}
-          <a href="{{url_for('sub.view_post', sub=post.sub, pid=post.pid)}}" class="title">{{post.title}}</a>
+          <a href="{{url_for('sub.view_post', sub=post.sub, pid=post.pid)}}" class="title">
+          {% if post.deleted == 1 %}
+            {{_('[Deleted by User]')}}
+          {% elif post.deleted == 2 %}
+            {{_('[Deleted by Mod or Admin]')}}
+          {% endif %}
+          {{post.title}}
+        </a>
         {% else %}
           {% if post.link.startswith('http:') %}<span title="not https" class="p-icon" data-icon="exclaim"></span>{% endif %}
-          <a rel="noopener nofollow ugc" href="{{post.link}}" class="title">{{post.title}}</a> <a href="{{url_for('home.all_domain_new', domain=func.getDomain(post.link), page=1)}}" class="domain">({{func.getDomain(post.link)}})</a>
+          <a rel="noopener nofollow ugc" href="{{post.link}}" class="title">
+            {% if post.deleted == 1 %}
+              {{_('[Deleted by User]')}}
+            {% elif post.deleted == 2 %}
+              {{_('[Deleted by Mod or Admin]')}}
+            {% endif %}
+            {{post.title}}
+          </a>
+          <a href="{{url_for('home.all_domain_new', domain=func.getDomain(post.link), page=1)}}" class="domain">({{func.getDomain(post.link)}})</a>
         {% endif %}
       </div>
       <div class="author">

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -30,9 +30,16 @@
             </p>
             {% else %}
             {% for comment in comments %}
-            <article id="{{comment.cid}}" data-cid="{{comment.cid}}" class="text-post no-padding comment usercomments">
+            <article id="{{comment.cid}}" data-cid="{{comment.cid}}" class="text-post no-padding comment usercomments {% if comment.status %}deletedcomment{% endif %}">
               <div class="commtitle">
-                <span class="title"><a href="{{ url_for('sub.view_post', sub=comment.sub, pid=comment.pid) }}">{{comment.title}}</a></span>
+                <span class="title"><a href="{{ url_for('sub.view_post', sub=comment.sub, pid=comment.pid) }}">
+                  {% if comment.status == 1 %}
+                    {{_('[Deleted by User]')}}
+                  {% elif comment.status == 2 %}
+                    {{_('[Deleted by Mod or Admin]')}}
+                  {% endif %}
+                  {{comment.title}}
+                </a></span>
                 in <a href="{{ url_for('sub.view_sub', sub=comment.sub) }}">{{comment.sub}}</a>
               </div>
               <div class="commentrow {%if comment.cid == highlight %}highlight{%endif%}" id="comment-{{comment.cid}}">

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -590,7 +590,9 @@ def posts(page):
     if not current_user.is_admin():
         abort(404)
     posts = (
-        misc.getPostList(misc.postListQueryBase(adminDetail=True), "new", page)
+        misc.getPostList(
+            misc.postListQueryBase(include_deleted_posts=True), "new", page
+        )
         .paginate(page, 50)
         .dicts()
     )

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -985,14 +985,20 @@ def get_txtpost(pid):
 
     post["visibility"] = ""
     if post["deleted"] == 1:
-        if current_user.is_admin():
+        if current_user.uid == post["uid"]:
+            post["visibility"] = "user-self-del"
+        elif current_user.is_admin():
             post["visibility"] = "admin-self-del"
         elif current_user.is_mod(post["sid"], 1):
             post["visibility"] = "mod-self-del"
         else:
             post["visibility"] = "none"
     elif post["deleted"] == 2:
-        if current_user.is_admin() or current_user.is_mod(post["sid"], 1):
+        if (
+            current_user.is_admin()
+            or current_user.is_mod(post["sid"], 1)
+            or current_user.uid == post[""]
+        ):
             post["visibility"] = "mod-del"
         else:
             post["visibility"] = "none"

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -582,14 +582,20 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
 
     post["visibility"] = ""
     if post["deleted"] == 1:
-        if current_user.is_admin():
+        if current_user.uid == post["uid"]:
+            post["visibility"] = "user-self-del"
+        elif current_user.is_admin():
             post["visibility"] = "admin-self-del"
         elif current_user.is_mod(sub["sid"], 1):
             post["visibility"] = "mod-self-del"
         else:
             post["visibility"] = "none"
     elif post["deleted"] == 2:
-        if current_user.is_admin() or current_user.is_mod(sub["sid"], 1):
+        if (
+            current_user.is_admin()
+            or current_user.is_mod(sub["sid"], 1)
+            or current_user.uid == post["uid"]
+        ):
             post["visibility"] = "mod-del"
         else:
             post["visibility"] = "none"

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -103,13 +103,17 @@ def view_user_posts(user, page):
 
     if current_user.is_admin():
         posts = misc.getPostList(
-            misc.postListQueryBase(adminDetail=True).where(User.uid == user.uid),
+            misc.postListQueryBase(include_deleted_posts=True).where(
+                User.uid == user.uid
+            ),
             "new",
             page,
         ).dicts()
     else:
         posts = misc.getPostList(
-            misc.postListQueryBase(noAllFilter=True).where(User.uid == user.uid),
+            misc.postListQueryBase(
+                include_deleted_posts=(user.uid == current_user.uid), noAllFilter=True
+            ).where(User.uid == user.uid),
             "new",
             page,
         ).dicts()
@@ -157,7 +161,9 @@ def view_user_comments(user, page):
     if user.status == 10:
         abort(404)
 
-    comments = misc.getUserComments(user.uid, page)
+    comments = misc.getUserComments(
+        user.uid, page, include_deleted_comments=(user.uid == current_user.uid)
+    )
     postmeta = misc.get_postmeta_dicts((c["pid"] for c in comments))
     return render_template(
         "usercomments.html", user=user, page=page, comments=comments, postmeta=postmeta


### PR DESCRIPTION
Show deleted posts and comments in `/u/<user>/posts` and `/u/<user>/comments` when the user is viewing their own posts or comments.  When a user is viewing one of their own deleted posts in single-post view, show the title and content.

Resolves #295.