### PR TITLE
Add an admin option to hide invite code relationships from users

### DIFF
--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -62,6 +62,9 @@ class UseInviteCodeForm(FlaskForm):
     """ Enable/Use an invite code to register """
 
     enableinvitecode = BooleanField(_l("Enable invite code to register"))
+    invitations_visible_to_users = BooleanField(
+        _l("Allow users to see who they invited and who invited them")
+    )
     minlevel = IntegerField(_l("Minimum level to create invite codes"))
     maxcodes = IntegerField(_l("Max amount of invites per user"))
 

--- a/app/misc.py
+++ b/app/misc.py
@@ -581,6 +581,16 @@ def enableInviteCode():
         return False
 
 
+@cache.memoize(600)
+def user_visible_invitations():
+    """ Returns True if users can see who they invited and who invited them. """
+    try:
+        xm = SiteMetadata.get(SiteMetadata.key == "invitations_visible_to_users")
+        return False if xm.value == "0" else True
+    except SiteMetadata.DoesNotExist:
+        return False
+
+
 @cache.memoize(30)
 def getMaxCodes(uid):
     """ Returns how many invite codes a user can create """
@@ -607,6 +617,12 @@ def getInviteCodeInfo(uid):
     Returns information about who invited a user and who they have invited.
     """
     info = {}
+
+    if not (
+        current_user.is_admin()
+        or (user_visible_invitations() and current_user.uid == uid)
+    ):
+        return info
 
     # The invite code that this user used to sign up
     try:

--- a/app/templates/admin/invitecodes.html
+++ b/app/templates/admin/invitecodes.html
@@ -25,6 +25,9 @@
                 <label for="enableinvitecode" class="pure-checkbox">
                   {{useinvitecodeform.enableinvitecode(checked=func.enableInviteCode())}} {{useinvitecodeform.enableinvitecode.label.text}}
                 </label>
+                <label for="invitations_visible_to_users" class="pure-checkbox">
+                  {{useinvitecodeform.invitations_visible_to_users(checked=func.user_visible_invitations())}} {{useinvitecodeform.invitations_visible_to_users.label.text}}
+                </label>
                 <div class="pure-control-group">
                     <label for="confirm">{{useinvitecodeform.minlevel.label.text}}</label>
                     {{useinvitecodeform.minlevel(autocomplete="off", required=True)}}

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -372,7 +372,13 @@ def invitecodes(page):
     invite_settings = {
         meta.key: meta.value
         for meta in SiteMetadata.select().where(
-            SiteMetadata.key << ["useinvitecode", "invite_level", "invite_max"]
+            SiteMetadata.key
+            << [
+                "useinvitecode",
+                "invitations_visible_to_users",
+                "invite_level",
+                "invite_max",
+            ]
         )
     }
 

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2256,6 +2256,16 @@ def use_invite_code():
             )
 
         try:
+            sm = SiteMetadata.get(SiteMetadata.key == "invitations_visible_to_users")
+            sm.value = "1" if form.invitations_visible_to_users.data else "0"
+            sm.save()
+        except SiteMetadata.DoesNotExist:
+            SiteMetadata.create(
+                key="invitations_visible_to_users",
+                value="1" if form.invitations_visible_to_users.data else "0",
+            )
+
+        try:
             sm = SiteMetadata.get(SiteMetadata.key == "invite_level")
             sm.value = form.minlevel.data
             sm.save()
@@ -2270,6 +2280,7 @@ def use_invite_code():
             SiteMetadata.create(key="invite_max", value=form.maxcodes.data)
 
         cache.delete_memoized(misc.enableInviteCode)
+        cache.delete_memoized(misc.user_visible_invitations)
         cache.delete_memoized(misc.getMaxCodes)
 
         if form.enableinvitecode.data:


### PR DESCRIPTION
If a user gives out an invite code using another social media account, and the recipient registers using it, then the recipient will be able to see the account name of the user who invited them, so they will know that the two accounts are the same person.  This may not be what the person giving out the invite code desires.  Similarly the recipient's newly registered username will be visible to the invite code donor, which may not be what they expect either.

This change gives the admin the option of protecting user privacy by hiding invite code relationships from the users who are part of them.  Admins will still be able to view the relationships on the user profile pages, and users can still see if their codes have been used or not on their invite code page.

The default is to hide the relationships, so that new installations will default to having more privacy protection.  Admins of existing installations will have to turn invite code relationship display back on using the admin invite code page if they want to keep invite code relationships visible to users.