### PR TITLE
Make registration friendlier when emails are required

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -241,6 +241,20 @@ class AuthProvider:
         user.save()
         User.update(resets=User.resets + 1).where(User.uid == user.uid).execute()
 
+    def change_unconfirmed_user_email(self, user, new_email):
+        """Use this to change the email before the user confirms it.  To
+        change the email of a user with a confirmed email address, use
+        the pending email change functions below.
+        """
+        user.email = new_email
+        if self.provider == "KEYCLOAK":
+            self.keycloak_admin.update_user(
+                user_id=self.get_user_remote_uid(user),
+                payload={"email": new_email, "emailVerified": False},
+            )
+        user.save()
+        User.update(resets=User.resets + 1).where(User.uid == user.uid).execute()
+
     @staticmethod
     def get_pending_email(user):
         try:

--- a/app/html/user/check-your-email.html
+++ b/app/html/user/check-your-email.html
@@ -1,4 +1,4 @@
-@require(reason)
+@require(reason, email, show_resend_link)
 @extends("shared/layout.html")
 
 @def content():
@@ -6,12 +6,18 @@
     <div id="center-container">
       <div class="content email-verification">
         <h1>@{_('Email sent!')}</h1>
-        <p>@{_('Click the link in the email we sent to you. You may want to check your spam folder, just in case ;)')}</p>
+        @if email == '':
+          <p>@{_('Click the link in the email we sent to you. You may want to check your spam folder, just in case ;)')}</p>
+        @else:
+          <p>We sent a confirmation email to:</p>
+          <p class="attention">@{email}</p>
+          <p>@{_('Check your email and click on the confirmation link. You may want to check your spam folder, just in case ;)')}</p>
+        @end
         @if reason == 'registration':
           <p>@{_('After you click the link, you will be able to log in and start using %(site)s!', site=config.site.name)}</p>
         @end
-        @if reason == 'email_change':
-          <p>@{_('The new email address on your account will take effect after you open the link.')}</p>
+        @if show_resend_link:
+          <p>@{_("Didn't get the email or made a mistake with your email address?")} <a href="@{url_for('auth.fix_registration_email')}">@{_('Resend')}</a></p>
         @end
       </div>
     </div>

--- a/app/html/user/fix_registration_email.html
+++ b/app/html/user/fix_registration_email.html
@@ -1,0 +1,32 @@
+@extends("shared/layout.html")
+@require(form, error)
+@def title():
+Resend confirmation instructions |\
+@end
+
+@def main():
+<div id="center-container">
+  <div class="content">
+    <form  method="POST" id="login-form" class="pure-form pure-form-aligned">
+      <h1>@{_('Resend account confirmation instructions')}</h1> @{ form.csrf_token() !!html}
+      <p>Please verify that your email address is correct before resending.</p>
+      @if error:
+      <div class="error">@{ error }</div>
+      @end
+      <fieldset>
+        <div class="pure-control-group">
+          <label for="email">@{_('E-mail address')}</label>@{form.email(required=True)!!html}
+        </div>
+        <div class="pure-controls">
+          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary">@{_('Send email')}</button>
+        </div>
+      </fieldset>
+      <ul class="loginlinklist">
+        <li><a href="@{url_for('auth.login')}">@{_('Log in')}</a></li>
+        <li><a href="@{url_for('auth.register')}">@{_('Sign up')}</a></li>
+        <li><a href="@{url_for('user.password_recovery')}">@{_('Forgot your password?')}</a></li>
+      </ul>
+    </form>
+  </div>
+</div>
+@end

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2614,3 +2614,10 @@ article.text-post.comment.deleted {
 .smaller {
   font-size: smaller
 }
+
+.attention {
+  color: red;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -1,6 +1,6 @@
 """ Authentication endpoints and functions """
 from urllib.parse import urlparse
-from datetime import datetime
+from datetime import datetime, timedelta
 import uuid
 import re
 import requests
@@ -219,6 +219,11 @@ def register():
 
     if email_validation_is_required():
         send_login_link_email(user)
+        session["reg"] = {
+            "uid": user.uid,
+            "email": user.email,
+            "now": datetime.utcnow(),
+        }
         return redirect(url_for("auth.confirm_registration"))
     else:
         theuser = misc.load_user(user.uid)
@@ -257,8 +262,10 @@ def user_from_login_token(token):
 def confirm_registration():
     if current_user.is_authenticated:
         return redirect(url_for("home.index"))
+
+    email = session.get("reg", {}).get("email", "")
     return engine.get_template("user/check-your-email.html").render(
-        {"reason": "registration"}
+        {"reason": "registration", "email": email, "show_resend_link": email != ""}
     )
 
 
@@ -282,7 +289,64 @@ def login_with_token(token):
         theuser = misc.load_user(user.uid)
         login_user(theuser)
         session["remember_me"] = False
+        session.pop("reg", None)
     return redirect(url_for("wiki.welcome"))
+
+
+@bp.route("/register/fix-registration-email", methods=["GET", "POST"])
+@ratelimit(SIGNUP_LIMIT)
+def fix_registration_email():
+    if current_user.is_authenticated:
+        return redirect(url_for("home.index"))
+
+    user = None
+    reg = session.get("reg")
+    if reg is not None and datetime.utcnow() - reg["now"] < timedelta(hours=8):
+        try:
+            user = User.get(
+                (User.uid == reg["uid"])
+                & (User.email == reg["email"])
+                & (User.status == UserStatus.PROBATION)
+            )
+        except User.DoesNotExist:
+            pass
+
+    if user is None:
+        flash(_("The link you used is invalid or has expired."), "error")
+        return redirect(url_for("auth.register"))
+
+    form = ResendConfirmationForm()
+    if not form.validate_on_submit():
+        form.email.data = reg["email"]
+        return engine.get_template("user/fix_registration_email.html").render(
+            {"form": form, "error": misc.get_errors(form, True)}
+        )
+
+    email = normalize_email(form.email.data)
+    if is_domain_banned(email, domain_type="email"):
+        return engine.get_template("user/fix_registration_email.html").render(
+            {
+                "error": _("We do not accept emails from your email provider."),
+                "form": form,
+            }
+        )
+    user_by_email = auth_provider.get_user_by_email(email)
+    if user_by_email is not None and user_by_email != user:
+        return engine.get_template("user/fix_registration_email.html").render(
+            {"error": _("E-mail address is already in use."), "form": form}
+        )
+    elif user_by_email is None:
+        auth_provider.change_unconfirmed_user_email(user, email)
+        user = User.get(User.uid == user.uid)
+
+    send_login_link_email(user)
+    session["reg"] = {
+        "uid": user.uid,
+        "email": user.email,
+        "now": datetime.utcnow(),
+    }
+
+    return redirect(url_for("auth.confirm_registration"))
 
 
 @bp.route("/register/resend-confirmation", methods=["GET", "POST"])
@@ -305,12 +369,15 @@ def resend_confirmation_email():
 
     if user.status == UserStatus.PROBATION:
         send_login_link_email(user)
+        session.pop("reg", None)
         return redirect(url_for("auth.confirm_registration"))
     elif user.status == UserStatus.OK:
         flash(_("Your email is already confirmed."))
         return redirect(url_for("auth.login"))
 
-    return redirect(url_for("user.recovery_email_sent"))
+    return engine.get_template("user/check-your-email.html").render(
+        {"reason": "registration", "email": "", "show_resend_link": False}
+    )
 
 
 @bp.route("/login", methods=["GET", "POST"])
@@ -355,6 +422,7 @@ def login():
     if user.status == UserStatus.PROBATION:
         return redirect(url_for("auth.resend_confirmation_email"))
     session["remember_me"] = form.remember.data
+    session.pop("reg", None)
     theuser = misc.load_user(user.uid)
     login_user(theuser, remember=form.remember.data)
     if request.args.get("service"):

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -310,7 +310,7 @@ def password_recovery():
 @bp.route("/recovery/email-sent")
 def recovery_email_sent():
     return engine.get_template("user/check-your-email.html").render(
-        {"reason": "recovery"}
+        {"reason": "recovery", "email": "", "show_resend_link": False}
     )
 
 

--- a/test/specs/test_auth.py
+++ b/test/specs/test_auth.py
@@ -14,7 +14,8 @@ from test.utilities import promote_user_to_admin
 
 
 @pytest.mark.parametrize(
-    "test_config", [{"auth": {"require_valid_emails": False}}],
+    "test_config",
+    [{"auth": {"require_valid_emails": False}}],
 )
 def test_registration_login(client, test_config):
     """The registration page logs a user in if they register correctly."""
@@ -154,7 +155,10 @@ def test_resend_registration_email(client, user_info, test_config):
     with mail.record_messages() as outbox:
         rv = client.post(
             url,
-            data=dict(csrf_token=csrf_token(rv.data), email=user_info["email"],),
+            data=dict(
+                csrf_token=csrf_token(rv.data),
+                email=user_info["email"],
+            ),
             follow_redirects=True,
         )
         assert b"spam" in rv.data  # Telling user to go check it.


### PR DESCRIPTION
There is a small percentage of new users who manage to type their emails incorrectly, and consequently don't get the confirmation email and can't use the account they created.  I don't much like the "type your email twice" solution myself, so these changes try to help users who make this kind of mistake by showing them the email address which they typed into the registration form in large red letters, and giving them a link with which they can fix the email if they notice a mistake.

A couple small cleanup items are included.  The config option `auth.validate_emails` was used in a test, but has been obsolete for a while, and the check-your-email template had a check for `reason == 'email_change'` which was never true.