### PR TITLE
Add a site configuration page for admins

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -17,7 +17,6 @@ from .models import (
     UserAuthSource,
     UserCrypto,
     UserStatus,
-    SiteMetadata,
     Sub,
     SubSubscriber,
 )
@@ -434,18 +433,6 @@ class AuthProvider:
 auth_provider = AuthProvider()
 
 
-def registration_is_enabled():
-    try:
-        enable_registration = SiteMetadata.get(
-            SiteMetadata.key == "enable_registration"
-        )
-        if enable_registration.value in ("False", "0"):
-            return False
-    except SiteMetadata.DoesNotExist:
-        pass
-    return True
-
-
 # Someday config.auth.require_valid_emails may move to site metadata.
 def email_validation_is_required():
     return config.auth.require_valid_emails
@@ -481,7 +468,7 @@ def create_user(username, password, email, invite_code, existing_user):
             verified_email=False,
             status=status,
         )
-    if misc.enableInviteCode():
+    if config.site.require_invite_code:
         UserMetadata.create(uid=user.uid, key="invitecode", value=invite_code)
 
     defaults = misc.getDefaultSubs()

--- a/app/config.py
+++ b/app/config.py
@@ -3,40 +3,18 @@ import os
 from pathlib import Path
 import yaml
 from flask import current_app
+from flask_babel import lazy_gettext as _l
 from werkzeug.local import LocalProxy
 import logging
 
-cfg_defaults = {  # key => default value
+
+defaults = {  # key => default value
     "site": {
-        "name": "Throat",
-        "lema": "Throat: Open discussion ;D",
-        "copyright": "Umbrella Corp",
         "enable_totp": False,
-        "placeholder_account": "Site",
         "sub_prefix": "s",
-        "enable_security_question": False,
         "cas_authorized_hosts": [],
-        "allow_uploads": False,
-        "allow_video_uploads": True,
-        "upload_max_size": 16777216,
-        "upload_min_level": 0,
-        "enable_chat": True,
-        "sitelog_public": True,
-        "force_sublog_public": True,
-        "front_page_submit": True,
-        "block_anon_stalking": False,
-        "changelog_sub": None,
         "btc_address": None,
         "xmr_address": None,
-        "title_edit_timeout": 300,
-        "sub_creation_min_level": 2,
-        "sub_creation_admin_only": False,
-        "sub_ownership_limit": 20,
-        "edit_history": False,
-        "anonymous_modding": False,
-        "send_pm_to_user_min_level": 3,
-        "daily_sub_posting_limit": 10,
-        "daily_site_posting_limit": 25,
         # Removing things from this list will work but adding will not.
         # See Expando.js.
         "expando_sites": [
@@ -54,15 +32,8 @@ cfg_defaults = {  # key => default value
             "player.vimeo.com",
         ],
         "footer": {"links": {"ToS": "/wiki/tos", "Privacy": "/wiki/privacy"}},
-        "archive_post_after": 60,
         "trusted_proxy_count": 0,
         "custom_hot_sort": False,
-        "recent_activity": {
-            "enabled": False,  # TODO: Address performance issues
-            "defaults_only": False,
-            "comments_only": False,
-            "max_entries": 10,
-        },
         "icon_url": None,
         "logo": "app/static/img/throat-logo.svg",
     },
@@ -82,7 +53,6 @@ cfg_defaults = {  # key => default value
             "path": "./app/static/stor",
             "url": "https://useruploads.shitposting.space/",
         },
-        "sub_css_max_file_size": 2,
     },
     "app": {
         "redis_url": "redis://127.0.0.1:6379",
@@ -103,48 +73,534 @@ cfg_defaults = {  # key => default value
 }
 
 
-class Map(dict):
-    """ A dictionary object whose keys are accessable as attributes. """
+# Nested map of configuration keys which are configurable in the admin
+# interface. The accompanying value will only be used in the migration
+# which writes that value to the database, and in the tests.
+configurable_defaults = {
+    "site": {
+        "type": "map",
+        "value": {
+            "name": {
+                "type": "string",
+                "doc": _l("Name of the site."),
+                "value": "Throat",
+            },
+            "lema": {
+                "type": "string",
+                "doc": _l("Lema shown in the page's title."),
+                "value": "Throat: Open discussion ;D",
+            },
+            "copyright": {
+                "type": "string",
+                "doc": _l("Copyright line shown in the footer."),
+                "value": "Umbrella Corp",
+            },
+            "placeholder_account": {
+                "type": "string",
+                "doc": _l(
+                    "Name shown when a sub is owned by a deleted account or abandoned."
+                ),
+                "value": "Site",
+            },
+            "enable_security_question": {
+                "type": "bool",
+                "doc": _l(
+                    "If True, enables setting security questions on the admin page. Users will be "
+                    "asked to answer one of these security questions before registering."
+                ),
+                "value": False,
+            },
+            "allow_uploads": {
+                "type": "bool",
+                "doc": _l(
+                    "Allow everybody to upload files (by default it's only admins and users "
+                    "authorized through a metadata key)."
+                ),
+                "value": False,
+            },
+            "allow_video_uploads": {
+                "type": "bool",
+                "doc": _l(
+                    "For those who are allowed to upload files, allow video uploads (.mp4 and .webm) as well."
+                ),
+                "value": True,
+            },
+            "upload_max_size": {
+                "type": "int",
+                "doc": _l("Maximum size of an uploaded file, in bytes."),
+                "value": 16777216,
+            },
+            "upload_min_level": {
+                "type": "int",
+                "doc": _l(
+                    "Minimum level a user must have before being able to upload files. Set to zero "
+                    "to disable file upload level limits."
+                ),
+                "value": 0,
+            },
+            "enable_chat": {
+                "type": "bool",
+                "doc": _l(
+                    "Allow chat access for all users. If enabled, each user will have the option of "
+                    "disabling chat for themselves."
+                ),
+                "value": True,
+            },
+            "sitelog_public": {
+                "type": "bool",
+                "doc": _l(
+                    "Allow all users to view the site log. If False, only admins can view the sitelog."
+                ),
+                "value": True,
+            },
+            "force_sublog_public": {
+                "type": "bool",
+                "doc": _l(
+                    "Forces all the sub logs and banned user lists to be public and removes the "
+                    "option to make them private."
+                ),
+                "value": True,
+            },
+            "front_page_submit": {
+                "type": "bool",
+                "doc": _l('Show the "Submit a post" button on the frontpage.'),
+                "value": True,
+            },
+            "block_anon_stalking": {
+                "type": "bool",
+                "doc": _l(
+                    "Blocks anonymous users from being able to look at a particular user's posts or "
+                    "comments (IE blocks /u/<user>/posts and /u/<user>/comments)."
+                ),
+                "value": False,
+            },
+            "changelog_sub": {
+                "type": "string",
+                "doc": _l("SID of the sub for changelog entries."),
+                "value": "",
+            },
+            "title_edit_timeout": {
+                "type": "int",
+                "doc": _l(
+                    "Amount of time in seconds the post author can edit a post's title after the "
+                    "post was created. Set to zero to disable title editing (default is 5 minutes)."
+                ),
+                "value": 300,
+            },
+            "sub_creation_min_level": {
+                "type": "int",
+                "doc": _l(
+                    "Minimum level a user must have before being able to create a sub. Set to zero "
+                    "to disable sub creation level limits."
+                ),
+                "value": 2,
+            },
+            "sub_creation_admin_only": {
+                "type": "bool",
+                "doc": _l(
+                    "Only allow Admins to create new subs. If True, only admins can create new subs."
+                ),
+                "value": False,
+            },
+            "sub_ownership_limit": {
+                "type": "int",
+                "doc": _l(
+                    "Maximum amount of subs a single user can own. The actual amount of subs a user "
+                    "may register scales with user level (user level minus one) so a level 0 or "
+                    "level 1 user cannot register any subs. This scaling is disabled if "
+                    "`sub_creation_min_level` is zero."
+                ),
+                "value": 20,
+            },
+            "edit_history": {
+                "type": "bool",
+                "doc": _l(
+                    "Allows Sub Mods and Admins to view the edit history of posts."
+                ),
+                "value": False,
+            },
+            "anonymous_modding": {
+                "type": "bool",
+                "doc": _l(
+                    "Removes the name of the Mod or Admin who took action on a post or user in "
+                    "notifications sent to user."
+                ),
+                "value": False,
+            },
+            "send_pm_to_user_min_level": {
+                "type": "int",
+                "doc": _l(
+                    "Minimum level required for a user to be permitted to private message "
+                    "nonprivileged users. Set to zero to allow users of all levels to PM other "
+                    "users. Users of any level may PM site admins."
+                ),
+                "value": 3,
+            },
+            "daily_sub_posting_limit": {
+                "type": "int",
+                "doc": _l(
+                    "Maximum amount of posts a user can create in a single sub in a day."
+                ),
+                "value": 10,
+            },
+            "daily_site_posting_limit": {
+                "type": "int",
+                "doc": _l("Maximum amount of posts a user can create in a single day."),
+                "value": 25,
+            },
+            "archive_post_after": {
+                "type": "int",
+                "doc": _l("Number of days after which posts will be archived."),
+                "value": 60,
+            },
+            "recent_activity": {
+                "type": "map",
+                "value": {
+                    "enabled": {
+                        "type": "bool",
+                        "doc": _l(
+                            "Enables or disables the recent activity sidebar and the page in /activity."
+                        ),
+                        "value": False,
+                    },
+                    "defaults_only": {
+                        "type": "bool",
+                        "doc": _l(
+                            "Only show recent activity from default subs in the sidebar (recent "
+                            "activity for all subs will be shown in /activity)."
+                        ),
+                        "value": False,
+                    },
+                    "comments_only": {
+                        "type": "bool",
+                        "doc": _l(
+                            "If true, only show recent comments (and not posts) in the sidebar."
+                        ),
+                        "value": False,
+                    },
+                    "max_entries": {
+                        "type": "int",
+                        "doc": _l(
+                            "Number of entries to display in the recent activity sidebar."
+                        ),
+                        "value": 10,
+                    },
+                },
+            },
+            "enable_posting": {
+                "type": "bool",
+                "doc": _l("Allow users to make posts and comments."),
+                "value": True,
+            },
+            "enable_registration": {
+                "type": "bool",
+                "doc": _l("Allow new users to register."),
+                "value": True,
+            },
+            "invitations_visible_to_users": {
+                "type": "bool",
+                "doc": _l(
+                    "Allow users to see the usernames of the people they invited or were invited by."
+                ),
+                "value": False,
+            },
+            "invite_level": {
+                "type": "int",
+                "doc": _l("Level requirement before a user can generate invite codes."),
+                "value": 3,
+            },
+            "invite_max": {
+                "type": "int",
+                "doc": _l(
+                    "The number of invite codes each user is allowed to generate (see also site.invite_level)."
+                ),
+                "value": 10,
+            },
+            "require_captchas": {
+                "type": "bool",
+                "doc": _l("Require the user to solve a captcha to register or post."),
+                "value": True,
+            },
+            "require_invite_code": {
+                "type": "bool",
+                "doc": _l("Require an invite code to register."),
+                "value": False,
+            },
+        },
+    },
+    "storage": {
+        "type": "map",
+        "value": {
+            "sub_css_max_file_size": {
+                "type": "int",
+                "doc": _l(
+                    "Max storage for image uploads for subs' stylesheets (in MiB)."
+                ),
+                "value": 2,
+            },
+        },
+    },
+}
 
-    def __init__(self, sdict, defaults, use_environment=True, prefix=""):
-        """Create a Map from the dictionary sdict, with missing values filled
-        in from defaults. If a non-empty prefix string is supplied,
-        and any environment variables exist beginning with that
-        prefix, add those values to the dictionary overwriting
-        anything in sdict or default.
-        """
-        super(Map, self).__init__(dict(sdict))
-        self.prefix = ("" if prefix == "" else prefix + "_").upper()
 
-        # If any values are missing, copy them from defaults.
-        # Turn all subdictionaries into Maps as well.
-        for key, val in defaults.items():
-            if isinstance(val, dict):
-                existing = self.get(key, {})
-                if existing is None:
-                    existing = {}
-                elif not isinstance(existing, dict):
+def add_database_source(cfg_dict):
+    """Add the source field to all entries in cfg_dict. Saves some typing
+    in the definition of configurable_defaults."""
+    for key in cfg_dict:
+        if cfg_dict[key]["type"] == "map":
+            cfg_dict[key]["source"] = None
+            add_database_source(cfg_dict[key]["value"])
+        else:
+            cfg_dict[key]["source"] = "database"
+
+
+def add_values_to_config(defaults, values, source):
+    """Given a defaults dictionary (structured like configurable_defaults above)
+    and a possibly nested config dict, combine the two and return a
+    new dict, structured like cfg_defaults.  Every node will have at least
+    'type', 'source' and 'value' keys."""
+    result = {}
+    for key in set(list(defaults.keys()) + list(values.keys())):
+        value = values.get(key)
+        default = defaults.get(key)
+        if key not in defaults:
+            if isinstance(values[key], dict):
+                result[key] = {
+                    "type": "map",
+                    "source": None,
+                    "value": add_values_to_config({}, value, source),
+                }
+            else:
+                result[key] = {"type": "any", "source": source, "value": value}
+        elif key not in values:
+            result[key] = default
+        else:
+            if default["source"] == "database":
+                assert source != "default"
+                result[key] = dict(default, configured_value=value)
+            elif default["type"] == "map":
+                if not isinstance(value, dict):
                     raise TypeError(
-                        f"Value found where dict expected at {prefix}{key} in config.yaml"
+                        f"Value found where dict expected at {key}: {value} in {source}"
                     )
-                self[key] = Map(existing, val, use_environment, f"{self.prefix}{key}")
-            elif key not in self.keys():
-                self[key] = val
+                result[key] = {
+                    "type": "map",
+                    "source": None,
+                    "value": add_values_to_config(default["value"], value, source),
+                }
+            else:
+                result[key] = {"type": "any", "source": source, "value": value}
+    return result
 
-        # Look for environment variables that override values or add additional values.
-        if self.prefix != "" and use_environment:
-            for var in os.environ.keys():
-                if var.startswith(self.prefix):
-                    self[var[len(self.prefix) :].lower()] = os.environ.get(var)
+
+def get_environment_values(config, prefix=""):
+    """Build a dict of values from environment variables with names
+    matching the keys in config."""
+    new_items = {}
+    if len(prefix) > 0:
+        for var in os.environ.keys():
+            if var.startswith(prefix):
+                env_key = var[len(prefix) :].lower()
+                new_items[env_key] = os.environ.get(var)
+    for key, val in config.items():
+        if val["type"] == "map":
+            env_vals = get_environment_values(val["value"], prefix + key.upper() + "_")
+            if env_vals:
+                new_items[key] = env_vals
+    return new_items
+
+
+add_database_source(configurable_defaults)
+cfg_defaults = add_values_to_config(configurable_defaults, defaults, "default")
+
+
+class Map:
+    """A dictionary-like object whose keys are accessable as attributes,
+    constructed from a nested dictionary structure like
+    configurable_defaults defined above.  Supports storing some of the
+    values in the database and cache.  Nested maps in the dictionary
+    passed at initialization will be converted to nested ConfigMap
+    objects."""
+
+    def __init__(
+        self,
+        sdict,
+        model=None,
+        cache=None,
+        prefixes=None,
+    ):
+        """Create a Map from the dictionary sdict.
+
+        Mutable values will be stored in the database and cached in
+        the cache."""
+
+        self._content = {}
+        self._prefixes = [] if prefixes is None else prefixes
+        self._model = model
+        self._cache = cache
+
+        for key, val in sdict.items():
+            self._content[key] = dict(val)
+            if val["type"] == "map":
+                self._content[key]["value"] = Map(
+                    val["value"], model, cache, self._prefixes + [key]
+                )
+
+    def get_mutable_items(self):
+        """Return mutable keys in this map and all nested maps, along with
+        their current value and metadata."""
+        result = []
+        prefixes = ".".join(self._prefixes) + "."
+        for key, val in self._content.items():
+            if isinstance(val["value"], Map):
+                result = result + val["value"].get_mutable_items()
+            elif val["source"] == "database":
+                result = result + [
+                    {
+                        "name": prefixes + key,
+                        "value": self.__getattr__(key),
+                        "type": val["type"],
+                        "doc": val["doc"],
+                    }
+                ]
+        return result
+
+    def mutable_item_configuration(self):
+        """Return a list of the full names of all the keys in the map which
+        are configurable, and the value set in the config file or
+        environment for them if it exists, otherwise the default
+        value.  For use by tests and by the migration that moves those
+        config file and environment values into SiteMetadata."""
+        result = []
+        prefixes = self._key_name_from_attr("")
+        for key, val in self._content.items():
+            if isinstance(val["value"], Map):
+                result = result + val["value"].mutable_item_configuration()
+            elif val["source"] == "database":
+                if "configured_value" in val:
+                    value = val["configured_value"]
+                else:
+                    value = val["value"]
+                result = result + [((prefixes + key), value, val["type"])]
+        return result
+
+    def _get_from_backing_store(self, attr):
+        """Get the value for a key from the cache or the database. Return
+        None if no value has been set in the backing store."""
+        key = self._key_name_from_attr(attr)
+        val = self._cache.get(key)
+        if val is None:
+            try:
+                val = self._model.get(self._model.key == key).value
+            except self._model.DoesNotExist:
+                # Did you add a new config key? If so, write a migration to
+                # add it to SiteMetadata.
+                logging.warning(f"{key} is not present in SiteMetadata")
+            self._cache.set(key, val)
+        return val
+
+    def _key_name_from_attr(self, attr):
+        return ".".join(self._prefixes) + "." + attr
 
     def __getattr__(self, attr):
-        return self[attr]
+        if self._content[attr]["source"] == "database":
+            val = self._get_from_backing_store(attr)
+            if val is None:
+                return self._content[attr]["value"]
+            else:
+                typ = self._content[attr]["type"]
+                if typ == "str":
+                    return val
+                elif typ == "int":
+                    return int(val)
+                elif typ == "bool":
+                    return val == "1"
+                else:
+                    return val
+        return self._content[attr]["value"]
+
+    def __getitem__(self, attr):
+        return self.__getattr__(attr)
+
+    def keys(self):
+        return self._content.keys()
+
+    def as_dict(self):
+        result = {}
+        for key, val in self._content.items():
+            if isinstance(val["value"], Map):
+                result[key] = val["value"].as_dict()
+            else:
+                result[key] = self.__getattr__(key)
+        return result
+
+    def items(self):
+        return self.as_dict().items()
+
+    def __contains__(self, attr):
+        return attr in self._content
+
+    def get_value(self, attr):
+        """Return a value possibly from a nested map named by keys joined by .'s"""
+        attrs = attr.split(".")
+        if len(attrs) > 1:
+            return self._content[attrs[0]]["value"].get_value(".".join(attrs[1:]))
+        else:
+            return self.__getattr__(attr)
+
+    def _set_value(self, attr, new_value):
+        """Set a value possibly in a nested map named by keys joined by .'s"""
+        attrs = attr.split(".")
+        if len(attrs) > 1:
+            return self._content[attrs[0]]["value"]._set_value(
+                ".".join(attrs[1:]), new_value
+            )
+        else:
+            self._content[attrs[0]]["value"] = new_value
+
+    def update_value(self, attr, new_val):
+        """Set a new value for one of the persistent mutable entries."""
+        attrs = attr.split(".")
+        if len(attrs) > 1:
+            self._content[attrs[0]]["value"].update_value(".".join(attrs[1:]), new_val)
+        else:
+            prefix = ".".join(self._prefixes)
+            if self._content[attr]["source"] != "database":
+                raise RuntimeError(
+                    f"Config value {prefix}.{attr} cannot be changed at runtime"
+                )
+
+            key = self._key_name_from_attr(attr)
+            if self._content[attr]["type"] == "bool":
+                val = "1" if new_val else "0"
+            elif self._content[attr]["type"] == "int":
+                # Force a ValueError if an integer can't be parsed.
+                val = str(int(new_val))
+            else:
+                val = new_val
+            try:
+                rec = self._model.get(self._model.key == key)
+                rec.value = val
+                rec.save()
+            except self._model.DoesNotExist:
+                # Did you add a new attribute?  If so use a migration to add it to the database.
+                raise RuntimeError(
+                    f"Value for config.{prefix}.{attr} is missing from database"
+                )
+            self._cache.set(key, val)
 
 
 class Config(Map):
     """ Main config object """
 
-    def __init__(self, config_filename=None, use_environment=True, config_dict=None):
+    def __init__(
+        self,
+        config_filename=None,
+        model=None,
+        cache=None,
+        use_environment=True,
+        config_dict=None,
+    ):
         if config_filename is None:
             cfg = {}
             if config_dict:
@@ -153,7 +609,12 @@ class Config(Map):
             with open(config_filename) as stream:
                 cfg = yaml.safe_load(stream)
 
-        super(Config, self).__init__(cfg, cfg_defaults, use_environment=use_environment)
+        config = add_values_to_config(cfg_defaults, cfg, "config")
+        if use_environment:
+            env = get_environment_values(config)
+            config = add_values_to_config(config, env, "environment")
+
+        super(Config, self).__init__(config, model, cache)
         self.check_storage_config()
         self.check_auth_config()
         self.check_ratelimit_config()
@@ -163,60 +624,75 @@ class Config(Map):
         storage = self.storage
         if storage.provider == "LOCAL":
             # Make sure our storage paths are absolute.
-            if not Path(storage.thumbnails["path"]).is_absolute():
-                storage.thumbnails[
-                    "path"
-                ] = f"{Path(__file__).parent.parent.absolute()}/{storage.thumbnails['path']}"
-            if not Path(storage.uploads["path"]).is_absolute():
-                storage.uploads[
-                    "path"
-                ] = f"{Path(__file__).parent.parent.absolute()}/{storage.uploads['path']}"
-            storage["container"] = storage.uploads["path"]
+            if not Path(storage.thumbnails.path).is_absolute():
+                self._set_value(
+                    "storage.thumbnails.path",
+                    f"{Path(__file__).parent.parent.absolute()}/{storage.thumbnails.path}",
+                )
+            if not Path(storage.uploads.path).is_absolute():
+                self._set_value(
+                    "storage.uploads.path",
+                    f"{Path(__file__).parent.parent.absolute()}/{storage.uploads.path}",
+                )
+            storage._content["container"] = storage.uploads._content["path"]
             if storage.server:
                 if storage.uploads.path != storage.thumbnails.path:
                     logging.warning(
                         "Thumbnails will not be served by local server "
                         "because thumbnails and uploads paths differ"
                     )
-                if storage["server_url"][-1] == "/":
+                if storage.server_url[-1] == "/":
                     # flask-cloudy does not want the trailing slash
-                    self.storage["server_url"] = self.storage["server_url"][:-1]
+                    self._set_value("storage.server_url", self.storage.server_url[:-1])
 
-        storage.acl = "" if storage.acl is None else storage.acl
+        self._set_value("storage.acl", "" if storage.acl is None else storage.acl)
 
         # This is not for flask-cloudy, just to make config more human-friendly
-        ensure_trailing_slash(storage.thumbnails, "url")
-        ensure_trailing_slash(storage.uploads, "url")
+        if "url" in storage.thumbnails:
+            self._set_value(
+                "storage.thumbnails.url", ensure_trailing_slash(storage.thumbnails.url)
+            )
+        if "url" in storage.uploads:
+            self._set_value(
+                "storage.uploads.url", ensure_trailing_slash(storage.uploads.url)
+            )
 
     def check_auth_config(self):
-        ensure_trailing_slash(self.auth.keycloak, "server")
+        if "server" in self.auth.keycloak:
+            self._set_value(
+                "auth.keycloak.server", ensure_trailing_slash(self.auth.keycloak.server)
+            )
 
     def check_ratelimit_config(self):
         if "storage_url" not in self.ratelimit:
-            self.ratelimit["storage_url"] = self.app.redis_url
+            self.ratelimit._content["storage_url"] = self.app._content["redis_url"]
 
     def get_flask_dict(self):
         flattened = {}
         for cpk in ["cache", "mail", "sendgrid", "app", "ratelimit"]:
-            if cpk in self.keys():
-                for i in self[cpk]:
+            if cpk in self._content:
+                for k in self._content[cpk]["value"].keys():
                     if cpk == "app":
-                        key = i.upper()
+                        key = k.upper()
                     else:
-                        key = "{}_{}".format(cpk, i).upper()
-                    flattened[key] = self[cpk][i]
+                        key = "{}_{}".format(cpk, k).upper()
+                    flattened[key] = self[cpk][k]
 
         # These values are used by flask-cloudy.
         for key in ["provider", "key", "secret", "container", "server", "server_url"]:
-            if key in self.storage:
-                flattened[f"STORAGE_{key}".upper()] = self.storage[key]
+            if key in self.storage.keys():
+                flattened[f"STORAGE_{key}".upper()] = self.storage._content[key][
+                    "value"
+                ]
         return flattened
 
 
-def ensure_trailing_slash(d, key):
-    """ Add a slash to the end of a dictionary entry if it doesn't already have one. """
-    if key in d and d[key] and d[key][-1] != "/":
-        d[key] = d[key] + "/"
+def ensure_trailing_slash(val):
+    """ Add a slash to the string if it doesn't already have one. """
+    if val and val[-1] != "/":
+        return val + "/"
+    else:
+        return val
 
 
 config = LocalProxy(lambda: current_app.config["THROAT_CONFIG"])

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ defaults = {  # key => default value
         "enable_totp": False,
         "sub_prefix": "s",
         "cas_authorized_hosts": [],
+        "upload_max_size": 16777216,
         "btc_address": None,
         "xmr_address": None,
         # Removing things from this list will work but adding will not.
@@ -124,11 +125,6 @@ configurable_defaults = {
                     "For those who are allowed to upload files, allow video uploads (.mp4 and .webm) as well."
                 ),
                 "value": True,
-            },
-            "upload_max_size": {
-                "type": "int",
-                "doc": _l("Maximum size of an uploaded file, in bytes."),
-                "value": 16777216,
             },
             "upload_min_level": {
                 "type": "int",

--- a/app/config.py
+++ b/app/config.py
@@ -106,7 +106,7 @@ configurable_defaults = {
             "enable_security_question": {
                 "type": "bool",
                 "doc": _l(
-                    "If True, enables setting security questions on the admin page. Users will be "
+                    "Enables setting security questions on the admin page. Users will be "
                     "asked to answer one of these security questions before registering."
                 ),
                 "value": False,
@@ -145,7 +145,7 @@ configurable_defaults = {
             "sitelog_public": {
                 "type": "bool",
                 "doc": _l(
-                    "Allow all users to view the site log. If False, only admins can view the sitelog."
+                    "Allow all users to view the site log. When disabled, only admins can view the sitelog."
                 ),
                 "value": True,
             },
@@ -194,7 +194,8 @@ configurable_defaults = {
             "sub_creation_admin_only": {
                 "type": "bool",
                 "doc": _l(
-                    "Only allow Admins to create new subs. If True, only admins can create new subs."
+                    "When enabled, only admins can create new subs, otherwise "
+                    "`sub_creation_min_level` controls who can create a sub."
                 ),
                 "value": False,
             },
@@ -270,7 +271,7 @@ configurable_defaults = {
                     "comments_only": {
                         "type": "bool",
                         "doc": _l(
-                            "If true, only show recent comments (and not posts) in the sidebar."
+                            "If enabled, only show recent comments (and not posts) in the sidebar."
                         ),
                         "value": False,
                     },

--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -3,6 +3,7 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField, TextAreaField, FileField
 from wtforms import IntegerField, RadioField, FieldList, SelectField
+from wtforms import HiddenField
 from wtforms.validators import DataRequired, Length, Regexp
 from flask_babel import lazy_gettext as _l
 
@@ -112,3 +113,8 @@ class CreateInviteCodeForm(FlaskForm):
 
 class SetSubOfTheDayForm(FlaskForm):
     sub = StringField(_l("Sub"))
+
+
+class ChangeConfigSettingForm(FlaskForm):
+    setting = HiddenField()
+    value = StringField()

--- a/app/html/admin/configuration.html
+++ b/app/html/admin/configuration.html
@@ -22,25 +22,35 @@ Admin |\
               <tr>
                 <th class="admin-config-name">@{_('Setting Name')}</th>
                 <th class="admin-config-value">@{_('Current Value')}</th>
-		<th class="admin-config-action"></th>
+                <th class="admin-config-action"></th>
               </tr>
             </thead>
             <tbody>
               @for data in config_data:
               <tr>
                 <td><a class="admin-config-doc-toggle" id="@{data['name']}">▹</a>@{data['name']}</td>
-                <td id="@{data['name']}-value">@{data['value']}</td>
+                <td id="@{data['name']}-value">
+                @if data['type'] == 'bool':
+                  @if data['value']:
+                    @{_('Enabled')}
+                  @else:
+                    @{_('Disabled')}
+                  @end
+                @else:
+                  @{data['value']}
+                @end
+                </td>
                 <td>
                   @if data['type'] == 'bool':
                   <a class="admin-config-edit" data-type="bool" data-setting="@{data['name']}">⇆</a>
                   @else:
                   <a class="icon admin-config-edit" data-type="@{data['type']}" data-setting="@{data['name']}" data-icon="edit"></a>
-		  @end
-		</td>
+                  @end
+                </td>
               </tr>
-	      <tr class="admin-config-doc hide" id="@{data['name']}-doc">
-	        <td class="helper-text" colspan="3">@{data['doc']}</td>
-	      </tr>
+              <tr class="admin-config-doc hide" id="@{data['name']}-doc">
+                <td class="helper-text" colspan="3">@{data['doc']}</td>
+              </tr>
               @end
             </tbody>
           </table>
@@ -49,11 +59,12 @@ Admin |\
               <form method="POST" class="ajaxform pure-form" data-reload="true" action="@{url_for('do.admin_modify_config_setting')}">
                 @{form.csrf_token!!html}
                 <p>
-	          @{form.setting()!!html}
+                  <span id="bool-label"></span>
+                  @{form.setting()!!html}
                   @{form.value()!!html}
                 </p>
-	        <p>
-                  <button type="submit" name="change" class="pure-button" data-prog="@{_('Saving...')}">@{_("Change")}</button>
+                <p>
+                  <button type="submit" id="admin-config-edit-submit" name="change" class="pure-button" data-prog="@{_('Saving...')}"></button>
                   <button type="button" id="admin-config-edit-cancel" class="pure-button">@{_("Cancel")}</button>
                   <div class="alert div-error"></div>
                 </p>

--- a/app/html/admin/configuration.html
+++ b/app/html/admin/configuration.html
@@ -1,0 +1,68 @@
+@extends("shared/layout.html")
+@require(config_data, form)
+@def title():
+Admin |\
+@end
+
+@def sidebar():
+@include('shared/sidebar/admin.html')
+@end
+
+@def main():
+<div id="container">
+  <div id="center-container">
+    <div class="content">
+      <h1>@{_('Site configuration')}</h1>
+      <p class="helper-text">See the <a href="@{url_for('site.view_sitelog')}">Site Log</a> for the history of changes to configuration values.</p>
+      <div class="error hide"></div>
+      <div class="admin section users">
+        <div class="col-12">
+          <table class="admin-config pure-table">
+            <thead>
+              <tr>
+                <th class="admin-config-name">@{_('Setting Name')}</th>
+                <th class="admin-config-value">@{_('Current Value')}</th>
+		<th class="admin-config-action"></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for data in config_data:
+              <tr>
+                <td><a class="admin-config-doc-toggle" id="@{data['name']}">▹</a>@{data['name']}</td>
+                <td id="@{data['name']}-value">@{data['value']}</td>
+                <td>
+                  @if data['type'] == 'bool':
+                  <a class="admin-config-edit" data-type="bool" data-setting="@{data['name']}">⇆</a>
+                  @else:
+                  <a class="icon admin-config-edit" data-type="@{data['type']}" data-setting="@{data['name']}" data-icon="edit"></a>
+		  @end
+		</td>
+              </tr>
+	      <tr class="admin-config-doc hide" id="@{data['name']}-doc">
+	        <td class="helper-text" colspan="3">@{data['doc']}</td>
+	      </tr>
+              @end
+            </tbody>
+          </table>
+          <div id="form-container">
+            <div class="admin-config-edit-form hide">
+              <form method="POST" class="ajaxform pure-form" data-reload="true" action="@{url_for('do.admin_modify_config_setting')}">
+                @{form.csrf_token!!html}
+                <p>
+	          @{form.setting()!!html}
+                  @{form.value()!!html}
+                </p>
+	        <p>
+                  <button type="submit" name="change" class="pure-button" data-prog="@{_('Saving...')}">@{_("Change")}</button>
+                  <button type="button" id="admin-config-edit-cancel" class="pure-button">@{_("Cancel")}</button>
+                  <div class="alert div-error"></div>
+                </p>
+              </form>
+            </div>
+         </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@end

--- a/app/html/admin/configuration.html
+++ b/app/html/admin/configuration.html
@@ -13,7 +13,7 @@ Admin |\
   <div id="center-container">
     <div class="content">
       <h1>@{_('Site configuration')}</h1>
-      <p class="helper-text">See the <a href="@{url_for('site.view_sitelog')}">Site Log</a> for the history of changes to configuration values.</p>
+      <p class="helper-text">@{_('See the <a href="%(url)s">Site log</a> for the history of changes to configuration values.', url=url_for('site.view_sitelog'))!!html}</p>
       <div class="error hide"></div>
       <div class="admin section users">
         <div class="col-12">

--- a/app/html/shared/sidebar/admin.html
+++ b/app/html/shared/sidebar/admin.html
@@ -13,4 +13,5 @@
 <a href="@{url_for('admin.domains', domain_type='link')}" class="sbm-post pure-button">@{_('Banned Domains')}</a>
 <a href="@{url_for('admin.domains', domain_type='email')}" class="sbm-post pure-button">@{_('Banned Email Domains')}</a>
 <hr>
+<a href="@{url_for('admin.configure')}" class="sbm-post pure-button">@{_('Site configuration')}</a>
 <a href="@{url_for('site.view_sitelog')}" class="sbm-post pure-button">@{_('Site log')}</a>

--- a/app/html/shared/sidebar/user.html
+++ b/app/html/shared/sidebar/user.html
@@ -24,7 +24,7 @@
     @if request.path == url_for('user.edit_account'):
     <a href="@{url_for('user.delete_account')}" class="sbm-post pure-button @{(request.path == url_for('user.delete_account')) and 'pure-button-primary' or ''}">@{_('Delete account')}</a>
     @end
-    @if func.enableInviteCode():
+    @if config.site.require_invite_code:
         <hr/>
         <a href="@{url_for('user.invite_codes')}" class="sbm-post pure-button @{(request.path == url_for('user.invite_codes')) and 'pure-button-primary' or ''}">@{_('Invite codes')}</a>
     @end

--- a/app/html/site/log.html
+++ b/app/html/site/log.html
@@ -80,6 +80,8 @@
                       @{_('Disabled captchas')}
                     @elif log.action == 72:
                       @{_('Enabled captchas')}
+                    @elif log.action == 75:
+		      @{_('Changed <code>%(setting)s</code> to <code>%(value)s<code>', setting=e(log.desc[:log.desc.find("/")]), value=e(log.desc[log.desc.find("/")+1:]))!!html}
                     @else:
                         <i>[Type @{log.action}]</i> @{log.desc}
                     @end

--- a/app/html/user/register.html
+++ b/app/html/user/register.html
@@ -15,7 +15,7 @@
             @{ regform.csrf_token()!!html }
             <h1>@{_('Register')}</h1>
             <fieldset>
-                @if func.enableInviteCode():
+                @if config.site.require_invite_code:
                 <div class="pure-control-group">
                     <label for="invitecode">@{regform.invitecode.label.text}</label>@{regform.invitecode(autocomplete="off", required=True)!!html}
                 </div>

--- a/app/html/user/registration_disabled.html
+++ b/app/html/user/registration_disabled.html
@@ -1,5 +1,4 @@
 @extends("shared/layout.html")
-@require(test)
 
 @def title():
 @{_('Register')} |\

--- a/app/models.py
+++ b/app/models.py
@@ -28,7 +28,7 @@ db = LocalProxy(get_db)
 
 
 def db_init_app(app):
-    dbconnect = dict(app.config["THROAT_CONFIG"].database)
+    dbconnect = app.config["THROAT_CONFIG"].database.as_dict()
     # Taken from peewee's flask_utils
     try:
         name = dbconnect.pop("name")

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -576,3 +576,11 @@ body.dark .selflair {
     color: #777;
     border-color: #222;
 }
+
+body.dark .admin-config-edit {
+    fill: #526a7d;
+}
+
+body.dark .admin-config-edit:hover {
+    fill: #d17262;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2632,6 +2632,7 @@ article.text-post.comment.deleted {
 .admin-config-doc-toggle {
   font-size: smallest;
   padding-right: 5px;
+  cursor: pointer;
 }
 
 .admin-config-edit-form input {
@@ -2642,6 +2643,7 @@ article.text-post.comment.deleted {
   fill:  #00419d;
   width: 16px;
   height: 16px;
+  cursor: pointer;
 }
 
 .admin-config-edit:hover {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2611,3 +2611,39 @@ article.text-post.comment.deleted {
   font-weight: bold;
   text-align: center;
 }
+
+.admin-config {
+  table-layout: fixed;
+  width: 95%;
+}
+
+.admin-config-name {
+  width: 35%;
+}
+
+.admin-config-value {
+  width: 60%;
+}
+
+.admin-config-action {
+  width: 5%;
+}
+
+.admin-config-doc-toggle {
+  font-size: smallest;
+  padding-right: 5px;
+}
+
+.admin-config-edit-form input {
+  width: 100%;
+}
+
+.admin-config-edit {
+  fill:  #00419d;
+  width: 16px;
+  height: 16px;
+}
+
+.admin-config-edit:hover {
+  fill: #64a6ca;
+}

--- a/app/static/js/Mod.js
+++ b/app/static/js/Mod.js
@@ -109,44 +109,43 @@ u.addEventForChild(document, 'click', '.admin-config-doc-toggle', function (e, q
 });
 
 u.addEventForChild(document, 'click', '.admin-config-edit', function (e, qelem) {
-  const errorbox = document.querySelector('.error');
   let name = qelem.getAttribute('data-setting');
-  let type = qelem.getAttribute('data-type');
-  errorbox.classList.add('hide');
+  let valueElem = document.getElementById(name + '-value');
+  let value = valueElem.innerText;
 
-  if (type == 'bool') {
-    u.post('/do/admin/config/toggle', {setting: name},
-           function (data) {
-             if (data.status != 'ok') {
-               errorbox.classList.remove('hide');
-               errorbox.innerHTML = _('Error: %1', data.error);
-               errorbox.scrollIntoView();
-             } else {
-               window.location.reload();
-             }
-           }, function () {
-             errorbox.classList.remove('hide');
-             errorbox.innerHTML = _('Could not contact the server');
-             errorbox.scrollIntoView();
-           });
-  } else {
-    const changeForm = document.querySelector('.admin-config-edit-form');
-    let parent = changeForm.parentElement;
-    let valueElem = document.getElementById(name + '-value');
-    let value = valueElem.innerText;
+  const changeForm = document.querySelector('.admin-config-edit-form');
+  let parent = changeForm.parentElement;
+  let valueField = document.getElementById('value');
+  let changeButton = document.getElementById('admin-config-edit-submit');
+  const label = document.getElementById('bool-label');
 
-    if (valueElem != parent) {
-      let oldValue = parent.getAttribute('data-old-value');
-      document.getElementById('value').value = value;
-      document.getElementById('setting').value = name;
-      changeForm.querySelector('.div-error').style.display = 'none';
-      changeForm.classList.remove('hide')
-      valueElem.setAttribute('data-old-value', value);
-      valueElem.innerHTML = "";
-      valueElem.appendChild(changeForm);
-      if (oldValue) {
-        parent.innerHTML = oldValue;
-      }
+  document.querySelector('.error').classList.add('hide');
+  changeForm.querySelector('.div-error').style.display = 'none';
+
+  if (valueElem != parent) {
+    let oldValue = parent.getAttribute('data-old-value');
+    let type = qelem.getAttribute('data-type');
+    document.getElementById('setting').value = name;
+
+    if (type == 'bool') {
+      let isSet = value == _('Enabled');
+      changeButton.innerHTML = isSet ? _('Disable') : _('Enable');
+      valueField.value = isSet ? 'False' : 'True';
+      valueField.classList.add('hide');
+      label.classList.remove('hide');
+      label.innerHTML = value;
+    } else {
+      changeButton.innerHTML = _('Change');
+      valueField.value = value;
+      valueField.classList.remove('hide');
+      label.classList.add('hide');
+    }
+    valueElem.setAttribute('data-old-value', value);
+    changeForm.classList.remove('hide');
+    valueElem.innerHTML = "";
+    valueElem.appendChild(changeForm);
+    if (oldValue) {
+      parent.innerHTML = oldValue;
     }
   }
 });

--- a/app/static/js/Mod.js
+++ b/app/static/js/Mod.js
@@ -93,3 +93,75 @@ u.addEventForChild(document, 'change', '#flair_id', function (e, qelem) {
     document.querySelector('#assign_flair_form #text').classList.add('hide')
   }
 });
+
+
+// Admin site configuration page
+
+u.addEventForChild(document, 'click', '.admin-config-doc-toggle', function (e, qelem) {
+    let docElem = document.getElementById(qelem.id + "-doc");
+    if (docElem.classList.contains('hide')) {
+        docElem.classList.remove('hide');
+        qelem.innerHTML = "▿";
+    } else {
+        docElem.classList.add('hide')
+        qelem.innerHTML = "▹";
+    }
+});
+
+u.addEventForChild(document, 'click', '.admin-config-edit', function (e, qelem) {
+  const errorbox = document.querySelector('.error');
+  let name = qelem.getAttribute('data-setting');
+  let type = qelem.getAttribute('data-type');
+  errorbox.classList.add('hide');
+
+  if (type == 'bool') {
+    u.post('/do/admin/config/toggle', {setting: name},
+           function (data) {
+             if (data.status != 'ok') {
+               errorbox.classList.remove('hide');
+               errorbox.innerHTML = _('Error: %1', data.error);
+               errorbox.scrollIntoView();
+             } else {
+               window.location.reload();
+             }
+           }, function () {
+             errorbox.classList.remove('hide');
+             errorbox.innerHTML = _('Could not contact the server');
+             errorbox.scrollIntoView();
+           });
+  } else {
+    const changeForm = document.querySelector('.admin-config-edit-form');
+    let parent = changeForm.parentElement;
+    let valueElem = document.getElementById(name + '-value');
+    let value = valueElem.innerText;
+
+    if (valueElem != parent) {
+      let oldValue = parent.getAttribute('data-old-value');
+      document.getElementById('value').value = value;
+      document.getElementById('setting').value = name;
+      changeForm.querySelector('.div-error').style.display = 'none';
+      changeForm.classList.remove('hide')
+      valueElem.setAttribute('data-old-value', value);
+      valueElem.innerHTML = "";
+      valueElem.appendChild(changeForm);
+      if (oldValue) {
+        parent.innerHTML = oldValue;
+      }
+    }
+  }
+});
+
+u.addEventForChild(document, 'click', '#admin-config-edit-cancel', function (e, qelem) {
+  const changeForm = document.querySelector('.admin-config-edit-form');
+  let parent = changeForm.parentElement;
+  let formContainer = document.getElementById('form-container');
+
+  if (formContainer != parent) {
+    let oldValue = parent.getAttribute('data-old-value');
+    formContainer.appendChild(changeForm);
+    changeForm.classList.add('hide')
+    if (oldValue) {
+      parent.innerHTML = oldValue;
+    }
+  }
+});

--- a/app/templates/admin/admin.html
+++ b/app/templates/admin/admin.html
@@ -10,10 +10,10 @@
 {{ super() }}
 <div id="center-container">
   <div class="content">
-    {% if not enable_posting %}
+    {% if not config.site.enable_posting %}
       <div class="error" style="margin-top: 2em;">Posting has been temporarily disabled</div>
     {% endif %}
-    {% if not enable_registration %}
+    {% if not config.site.enable_registration %}
       <div class="error" style="margin-top: 2em;">Registration has been temporarily disabled</div>
     {% endif %}
     <h1>Admin</h1>
@@ -60,7 +60,7 @@
       </div>
       <div class="col-12 admin-page-form">
         <div>
-          {% if enable_posting %}
+          {% if config.site.enable_posting %}
           <div>Disable posting for non-admin users</div>
           <a class="pure-button button-warning" href="{{url_for('do.enable_posting', value='False')}}">Disable Posting</a>
           {% else %}
@@ -74,7 +74,7 @@
       </div>
       <div class="col-12 admin-page-form">
         <div>
-          {% if enable_registration %}
+          {% if config.site.enable_registration %}
           <div>Disable registration for new users</div>
           <a class="pure-button button-warning" href="{{url_for('do.enable_registration', value='False')}}">Disable Registration</a>
           {% else %}
@@ -88,7 +88,7 @@
       </div>
       <div class="col-12 admin-page-form">
         <div>
-          {% if enable_captchas %}
+          {% if config.site.require_captchas %}
           <div>Disable captchas for registration, password recovery and post creation</div>
           <a class="pure-button button-error" href="{{url_for('do.enable_captchas', value='False')}}">Disable Captchas</a>
           {% else %}

--- a/app/templates/admin/invitecodes.html
+++ b/app/templates/admin/invitecodes.html
@@ -20,13 +20,13 @@
         <div>
           <form id="useinvitecode" class="ajaxform nice-form pure-form pure-form-aligned" method="POST" action="{{url_for('do.use_invite_code')}}" data-reload="true">
             {{useinvitecodeform.csrf_token}}
-            <h2>Invite Code to register: {% if func.enableInviteCode() %}Enabled{% else %}Disabled{% endif %}</h2>
+            <h2>Invite Code to register: {% if config.site.require_invite_code %}Enabled{% else %}Disabled{% endif %}</h2>
             <fieldset>
                 <label for="enableinvitecode" class="pure-checkbox">
-                  {{useinvitecodeform.enableinvitecode(checked=func.enableInviteCode())}} {{useinvitecodeform.enableinvitecode.label.text}}
+                  {{useinvitecodeform.enableinvitecode(checked=config.site.require_invite_code)}} {{useinvitecodeform.enableinvitecode.label.text}}
                 </label>
                 <label for="invitations_visible_to_users" class="pure-checkbox">
-                  {{useinvitecodeform.invitations_visible_to_users(checked=func.user_visible_invitations())}} {{useinvitecodeform.invitations_visible_to_users.label.text}}
+                  {{useinvitecodeform.invitations_visible_to_users(checked=config.site.invitations_visible_to_users)}} {{useinvitecodeform.invitations_visible_to_users.label.text}}
                 </label>
                 <div class="pure-control-group">
                     <label for="confirm">{{useinvitecodeform.minlevel.label.text}}</label>

--- a/app/templates/admin/sidebar.html
+++ b/app/templates/admin/sidebar.html
@@ -14,4 +14,5 @@
 <a href="{{url_for('admin.domains', domain_type='link')}}" class="sbm-post pure-button">Banned Domains</a>
 <a href="{{url_for('admin.domains', domain_type='email')}}" class="sbm-post pure-button">Banned Email Domains</a>
 <hr>
+<a href="{{url_for('admin.configure')}}" class="sbm-post pure-button">Site configuration</a>
 <a href="{{url_for('site.view_sitelog')}}" class="sbm-post pure-button">Sitelog</a>

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -30,13 +30,12 @@ from ..forms import (
     EditModForm,
     BanDomainForm,
     WikiForm,
-)
-from ..forms import (
     CreateInviteCodeForm,
     UpdateInviteCodeForm,
     EditBadgeForm,
     NewBadgeForm,
     SetSubOfTheDayForm,
+    ChangeConfigSettingForm,
 )
 from ..models import (
     UserMetadata,
@@ -748,6 +747,20 @@ def reports(page):
             "subInfo": False,
             "subMods": False,
         }
+    )
+
+
+@bp.route("/configuration")
+@login_required
+def configure():
+    if not current_user.is_admin():
+        abort(404)
+
+    form = ChangeConfigSettingForm()
+
+    config_data = sorted(config.get_mutable_items(), key=(lambda x: x["name"]))
+    return engine.get_template("admin/configuration.html").render(
+        {"form": form, "config_data": config_data}
     )
 
 

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -22,7 +22,7 @@ from itsdangerous import URLSafeTimedSerializer
 from itsdangerous.exc import SignatureExpired, BadSignature
 from .. import misc
 from ..config import config
-from ..auth import auth_provider, registration_is_enabled, email_validation_is_required
+from ..auth import auth_provider, email_validation_is_required
 from ..auth import normalize_email, create_user
 from ..forms import LoginForm, RegistrationForm, ResendConfirmationForm
 from ..misc import engine, send_email, is_domain_banned
@@ -105,10 +105,8 @@ def register():
         del form.email_required
     captcha = misc.create_captcha()
 
-    if not registration_is_enabled():
-        return engine.get_template("user/registration_disabled.html").render(
-            {"test": "test"}
-        )
+    if not config.site.enable_registration:
+        return engine.get_template("user/registration_disabled.html").render({})
 
     if not form.validate():
         return engine.get_template("user/register.html").render(
@@ -184,7 +182,7 @@ def register():
                 }
             )
 
-    if misc.enableInviteCode():
+    if config.site.require_invite_code:
         if not form.invitecode.data:
             return engine.get_template("user/register.html").render(
                 {

--- a/app/views/subs.py
+++ b/app/views/subs.py
@@ -151,23 +151,18 @@ def create_post(ptype, sub):
             )
 
     # Put pre-posting checks here
-    if not current_user.is_admin():
-        try:
-            enable_posting = SiteMetadata.get(SiteMetadata.key == "enable_posting")
-            if enable_posting.value in ("False", "0"):
-                return (
-                    engine.get_template("sub/createpost.html").render(
-                        {
-                            "error": _("Posting has been temporarily disabled."),
-                            "form": form,
-                            "sub": sub,
-                            "captcha": captcha,
-                        }
-                    ),
-                    400,
-                )
-        except SiteMetadata.DoesNotExist:
-            pass
+    if not current_user.is_admin() and not config.site.enable_posting:
+        return (
+            engine.get_template("sub/createpost.html").render(
+                {
+                    "error": _("Posting has been temporarily disabled."),
+                    "form": form,
+                    "sub": sub,
+                    "captcha": captcha,
+                }
+            ),
+            400,
+        )
 
     if sub.name.lower() in ("all", "new", "hot", "top", "admin", "home"):
         return (

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -186,7 +186,7 @@ def view_user_uploads(page):
 @bp.route("/settings/invite")
 @login_required
 def invite_codes():
-    if not misc.enableInviteCode():
+    if not config.site.require_invite_code:
         return redirect("/settings")
 
     codes = InviteCode.select().where(InviteCode.user == current_user.uid)

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -13,6 +13,9 @@ site:
   # It can be anything EXCEPT 'u', 'c' or 'p'
   sub_prefix: 's'
 
+  # Maximum size of an uploaded file, in bytes.
+  upload_max_size: 16777216
+
   # List of links that will be shown in the footer.
   # Privacy and ToS links cannot be removed, and the license link can't be modified
   footer:

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,97 +1,17 @@
 # Any value in this file can be overridden by an environment variable
 # named using the keys, in upper case, joined by underscores.  So for
-# example, if the environment variable $SITE_NAME is set, its value
-# will be used instead of the site name declared below.
+# example, if the environment variable $SITE_SERVER_NAME is set, its
+# value will be used instead of the server name declared below.
 
 site:
-  name: 'Throat'
-  # Lema shown in the page's title
-  lema: 'Throat: Open discussion ;D'
-  # Copyright line shown in the footer
-  copyright: 'Umbrella Corp'
-
-  # If False we won't show the "Submit a post" button in the frontpage
-  front_page_submit: True
-
   # Domain name at which the app is being served.  This must be
   # configured for websocket support (chat and push new posts) on
   # Safari and Apple WebKit.  For development, you can omit this.
   #server_name: "throat.example.com"
 
-  # Name shown when a sub is owned by a deleted account or abandoned
-  placeholder_account: 'Site'
-
-  # Blocks anonymous users from being able to look at a particular user's
-  # posts or comments (IE blocks /u/<user>/posts and /u/<user>/comments
-  block_anon_stalking: False
-
   # Prefix for subs (by default it's 's').
   # It can be anything EXCEPT 'u', 'c' or 'p'
   sub_prefix: 's'
-
-  # Allow everybody to upload files
-  # (by default it's only admins and users authorized through a metadata key)
-  allow_uploads: False
-
-  # Minimum level a user must have before being able to upload files.
-  # Set to zero to disable file upload level limits
-  upload_min_level: 0
-
-  # For those who are allowed to upload files, allow video uploads
-  # (.mp4 and .webm) as well.
-  allow_video_uploads: True
-
-  # Maximum size of an uploaded file, in bytes.
-  upload_max_size: 16777216
-
-  # Allow chat access for all users
-  # If True, each user will have the option of disabling chat for themselves
-  enable_chat: True
-
-  # Allow all users to view the site log
-  # If False, only Admin can view the sitelog
-  sitelog_public: True
-
-  # Forces all the sub logs and banned user lists to be public and removes the option to make them private.
-  force_sublog_public: True
-
-  # Amount of time in seconds the post author can edit a post's title after the post
-  # was created. Set to zero to disable title editing (default is 5 minutes)
-  title_edit_timeout: 300
-
-  # If True, enables setting security questions on the admin page.
-  # Users will be asked to answer one of these security questions before registering
-  enable_security_question: False
-
-  # Only allow Admins to create new subs
-  # If True, only admins can create new subs
-  sub_creation_admin_only: False
-
-  # Minimum level required for a user to be permitted to private message nonprivileged users.
-  # Set to zero to allow users of all levels to PM other users.
-  # Users of any level may PM site admins.
-  send_pm_to_user_min_level: 3
-
-  # Minimum level a user must have before being able to create a sub.
-  # Set to zero to disable sub creation level limits
-  sub_creation_min_level: 2
-
-  # Allows Sub Mods and Admins to view the edit history of posts
-  edit_history: False
-
-  # Removes the name of the Mod or Admin who took action on a post or user in notifications sent to user
-  anonymous_modding: False
-
-  # Maximum amount of subs a single user can own.
-  # The actual amount of subs a user may register scales with user level (user level minus one)
-  # so a level 0 or level 1 user cannot register any subs. This scaling is disabled if `sub_creation_min_level` is zero
-  sub_ownership_limit: 20
-
-  # Maximum amount of posts a user can create in a single sub in a day
-  daily_sub_posting_limit: 10
-
-  # Maximum amount of posts a user can create in a single day
-  daily_site_posting_limit: 25
 
   # List of links that will be shown in the footer.
   # Privacy and ToS links cannot be removed, and the license link can't be modified
@@ -103,9 +23,6 @@ site:
       Donate: '/wiki/donate'
       Bugs: 'https://github.com/Phuks-co/throat/issues'
 
-  # Time after which post will be archived
-  archive_post_after: 60
-
   # Number of trusted proxies which set the X-Forwarded-For header
   # ahead of the application.  If you run the application behind
   # a load balancer, this should be set to 1 or more.
@@ -116,17 +33,6 @@ site:
   # This requires additional database configuration; see README.md for
   # more information.
   custom_hot_sort: False
-
-  recent_activity:
-    # Enables or disables the recent activity sidebar and the page in /activity
-    enabled: True
-    # If true, only show recent activity from default subs in the sidebar (recent activity for all subs will be shown in
-    # /activity)
-    defaults_only: False
-    # If true, only show recent comments (and not posts) in the sidebar
-    comments_only: False
-    # Number of entries to display in the recenta activity sidebar
-    max_entries: 10
 
   # URL of the icon to be used for push notifications
   icon_url: 'https://phuks.co/static/img/icon.png'
@@ -264,9 +170,6 @@ storage:
     # Same rules as thumbnails
     path: './stor'
     url: 'https://usercontent.example.com/'
-
-  # Max storage for image uploads for subs' stylesheets (in MiB)
-  sub_css_max_file_size: 2
 
 database:
   # Database engine. Possible values:

--- a/migrations/027_configuration_interface.py
+++ b/migrations/027_configuration_interface.py
@@ -1,0 +1,138 @@
+"""Peewee migrations -- 027_configuration_interface.py.
+
+Enter all the config values modifiable in the admin interface into SiteMetadata.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+from app.config import config
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+mutable_config_keys = [
+    "site.allow_uploads",
+    "site.allow_video_uploads",
+    "site.anonymous_modding",
+    "site.archive_post_after",
+    "site.block_anon_stalking",
+    "site.changelog_sub",
+    "site.copyright",
+    "site.daily_site_posting_limit",
+    "site.daily_sub_posting_limit",
+    "site.edit_history",
+    "site.enable_chat",
+    "site.enable_security_question",
+    "site.force_sublog_public",
+    "site.front_page_submit",
+    "site.lema",
+    "site.name",
+    "site.placeholder_account",
+    "site.recent_activity.comments_only",
+    "site.recent_activity.defaults_only",
+    "site.recent_activity.enabled",
+    "site.recent_activity.max_entries",
+    "site.send_pm_to_user_min_level",
+    "site.sitelog_public",
+    "site.sub_creation_admin_only",
+    "site.sub_creation_min_level",
+    "site.sub_ownership_limit",
+    "site.title_edit_timeout",
+    "site.upload_max_size",
+    "site.upload_min_level",
+    "storage.sub_css_max_file_size",
+]
+
+translate_config_keys = {
+    "enable_posting": "site.enable_posting",
+    "enable_registration": "site.enable_registration",
+    "invitations_visible_to_users": "site.invitations_visible_to_users",
+    "invite_level": "site.invite_level",
+    "invite_max": "site.invite_max",
+    "require_captchas": "site.require_captchas",
+    "useinvitecode": "site.require_invite_code",
+}
+
+new_defaults = {
+    "enable_posting": "1",
+    "enable_registration": "1",
+    "invitations_visible_to_users": "0",
+    "invite_level": "3",
+    "invite_max": "10",
+    "require_captchas": "1",
+    "useinvitecode": "0",
+}
+
+reverse_translate = {v: k for k, v in translate_config_keys.items()}
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    SiteMetadata = migrator.orm["site_metadata"]
+
+    def get_value(rec):
+        if rec["type"] == "bool":
+            return "1" if rec["value"] else "0"
+        else:
+            return str(rec["value"])
+
+    if not fake:
+        new_records = [
+            {"key": m["name"], "value": get_value(m)}
+            for m in config.get_mutable_items()
+            if m["name"] in mutable_config_keys
+        ]
+        SiteMetadata.insert_many(new_records).execute()
+
+        existing_records = SiteMetadata.select().where(
+            SiteMetadata.key << list(translate_config_keys.keys())
+        )
+        existing_keys = [rec.key for rec in existing_records]
+        for rec in existing_records:
+            rec.key = translate_config_keys[rec.key]
+            rec.save()
+        new_records = [
+            {"key": translate_config_keys[k], "value": v}
+            for k, v in new_defaults.items()
+            if k not in existing_keys
+        ]
+        SiteMetadata.insert_many(new_records).execute()
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(SiteMetadata.key << mutable_config_keys).execute()
+
+        existing_records = SiteMetadata.select().where(
+            SiteMetadata.key << list(reverse_translate.keys())
+        )
+        for rec in existing_records:
+            rec.key = reverse_translate[rec.key]
+            rec.save()

--- a/migrations/027_configuration_interface.py
+++ b/migrations/027_configuration_interface.py
@@ -63,7 +63,6 @@ mutable_config_keys = [
     "site.sub_creation_min_level",
     "site.sub_ownership_limit",
     "site.title_edit_timeout",
-    "site.upload_max_size",
     "site.upload_min_level",
     "storage.sub_css_max_file_size",
 ]

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -3,7 +3,7 @@ from flask import url_for
 from peewee import fn
 from app import mail
 from app.auth import email_validation_is_required
-from app.models import User, UserMetadata
+from app.models import User, UserMetadata, SiteMetadata
 
 
 def csrf_token(data):
@@ -33,6 +33,22 @@ def recursively_update(dictionary, new_values):
             recursively_update(dictionary[elem], new_values[elem])
         else:
             dictionary[elem] = new_values[elem]
+
+
+def add_config_to_site_metadata(config):
+    """Add config values to the database."""
+
+    def get_value(value, typ):
+        if typ == "bool":
+            return "1" if value else "0"
+        else:
+            return str(value)
+
+    new_records = [
+        {"key": key, "value": get_value(val, typ)}
+        for key, val, typ in config.mutable_item_configuration()
+    ]
+    SiteMetadata.insert_many(new_records).execute()
 
 
 def log_in_user(client, user_info, expect_success=True):


### PR DESCRIPTION
Allow admins to change many site settings from a new page which resembles FireFox's about:config.  The config settings which are necessary to get the site up in the first place remain in `config.yaml` or environment variables, and the remainder, which mostly control site behavior, move to the `SiteMetadata` table.  Two exceptions are `site.footer` and `site.expando_sites` which remain in `config.yaml` for now because they are not simple data types.  A new Site Configuration page allows the admin to edit all these settings.

This PR contains a new migration to create `SiteMetadata` entries based on the existing configuration, so admins of existing sites should run the migration with the same `config.yaml` and environment variables set that they have been using to run the site.  After the migration, check the new admin Site Configuration page, and any value listed there may now be removed from the config file and/or environment.  For future new installations, the migration will write the defaults from `config.py` to the database, and then the admin can change those settings using the Site Configuration page.