### PR TITLE
Fix footer links being out of order

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -357,7 +357,7 @@ def add_values_to_config(defaults, values, source):
     new dict, structured like cfg_defaults.  Every node will have at least
     'type', 'source' and 'value' keys."""
     result = {}
-    for key in set(list(defaults.keys()) + list(values.keys())):
+    for key in list(defaults.keys()) + list(values.keys()):
         value = values.get(key)
         default = defaults.get(key)
         if key not in defaults:


### PR DESCRIPTION
This fixes a regression from #333, which caused the footer links to be displayed in a different order than they are given in `config.yaml`.

The code to merge config dictionaries was converting the lists of keys in the two dictionaries into a set to avoid doing the same work twice, but the set conversion doesn't preserve the order of the keys.  The amount of work saved by using a set is not enough to matter, plus it's only done once at startup.