### PR TITLE
Various improvements to private messages

### DIFF
--- a/app/forms/user.py
+++ b/app/forms/user.py
@@ -170,6 +170,15 @@ class CreateUserMessageForm(FlaskForm):
     )
 
 
+class CreateUserMessageReplyForm(FlaskForm):
+    """ Form for replies to private messages. """
+
+    mid = HiddenField()
+    content = TextAreaField(
+        _l("message"), validators=[DataRequired(), Length(min=1, max=16384)]
+    )
+
+
 class PasswordRecoveryForm(FlaskForm):
     """ the 'forgot your password?' form """
 

--- a/app/html/shared/sidebar/messages.html
+++ b/app/html/shared/sidebar/messages.html
@@ -3,8 +3,8 @@
   <div>
     <a class="sbm-post pure-button" href="@{ url_for('messages.view_messages') }">
       @{_('Inbox')}
-      @if func.get_unread_count(func.MESSAGE_TYPE_PM) > 0:
-        <span class="newmsgcount"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> @{func.get_unread_count(func.MESSAGE_TYPE_PM)}</span>
+      @if func.get_unread_count() > 0:
+        <span class="newmsgcount"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> @{func.get_unread_count()}</span>
       @end
     </a>
   </div>

--- a/app/html/user/profile.html
+++ b/app/html/user/profile.html
@@ -13,7 +13,7 @@
             @if target_user_is_admin or current_user.can_pm_users() or current_user.is_admin():
                 <hr>
                 <div class="pmessage">
-                    <a href="#msg-form" data-replyto='@{user.name}' data-replytitle='' class="formpopmsg sbm-post pure-button">@{_('Send a message')}</a>
+                    <a href="#msg-form" data-replyto='@{user.name}' class="formpopmsg sbm-post pure-button">@{_('Send a message')}</a>
                 </div>
             @end
         @end

--- a/app/html/user/profile.html
+++ b/app/html/user/profile.html
@@ -146,15 +146,21 @@
                                     <label for="to">@{_('User')}</label>
                                     @{msgform.to(placeholder=msgform.to.label.text, required=True, value=user.name)!!html}
                                 </div>
-                                <div class="pure-control-group">
+                                <div>
                                     <label for="subject">@{_('Subject')}</label>
                                     @{msgform.subject(placeholder=msgform.subject.label.text, required=True)!!html}
                                 </div>
-                                <div class="pure-control-group markdown-editor">
-                                    @{msgform.content(placeholder=_('Styling with Markdown format is supported.'), rows="10", id="cntnt")!!html}
+                                <div class="pure-control-group markdown-editor" id="msge">
+                                  @{msgform.content(placeholder=_('Styling with Markdown format is supported.'), rows="10", id="cntnt")!!html}
                                 </div>
-                                <div class="pure-controls">
-                                    <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="@{_('Sending...')}">@{_('Send Message')}</button>
+                                <div>
+                                  <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="@{_('Sending...')}">@{_('Send Message')}</button>
+                                  <button data-pvid="msge" class="pure-button btn-preview">@{_('Preview')}</button>
+                                  <div class="cmpreview canclose" style="display:none;">
+                                    <h4>@{_('Message preview')}</h4>
+                                    <span class="closemsg">×</span>
+                                    <div class="cpreview-content"></div>
+                                  </div>
                                 </div>
                             </fieldset>
                         </form>

--- a/app/misc.py
+++ b/app/misc.py
@@ -1325,39 +1325,10 @@ def getMessagesIndex(page, uid=None):
             Message.posted,
             Message.read,
             Message.mtype,
-            Message.mlink,
         )
         msg = (
             msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.sentby))
             .where(Message.mtype == 1)
-            .where(Message.receivedby == uid)
-            .order_by(Message.mid.desc())
-            .paginate(page, 20)
-            .dicts()
-        )
-    except Message.DoesNotExist:
-        return False
-    return msg
-
-
-def getMentionsIndex(page):
-    """ Returns user mentions inbox """
-    try:
-        msg = Message.select(
-            Message.mid,
-            User.name.alias("username"),
-            Message.sentby,
-            Message.receivedby,
-            Message.subject,
-            Message.content,
-            Message.posted,
-            Message.read,
-            Message.mtype,
-            Message.mlink,
-        )
-        msg = (
-            msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.sentby))
-            .where(Message.mtype == 8)
             .where(Message.receivedby == current_user.uid)
             .order_by(Message.mid.desc())
             .paginate(page, 20)
@@ -1380,39 +1351,11 @@ def getMessagesSent(page):
             Message.posted,
             Message.read,
             Message.mtype,
-            Message.mlink,
         )
         msg = (
             msg.join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.receivedby))
             .where(Message.mtype << [1, 6, 9, 41])
             .where(Message.sentby == current_user.uid)
-            .order_by(Message.mid.desc())
-            .paginate(page, 20)
-            .dicts()
-        )
-    except Message.DoesNotExist:
-        return False
-    return msg
-
-
-def getMessagesModmail(page):
-    """ Returns modmail """
-    try:
-        msg = Message.select(
-            Message.mid,
-            User.name.alias("username"),
-            Message.receivedby,
-            Message.subject,
-            Message.content,
-            Message.posted,
-            Message.read,
-            Message.mtype,
-            Message.mlink,
-        )
-        msg = (
-            msg.join(User, on=(User.uid == Message.sentby))
-            .where(Message.mtype << [2, 7, 11])
-            .where(Message.receivedby == current_user.uid)
             .order_by(Message.mid.desc())
             .paginate(page, 20)
             .dicts()
@@ -1434,103 +1377,10 @@ def getMessagesSaved(page):
             Message.posted,
             Message.read,
             Message.mtype,
-            Message.mlink,
         )
         msg = (
             msg.join(User, on=(User.uid == Message.sentby))
             .where(Message.mtype == 9)
-            .where(Message.receivedby == current_user.uid)
-            .order_by(Message.mid.desc())
-            .paginate(page, 20)
-            .dicts()
-        )
-    except Message.DoesNotExist:
-        return False
-    return msg
-
-
-def getMsgCommReplies(page):
-    """ Returns comment replies messages """
-    try:
-        msg = Message.select(
-            Message.mid,
-            User.name.alias("username"),
-            Message.sentby,
-            Message.receivedby,
-            Message.subject,
-            Message.posted,
-            Message.read,
-            Message.mtype,
-            Message.mlink,
-            SubPostComment.pid,
-            SubPostComment.content,
-            SubPostComment.score,
-            SubPostCommentVote.positive,
-            Sub.name.alias("sub"),
-        )
-        msg = (
-            msg.join(SubPostComment, on=SubPostComment.cid == Message.mlink)
-            .join(SubPost)
-            .join(Sub)
-            .switch(SubPostComment)
-            .join(
-                SubPostCommentVote,
-                JOIN.LEFT_OUTER,
-                on=(
-                    (SubPostCommentVote.uid == current_user.uid)
-                    & (SubPostCommentVote.cid == Message.mlink)
-                ),
-            )
-        )
-        msg = (
-            msg.join(User, on=(User.uid == Message.sentby))
-            .where(Message.mtype == 5)
-            .where(Message.receivedby == current_user.uid)
-            .order_by(Message.mid.desc())
-            .paginate(page, 20)
-            .dicts()
-        )
-    except Message.DoesNotExist:
-        return False
-    return msg
-
-
-def getMsgPostReplies(page):
-    """ Returns post replies messages """
-    try:
-        msg = Message.select(
-            Message.mid,
-            User.name.alias("username"),
-            Message.sentby,
-            Message.receivedby,
-            Message.subject,
-            Message.posted,
-            Message.read,
-            Message.mtype,
-            Message.mlink,
-            SubPostCommentVote.positive,
-            SubPostComment.pid,
-            SubPostComment.score,
-            SubPostComment.content,
-            Sub.name.alias("sub"),
-        )
-        msg = (
-            msg.join(SubPostComment, on=SubPostComment.cid == Message.mlink)
-            .join(SubPost)
-            .join(Sub)
-            .switch(SubPostComment)
-            .join(
-                SubPostCommentVote,
-                JOIN.LEFT_OUTER,
-                on=(
-                    (SubPostCommentVote.uid == current_user.uid)
-                    & (SubPostCommentVote.cid == Message.mlink)
-                ),
-            )
-        )
-        msg = (
-            msg.join(User, on=(User.uid == Message.sentby))
-            .where(Message.mtype == 4)
             .where(Message.receivedby == current_user.uid)
             .order_by(Message.mid.desc())
             .paginate(page, 20)
@@ -1816,14 +1666,13 @@ def pick_random_security_question():
     return sc[1]
 
 
-def create_message(mfrom, to, subject, content, link, mtype):
+def create_message(mfrom, to, subject, content, mtype):
     """ Creates a message. """
     posted = datetime.utcnow()
     return Message.create(
         sentby=mfrom,
         receivedby=to,
         subject=subject,
-        mlink=link,
         content=content,
         posted=posted,
         mtype=mtype,

--- a/app/models.py
+++ b/app/models.py
@@ -832,11 +832,10 @@ class Notification(BaseModel):
 class Message(BaseModel):
     mid = PrimaryKeyField()
     content = TextField(null=True)
-    mlink = CharField(null=True)
+    mlink = CharField(null=True)  # Unused
     # mtype values:
-    # 1: sent, 4: post replies, 5: comment replies, 8: mentions, 9: saved message
+    # 1: sent, 9: saved message
     # 6: deleted, 41: ignored messages  => won't display anywhere
-    # 2 (mod invite), 7 (ban notification), 11 (deletion): modmail
     mtype = IntegerField(null=True)
     posted = DateTimeField(null=True)
     read = DateTimeField(null=True)

--- a/app/models.py
+++ b/app/models.py
@@ -843,8 +843,7 @@ class MessageType(IntEnum):
 
 
 class MessageMailbox(IntEnum):
-    """Mailboxes for private messages.
-    Used in UserMessageMailbox and ModMessageMailbox."""
+    """Mailboxes for private messages."""
 
     INBOX = 200
     SENT = 201

--- a/app/models.py
+++ b/app/models.py
@@ -829,19 +829,43 @@ class Notification(BaseModel):
         return f'<Notification target="{self.user}" type="{self.type}" >'
 
 
+class MessageType(IntEnum):
+    """Types of private messages.
+    Value of the 'mtype' field in Message."""
+
+    USER_TO_USER = 100
+    USER_TO_MODS = 101
+    MOD_TO_USER_AS_USER = 102
+    MOD_TO_USER_AS_MOD = 103
+    MOD_DISCUSSION = 104
+    USER_BAN_APPEAL = 105
+    MOD_NOTIFICATION = 106
+
+
+class MessageMailbox(IntEnum):
+    """Mailboxes for private messages.
+    Used in UserMessageMailbox and ModMessageMailbox."""
+
+    INBOX = 200
+    SENT = 201
+    SAVED = 202
+    ARCHIVED = 203  # Modmail only.
+    TRASH = 204
+    DELETED = 205
+
+
 class Message(BaseModel):
     mid = PrimaryKeyField()
     content = TextField(null=True)
-    mlink = CharField(null=True)  # Unused
-    # mtype values:
-    # 1: sent, 9: saved message
-    # 6: deleted, 41: ignored messages  => won't display anywhere
     mtype = IntegerField(null=True)
     posted = DateTimeField(null=True)
-    read = DateTimeField(null=True)
+
+    # Relevant for messages to individual users, otherwise NULL.
     receivedby = ForeignKeyField(
         db_column="receivedby", null=True, model=User, field="uid"
     )
+
+    # The user who created the message, even for modmails.
     sentby = ForeignKeyField(
         db_column="sentby",
         null=True,
@@ -849,10 +873,40 @@ class Message(BaseModel):
         backref="user_sentby_set",
         field="uid",
     )
+    reply_to = ForeignKeyField(
+        db_column="reply_to", null=True, model="self", field="mid"
+    )
+    replies = IntegerField(default=0)
     subject = CharField(null=True)
 
+    # Relevant for modmail messages, otherwise NULL.
+    sub = ForeignKeyField(db_column="sid", null=True, model=Sub, field="sid")
+
     def __repr__(self):
-        return f'<Message "{self.subject[:20]}"'
+        return f'<Message "{self.mid}"'
 
     class Meta:
         table_name = "message"
+
+
+class UserUnreadMessage(BaseModel):
+    uid = ForeignKeyField(db_column="uid", model=User, field="uid")
+    mid = ForeignKeyField(db_column="mid", model=Message, field="mid")
+
+    def __repr__(self):
+        return f'<UserUnreadMessage "{self.uid}/{self.mid}"'
+
+    class Meta:
+        table_name = "user_unread_message"
+
+
+class UserMessageMailbox(BaseModel):
+    uid = ForeignKeyField(db_column="uid", model=User, field="uid")
+    mid = ForeignKeyField(db_column="mid", model=Message, field="mid")
+    mailbox = IntegerField(default=MessageMailbox.INBOX)
+
+    def __repr__(self):
+        return f'<UserMessageMailbox "{self.uid}/{self.mid}"'
+
+    class Meta:
+        table_name = "user_message_mailbox"

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -63,19 +63,26 @@ u.sub('.deletenotif', 'click', function(e){
   });
 });
 
-// Toggle message reply
+// Show message reply
 u.sub('.pmessage .replymsg', 'click', function(e){
   e.preventDefault();
   var replyto = this.getAttribute('data-replyto')
   var title = this.getAttribute('data-replytitle')
   var mid = this.getAttribute('data-mid')
   document.querySelector('#msg-form #to').setAttribute('value', replyto);
-  if(document.querySelector('#msg-form #lto')){
-    document.querySelector('#msg-form #lto').style.display = 'none';
-  }
   document.querySelector('#msg-form #subject').setAttribute('value', 'Re:' + title);
   var modal = document.getElementById('msgpop');
-  document.querySelector('#replyto'+mid).appendChild(document.getElementById('msgpop'));
+  var existingParent = modal.parentNode;
+  var newParent = document.querySelector('#replyto'+mid);
+  if (existingParent != newParent) {
+    var markdownEditor = document.querySelector('#msg-form #content')
+    var existingContent = markdownEditor.value;
+    var newContent = newParent.getAttribute('data-content');
+    existingParent.setAttribute('data-content', existingContent);
+    newParent.appendChild(modal);
+    markdownEditor.value = newContent ? newContent : '';
+    document.querySelector('.cmpreview').style.display = 'none';
+  }
   modal.style.display = "block";
 });
 

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -90,22 +90,6 @@ u.sub('.pmessage .formpopmsg', 'click', function(e){
   modal.style.display = "block";
 });
 
-u.sub('.pmessage .replycom', 'click', function(e){
-  var replyto = this.getAttribute('data-replyto')
-  var post = this.getAttribute('data-post')
-  var sub = this.getAttribute('data-sub')
-  var parentid = this.getAttribute('data-parentid')
-  var mid = this.getAttribute('data-mid')
-  document.querySelector('#comment-form #from').innerHTML = replyto;
-  document.querySelector('#comment-form #sub').innerHTML = sub;
-  document.querySelector('#comment-form #post').setAttribute('value', post);
-  document.querySelector('#comment-form #sub').setAttribute('value', sub);
-  document.querySelector('#comment-form #parent').setAttribute('value', parentid);
-  var modal = document.getElementById('msgpop');
-  document.querySelector('#replyto'+mid).appendChild(document.getElementById('msgpop'));
-  modal.style.display = "block";
-});
-
 u.addEventForChild(document, 'click', '.closemsg', function(e, qelem){
   e.preventDefault();
   qelem.parentNode.style.display = 'none';

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -66,11 +66,8 @@ u.sub('.deletenotif', 'click', function(e){
 // Show message reply
 u.sub('.pmessage .replymsg', 'click', function(e){
   e.preventDefault();
-  var replyto = this.getAttribute('data-replyto')
-  var title = this.getAttribute('data-replytitle')
   var mid = this.getAttribute('data-mid')
-  document.querySelector('#msg-form #to').setAttribute('value', replyto);
-  document.querySelector('#msg-form #subject').setAttribute('value', 'Re:' + title);
+  document.querySelector('#msg-form #mid').setAttribute('value', mid);
   var modal = document.getElementById('msgpop');
   var existingParent = modal.parentNode;
   var newParent = document.querySelector('#replyto'+mid);

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -105,10 +105,10 @@ u.sub('.block', 'click', function(e){
   u.post('/do/toggle_ignore/'+uid, {},
   function(data){
     if (data.status == "ok") {
-      if(obj.innerHTML.trim() == _('block')){
-        u.each('a[data-uid="' + uid + '"]', function(el,i){el.innerHTML = _('unblock');});
+      if(obj.innerHTML.trim() == _('block sender')){
+        u.each('a[data-uid="' + uid + '"]', function(el,i){el.innerHTML = _('unblock sender');});
       }else{
-        u.each('a[data-uid="' + uid + '"]', function(el,i){el.innerHTML = _('block');});
+        u.each('a[data-uid="' + uid + '"]', function(el,i){el.innerHTML = _('block sender');});
       }
     }
   });

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -10,17 +10,14 @@ u.sub('.readmsg', 'click', function(e){
   u.post('/do/read_pm/'+mid, {},
   function(data){
     if (data.status == "ok") {
-      obj.innerHTML = _('read');
-      obj.classList.remove('readmsg');
-      obj.classList.add('read');
       obj.parentNode.parentNode.parentNode.classList.remove('newmsg');
+      obj.remove();
     }
   });
 });
 
 u.sub('.markall', 'click', function(e){
-  var bid = this.getAttribute('data-bid'),obj=this;
-  u.post('/do/readall_msgs/'+bid, {},
+  u.post('/do/readall_msgs', {},
   function(data){
     if (data.status == "ok") {
       document.location.reload();

--- a/app/templates/messages/ignores.html
+++ b/app/templates/messages/ignores.html
@@ -12,16 +12,23 @@
 {% block content %}
 {{ super() }}
 <div id="container">
-  {% if igns %}
-
-    {% for ig in igns %}
-    <li><span class="postflair">{{func.getUser(ig).name}}</span>
-      <form  method="POST" data-reload="true" action="{{url_for('do.ignore_user', uid=ig)}}" class="ajaxform" style="display: inline-block; margin-left: 1em; margin-top: 5px;">
-      <button type="submit" class="pure-button button-xsmall" id="editsub-btnsubmit" data-prog="Deleting..." data-success="Deleted!">Delete</button></form>
-    {% endfor %}
+  <div class="inbox content">
+    <h3 style="display: inline-block;"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> Blocked Users</h3>
+    {% if igns %}
+    <p class="helper-text">Messages from the users you have blocked will not be shown in your Inbox.</p>
+    <ul>
+      {% for ig in igns %}
+      <li>{{func.getUser(ig).name}}
+        <form  method="POST" data-reload="true" action="{{url_for('do.ignore_user', uid=ig)}}" class="ajaxform" style="display: inline-block; margin-left: 1em; margin-top: 5px;">
+          <button type="submit" class="pure-button button-xsmall" id="editsub-btnsubmit" data-prog="Deleting..." data-success="Unblocked!">Unblock</button>
+        </form>
+      </li>
+      {% endfor %}
+    </ul>
   {% else %}
   <h4>You haven't blocked anybody</h4>
   You can block users from the inbox.
   {%endif%}
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/messages/messages.html
+++ b/app/templates/messages/messages.html
@@ -42,9 +42,11 @@
                 <a class="readmsg" data-mid="{{message.mid}}">mark as read</a>
               {% endif %}
               <!--<a class="btn small">forward</a>-->
+              {% if message.username and not message.sub %}
+                <a class="block" data-uid="{{message.sentby}}">{{_("block sender") if message.sentby not in func.get_ignores(current_user.uid) else _("unblock sender")}}</a>
+              {% endif %}
               <a class="savemsg" data-mid="{{message.mid}}">save</a>
               <a class="deletemsg" data-mid="{{message.mid}}">delete</a>
-              <a class="block" data-uid="{{message.sentby}}">{% if message.sentby not in func.get_ignores(current_user.uid) %}block{%else%}unblock{%endif%}</a>
             </p>
           </div>
           <div id="replyto{{message.mid}}"></div>

--- a/app/templates/messages/messages.html
+++ b/app/templates/messages/messages.html
@@ -15,31 +15,32 @@
   <div class="inbox content">
     <div class="user-activity col-12">
       <h3 style="display: inline-block;"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> {{box_name}}</h3>
-      - <span class="links"><a data-bid="{{boxID}}" class="markall">Mark all as read</a></span>
+      - <span class="links"><a class="markall">Mark all as read</a></span>
       {% for message in messages %}
         <article class="pmessage post{% if not message.read %} newmsg{% endif %}">
           <div class="main">
             <p class="title">{{message.subject}}</p>
             <p class="container">{{markdown(message.content)|safe}}</p>
-            <p class="author"><time-ago datetime="{{message.posted.isoformat()}}Z"></time-ago></p>
-            <p class="container">
+            <p class="author">&#10148;
+              Sent <time-ago datetime="{{message.posted.isoformat()}}Z"></time-ago>
               {% if message.username %}
-              <a href="{{url_for('user.view', user=message.username)}}" class="btn small">/u/{{message.username}}</a>
-              {%else%}
-              <a href="#" class="btn small">Phuks</a>
-              {%endif%}
-              {% if message.read %}
-                <a class="read">read <time-ago datetime="{{message.read.isoformat()}}Z"></time-ago></a>
+                by <a href="{{url_for('user.view', user=message.username)}}">{{message.username}}</a>
+                {% if message.sub %}
+                  [as mod of <a href="{{url_for('sub.view_sub', sub=message.sub)}}">{{config.site.sub_prefix}}/{{message.sub}}</a>]
+                {% endif %}
+              {% elif message.sub %}
+                by the mods of <a href="{{url_for('sub.view_sub', sub=message.sub)}}">{{config.site.sub_prefix}}/{{message.sub}}</a>
               {% else %}
-                {% if message.mtype == 8 %}
-                  <a class="" data-mid="{{message.mid}}">new</a>
-                {%else%}
-                  <a class="readmsg" data-mid="{{message.mid}}">mark as read</a>
-                {%endif%}
+                by <a href="#">{{config.site.name}}</a>
               {% endif %}
-              {% if message.username %}
-              <a href="#msg-form" data-mid="{{message.mid}}" data-replyto='{{message.username}}' data-replytitle='{{message.subject}}' class="replymsg">reply</a>
-              {%endif%}
+            </p>
+            <p class="container">
+              {% if message.username or message.sub %}
+                <a href="#msg-form" data-mid="{{message.mid}}" class="replymsg">reply</a>
+              {% endif %}
+              {% if not message.read %}
+                <a class="readmsg" data-mid="{{message.mid}}">mark as read</a>
+              {% endif %}
               <!--<a class="btn small">forward</a>-->
               <a class="savemsg" data-mid="{{message.mid}}">save</a>
               <a class="deletemsg" data-mid="{{message.mid}}">delete</a>

--- a/app/templates/messages/messages.html
+++ b/app/templates/messages/messages.html
@@ -54,34 +54,5 @@
     {% include 'messages/nav.html' %}
   </div>
 </div>
-
-<div id="msgpop" style="display:none;">
-  <span class="closemsg">&times;</span>
-  <div class="modal-content">
-    <form data-reset="true" id="msg-form" action="{{url_for('do.create_sendmsg')}}" data-redir="{{url_for('messages.inbox_sort')}}" class="pure-form pure-form-aligned ajaxform">
-      {% set msgform = form.CreateUserMessageForm()%}
-      {{msgform.csrf_token}}
-      <h3>Send user message</h3>
-      <fieldset>
-        <div id="lto" class="pure-control-group">
-          <label for="to">User</label>
-          {{msgform.to(placeholder=msgform.to.label.text, required=True)}}
-        </div>
-        <div class="pure-control-group">
-          <label for="subject">Subject</label>
-          {{msgform.subject(placeholder=msgform.subject.label.text, required=True)}}
-        </div>
-        <div class="pure-control-group markdown-editor">
-          {{msgform.content(placeholder="Styling with Markdown format is supported.", rows="10", **{'data-provide' :"markdown"})}}
-        </div>
-        <div class="pure-controls">
-          {% if error %}
-            <div class="error">{{error}}</div>
-          {%endif%}
-          <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="Sending...">Send Message</button>
-        </div>
-      </fieldset>
-    </form>
-  </div>
-</div>
+{% include 'messages/reply.html' %}
 {% endblock %}

--- a/app/templates/messages/reply.html
+++ b/app/templates/messages/reply.html
@@ -1,13 +1,10 @@
 <div id="msgpop" style="display:none;">
   <span class="closemsg">&times;</span>
   <div class="modal-content">
-    <form data-reset="true" id="msg-form" action="{{url_for('do.create_sendmsg')}}" data-redir="{{url_for('messages.inbox_sort')}}" class="pure-form pure-form-aligned ajaxform">
-      {% set msgform = form.CreateUserMessageForm()%}
+    <form data-reset="true" id="msg-form" action="{{url_for('do.create_replymsg')}}" data-reload="true" class="pure-form pure-form-aligned ajaxform">
+      {% set msgform = form.CreateUserMessageReplyForm()%}
       {{msgform.csrf_token}}
-      <div class="hide">
-        {{msgform.to(placeholder=msgform.to.label.text, required=True)}}
-        {{msgform.subject(placeholder=msgform.subject.label.text, required=True)}}
-      </div>
+      {{msgform.mid(required=True)}}
       <div class="pure-control-group markdown-editor" id="msge">
         {{msgform.content(placeholder="Type your reply here. Styling with Markdown format is supported.", rows="10", **{'data-provide' :"markdown"})}}
       </div>
@@ -15,6 +12,7 @@
         {% if error %}
         <div class="error">{{error}}</div>
         {%endif%}
+        <div class="alert div-error"></div>
         <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="Sending...">Send Reply</button>
         <button data-pvid="msge" class="pure-button btn-preview">Preview</button>
         <div class="cmpreview canclose" style="display:none;">

--- a/app/templates/messages/reply.html
+++ b/app/templates/messages/reply.html
@@ -1,0 +1,28 @@
+<div id="msgpop" style="display:none;">
+  <span class="closemsg">&times;</span>
+  <div class="modal-content">
+    <form data-reset="true" id="msg-form" action="{{url_for('do.create_sendmsg')}}" data-redir="{{url_for('messages.inbox_sort')}}" class="pure-form pure-form-aligned ajaxform">
+      {% set msgform = form.CreateUserMessageForm()%}
+      {{msgform.csrf_token}}
+      <div class="hide">
+        {{msgform.to(placeholder=msgform.to.label.text, required=True)}}
+        {{msgform.subject(placeholder=msgform.subject.label.text, required=True)}}
+      </div>
+      <div class="pure-control-group markdown-editor" id="msge">
+        {{msgform.content(placeholder="Type your reply here. Styling with Markdown format is supported.", rows="10", **{'data-provide' :"markdown"})}}
+      </div>
+      <div>
+        {% if error %}
+        <div class="error">{{error}}</div>
+        {%endif%}
+        <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="Sending...">Send Reply</button>
+        <button data-pvid="msge" class="pure-button btn-preview">Preview</button>
+        <div class="cmpreview canclose" style="display:none;">
+          <h4>Reply preview</h4>
+          <span class="closemsg">×</span>
+          <div class="cpreview-content"></div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/templates/messages/saved.html
+++ b/app/templates/messages/saved.html
@@ -16,7 +16,7 @@
     <div class="user-activity col-12">
       <h3><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> Saved Messages</h3>
       {% for message in messages %}
-        <article class="pmessage post{% if not message.read %} newmsg{% endif %}" data-replyto='{{message.sentby}}' data-replytitle='Re: {{message.subject}}'>
+        <article class="pmessage post{% if not message.read %} newmsg{% endif %}">
           <div class="main">
             <p class="title">{{message.subject}}</p>
             <p class="container">{{markdown(message.content)|safe}}</p>
@@ -33,7 +33,7 @@
 	    </p>
             <p class="container">
               {% if message.username or message.sub %}
-                <a href="#msg-form" data-mid="{{message.mid}}" data-replyto='{{message.username}}' data-replytitle='{{message.subject}}' class="replymsg">reply</a>
+                <a href="#msg-form" data-mid="{{message.mid}}" class="replymsg">reply</a>
               {% endif %}
               {% if not message.read %}
                 <a class="readmsg" data-mid="{{message.mid}}">mark as read</a>

--- a/app/templates/messages/saved.html
+++ b/app/templates/messages/saved.html
@@ -20,21 +20,30 @@
           <div class="main">
             <p class="title">{{message.subject}}</p>
             <p class="container">{{markdown(message.content)|safe}}</p>
-            <p class="author"><time-ago datetime="{{message.posted.isoformat()}}Z"></time-ago></p>
+            <p class="author">&#10148;
+              Sent <time-ago datetime="{{message.posted.isoformat()}}Z"></time-ago>
+              {% if message.username %}
+                by <a href="{{url_for('user.view', user=message.username)}}">{{message.username}}</a>
+                {% if message.sub %}
+                  [as mod of <a href="{{url_for('sub.view_sub', sub=message.sub)}}">{{config.site.sub_prefix}}/{{message.sub}}</a>]
+                {% endif %}
+              {% elif message.sub %}
+                by the mods of <a href="{{url_for('sub.view_sub', sub=message.sub)}}">{{config.site.sub_prefix}}/{{message.sub}}</a>
+              {% endif %}
+	    </p>
             <p class="container">
-              <a href="{{url_for('user.view', user=message.username)}}" class="btn small">/u/{{message.username}}</a>
-              {% if message.read %}
-                <a class="read">read <time-ago datetime="{{message.read.isoformat()}}Z"></time-ago></a>
-              {% else %}
+              {% if message.username or message.sub %}
+                <a href="#msg-form" data-mid="{{message.mid}}" data-replyto='{{message.username}}' data-replytitle='{{message.subject}}' class="replymsg">reply</a>
+              {% endif %}
+              {% if not message.read %}
                 <a class="readmsg" data-mid="{{message.mid}}">mark as read</a>
               {% endif %}
-              <a href="#msg-form" data-mid="{{message.mid}}" data-replyto='{{message.username}}' data-replytitle='{{message.subject}}' class="replymsg">reply</a>
               <!--<a class="btn small">forward</a>-->
               <!--<a class="unsave btn small btn-red" data-mid="{{message.mid}}">unsave</a>-->
               <a class="deletemsg" data-mid="{{message.mid}}">delete</a>
             </p>
           </div>
-          <div id="replyto{{message.mid}}"><div>
+          <div id="replyto{{message.mid}}"></div>
         </article>
       {% endfor %}
     </div>

--- a/app/templates/messages/saved.html
+++ b/app/templates/messages/saved.html
@@ -50,34 +50,5 @@
     {% include 'messages/nav.html' %}
   </div>
 </div>
-
-<div id="msgpop" style="display:none;">
-  <span class="closemsg">&times;</span>
-  <div class="modal-content">
-    <form data-reset="true" id="msg-form" action="{{url_for('do.create_sendmsg')}}" data-redir="{{url_for('messages.inbox_sort')}}" class="pure-form pure-form-aligned ajaxform">
-      {% set msgform = form.CreateUserMessageForm()%}
-      {{msgform.csrf_token}}
-      <h3>Send user message</h3>
-      <fieldset>
-        <div class="pure-control-group">
-          <label for="to">User</label>
-          {{msgform.to(placeholder=msgform.to.label.text, required=True)}}
-        </div>
-        <div class="pure-control-group">
-          <label for="subject">Subject</label>
-          {{msgform.subject(placeholder=msgform.subject.label.text, required=True)}}
-        </div>
-        <div class="pure-control-group markdown-editor">
-          {{msgform.content(placeholder="Styling with Markdown format is supported.", rows="10", **{'data-provide' :"markdown"})}}
-        </div>
-        <div class="pure-controls">
-          {% if error %}
-            <div class="error">{{error}}</div>
-          {%endif%}
-          <button type="submit" id="msg-btnsubmit" class="pure-button pure-button-primary" data-prog="Sending...">Send Message</button>
-        </div>
-      </fieldset>
-    </form>
-  </div>
-</div>
+{% include 'messages/reply.html' %}
 {% endblock %}

--- a/app/templates/messages/sent.html
+++ b/app/templates/messages/sent.html
@@ -20,8 +20,12 @@
           <div class="main">
             <p class="title">{{message.subject}}</p>
             <p class="container">{{markdown(message.content)|safe}}</p>
-            <p class="author">&#10148;
-              <a href="{{url_for('user.view', user=message.username)}}" class="btn small">/u/{{message.username}}</a>
+            <p class="author">&#10148; Sent to
+              {% if message.username %}
+                <a href="{{url_for('user.view', user=message.username)}}" class="btn small">/u/{{message.username}}</a>
+              {% else %}
+                the mods of <a href="{{url_for('sub.view_sub', sub=message.sub)}}" class="btn small">/{{config.site.sub_prefix}}/{{message.sub}}</a>
+              {% endif %}
               <time-ago datetime="{{message.posted.isoformat()}}Z"></time-ago>
             </p>
           </div>

--- a/app/templates/messages/sidebar.html
+++ b/app/templates/messages/sidebar.html
@@ -3,8 +3,8 @@
   <div>
     <a class="sbm-post pure-button{% if box_route=='messages.view_messages' %} button-secondary{% endif %}" href="{{ url_for('messages.view_messages') }}">
       Inbox
-      {% if func.get_unread_count(func.MESSAGE_TYPE_PM) > 0 %}
-        <span class="newmsgcount"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> {{func.get_unread_count(func.MESSAGE_TYPE_PM)}}</span>
+      {% if func.get_unread_count() > 0 %}
+        <span class="newmsgcount"><span class="p-icon" data-icon="mail" style="display: inline-block;"></span> {{func.get_unread_count()}}</span>
       {% endif %}
     </a>
   </div>

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -857,8 +857,6 @@ def delete_comment(_sub, pid, cid):
     comment.status = 1
     comment.save()
 
-    q = Message.delete().where(Message.mlink == cid)
-    q.execute()
     return jsonify(), 200
 
 

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -38,6 +38,10 @@ from ..models import (
     SiteMetadata,
     UserMetadata,
     Message,
+    MessageType,
+    MessageMailbox,
+    UserUnreadMessage,
+    UserMessageMailbox,
     SubRule,
     Notification,
     SubMod,
@@ -1456,35 +1460,9 @@ def get_messages():
     page = request.args.get("page", default=1, type=int)
     # autoMarkAsRead = request.args.get('autoMarkAsRead', default=True, type=bool)
 
-    msg = (
-        Message.select(
-            Message.mid.alias("id"),
-            User.name.alias("sender"),
-            Message.subject,
-            Message.content,
-            Message.posted,
-            Message.read,
-            UserIgnores.id.alias("ignored"),
-        )
-        .join(
-            UserIgnores,
-            JOIN.LEFT_OUTER,
-            on=(UserIgnores.uid == uid) & (UserIgnores.target == Message.sentby),
-        )
-        .join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.sentby))
-        .where(Message.mtype == 1)
-        .where(Message.receivedby == uid)
-        .order_by(Message.mid.desc())
-        .paginate(page, 20)
-        .dicts()
-    )
+    msg = misc.get_messages_inbox(page, uid=uid)
 
-    msg = list(msg)
-
-    for i in msg:
-        i["content"] = misc.our_markdown(i["content"])
-
-    return jsonify(messages=list(msg))
+    return jsonify(messages=[message_fields_for_api(m) for m in msg])
 
 
 @API.route("/messages", methods=["DELETE"])
@@ -1499,12 +1477,17 @@ def delete_message():
         return jsonify(error="The messageId parameter is required"), 400
 
     try:
-        message = Message.get((Message.mid == message_id) & (Message.receivedby == uid))
-    except Notification.DoesNotExist:
+        Message.get((Message.mid == message_id) & (Message.receivedby == uid))
+    except Message.DoesNotExist:
         return jsonify(error="Message does not exist"), 404
 
-    message.mtype = 6
-    message.save()
+    UserUnreadMessage.delete().where(
+        (UserUnreadMessage.uid == uid) & (UserUnreadMessage.mid == message_id)
+    ).execute()
+    UserMessageMailbox.update(mailbox=MessageMailbox.DELETED).where(
+        (UserMessageMailbox.uid == uid) & (UserMessageMailbox.mid == message_id)
+    ).execute()
+
     return jsonify(status="ok")
 
 
@@ -1537,15 +1520,7 @@ def send_message():
         to=message_to.uid,
         subject=subject,
         content=content,
-        link=None,
-        mtype=1 if uid not in misc.get_ignores(message_to.uid) else 41,
-    )
-
-    socketio.emit(
-        "notification",
-        {"count": misc.get_notification_count(message_to.uid)},
-        namespace="/snt",
-        room="user" + message_to.uid,
+        mtype=MessageType.USER_TO_USER,
     )
     return jsonify(status="ok")
 
@@ -1556,29 +1531,9 @@ def get_sent_messages():
     """ Returns an array of sent messages """
     uid = get_jwt_identity()
     page = request.args.get("page", default=1, type=int)
+    msg = misc.get_messages_sent(page, uid)
 
-    msg = (
-        Message.select(
-            Message.mid.alias("id"),
-            User.name.alias("sender"),
-            Message.subject,
-            Message.content,
-            Message.posted,
-        )
-        .join(User, JOIN.LEFT_OUTER, on=(User.uid == Message.receivedby))
-        .where(Message.mtype << (1, 6, 9, 41))
-        .where(Message.sentby == uid)
-        .order_by(Message.mid.desc())
-        .paginate(page, 20)
-        .dicts()
-    )
-
-    msg = list(msg)
-
-    for i in msg:
-        i["content"] = misc.our_markdown(i["content"])
-
-    return jsonify(messages=list(msg))
+    return jsonify(messages=[message_fields_for_api(m) for m in msg])
 
 
 @API.route("/messages/<int:mid>/read", methods=["POST"])
@@ -1587,13 +1542,18 @@ def read_message(mid):
     """ Marks a message as read """
     uid = get_jwt_identity()
     try:
-        message = Message.get((Message.mid == mid) & (Message.receivedby == uid))
+        Message.get((Message.mid == mid) & (Message.receivedby == uid))
     except Message.DoesNotExist:
         return jsonify(error="Message not found"), 404
 
-    message.read = datetime.datetime.utcnow()
-    message.save()
+    try:
+        um = UserUnreadMessage.get(
+            (UserUnreadMessage.uid == uid) & (UserUnreadMessage.mid == mid)
+        )
+    except UserUnreadMessage.DoesNotExist:
+        return jsonify(status="ok")
 
+    um.delete_instance()
     socketio.emit(
         "notification",
         {"count": misc.get_notification_count(uid)},
@@ -1602,6 +1562,23 @@ def read_message(mid):
     )
 
     return jsonify(status="ok")
+
+
+def message_fields_for_api(m):
+    result = {k: v for k, v in m.items() if k in ["subject", "content", "posted"]}
+    if "read" in m:
+        result["read"] = m["read"]
+    if "ignored" in m:
+        result["ignored"] = m["ignored"]
+
+    result.update(
+        {
+            "id": m["mid"],
+            "sender": m["username"],
+            "content": misc.our_markdown(m["content"]),
+        }
+    )
+    return result
 
 
 @API.route("/user/settings", methods=["GET"])

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1361,7 +1361,6 @@ def create_sendmsg():
             to=user.uid,
             subject=form.subject.data,
             content=form.content.data,
-            link=None,
             mtype=1 if current_user.uid not in misc.get_ignores(user.uid) else 41,
         )
         socketio.emit(
@@ -2697,9 +2696,6 @@ def delete_comment():
             comment.status = 1
 
         comment.save()
-
-        q = Message.delete().where(Message.mlink == form.cid.data)
-        q.execute()
         return jsonify(status="ok")
     return json.dumps({"status": "error", "error": get_errors(form)})
 

--- a/app/views/messages.py
+++ b/app/views/messages.py
@@ -15,7 +15,7 @@ bp = Blueprint("messages", __name__)
 @login_required
 def inbox_sort():
     """ Go to inbox with the new message """
-    if misc.get_unread_count(misc.MESSAGE_TYPE_PM) > 0:
+    if misc.get_unread_count() > 0:
         return redirect(url_for("messages.view_messages"))
     elif misc.get_notif_count():
         return redirect(url_for("messages.view_notifications"))
@@ -65,13 +65,12 @@ def delete_notification(mid):
 @login_required
 def view_messages(page):
     """ View user's messages """
-    msgs = misc.getMessagesIndex(page)
+    msgs = misc.get_messages_inbox(page)
     return render_template(
         "messages/messages.html",
         page=page,
         messages=msgs,
         box_name="Inbox",
-        boxID="1",
         box_route="messages.view_messages",
     )
 
@@ -81,7 +80,7 @@ def view_messages(page):
 @login_required
 def view_messages_sent(page):
     """ View user's messages sent """
-    msgs = misc.getMessagesSent(page)
+    msgs = misc.get_messages_sent(page)
     return render_template(
         "messages/sent.html",
         messages=msgs,
@@ -103,7 +102,7 @@ def view_ignores():
 @login_required
 def view_saved_messages(page):
     """ WIP: View user's saved messages """
-    msgs = misc.getMessagesSaved(page)
+    msgs = misc.get_messages_saved(page)
     return render_template(
         "messages/saved.html",
         messages=msgs,

--- a/migrations/028_message_types_and_mailboxes.py
+++ b/migrations/028_message_types_and_mailboxes.py
@@ -1,0 +1,170 @@
+"""Peewee migrations -- 028_message_types_and_mailboxes.py
+
+Modify the Message model to separate message mailboxes for sender and
+receiver, to support multiple receivers, and to support a future
+implentation of modmail.
+
+"""
+
+import datetime as dt
+from enum import IntEnum
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+class MessageType(IntEnum):
+    """Types of private messages.
+    Value of the 'mtype' field in Message."""
+
+    USER_TO_USER = 100
+    USER_TO_MODS = 101
+    MOD_TO_USER_AS_USER = 102
+    MOD_TO_USER_AS_MOD = 103
+    MOD_DISCUSSION = 104
+    USER_BAN_APPEAL = 105
+    MOD_NOTIFICATION = 106
+
+
+class MessageMailbox(IntEnum):
+    """Mailboxes for private messages.
+    Used in UserMessageMailbox and ModMessageMailbox."""
+
+    INBOX = 200
+    SENT = 201
+    SAVED = 202
+    ARCHIVED = 203  # Modmail only.
+    TRASH = 204
+    DELETED = 205
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+
+    User = migrator.orm["user"]
+    Message = migrator.orm["message"]
+    Sub = migrator.orm["sub"]
+
+    @migrator.create_model
+    class UserUnreadMessage(pw.Model):
+        id = pw.AutoField()
+        uid = pw.ForeignKeyField(db_column="uid", model=User, field="uid")
+        mid = pw.ForeignKeyField(db_column="mid", model=Message, field="mid")
+
+        class Meta:
+            table_name = "user_unread_message"
+
+    @migrator.create_model
+    class UserMessageMailbox(pw.Model):
+        uid = pw.ForeignKeyField(db_column="uid", model=User, field="uid")
+        mid = pw.ForeignKeyField(db_column="mid", model=Message, field="mid")
+        mailbox = pw.IntegerField(default=MessageMailbox.INBOX)
+
+        class Meta:
+            table_name = "user_message_mailbox"
+
+    if not fake:
+        UserUnreadMessage.create_table(True)
+        UserMessageMailbox.create_table(True)
+        for msg in Message.select():
+            if not msg.read:
+                UserUnreadMessage.create(mid=msg.mid, uid=msg.receivedby)
+            old_mtype = msg.mtype
+            msg.mtype = MessageType.USER_TO_USER
+            msg.save()
+
+            if old_mtype == 9:
+                mailbox = MessageMailbox.SAVED
+            elif old_mtype == 6:
+                mailbox = MessageMailbox.DELETED
+            else:
+                mailbox = MessageMailbox.INBOX
+            UserMessageMailbox.create(mid=msg.mid, uid=msg.receivedby, mailbox=mailbox)
+            UserMessageMailbox.create(
+                mid=msg.mid, uid=msg.sentby, mailbox=MessageMailbox.SENT
+            )
+
+    migrator.add_fields(
+        "message",
+        reply_to=pw.ForeignKeyField(
+            db_column="reply_to", null=True, model="self", field="mid"
+        ),
+    )
+    migrator.add_fields(
+        "message",
+        sub=pw.ForeignKeyField(db_column="sid", null=True, model=Sub, field="sid"),
+    )
+    migrator.add_fields("message", replies=pw.IntegerField(default=0))
+
+    migrator.remove_fields("message", "mlink")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+
+    UserMessageMailbox = migrator.orm["user_message_mailbox"]
+    UserUnreadMessage = migrator.orm["user_unread_message"]
+    Message = migrator.orm["message"]
+    UserIgnores = migrator.orm["user_ignores"]
+
+    now = dt.datetime.utcnow()
+    if not fake:
+        for msg in (
+            Message.select()
+            .join(
+                UserUnreadMessage,
+                pw.JOIN.LEFT_OUTER,
+                on=(
+                    (UserUnreadMessage.mid == Message.mid)
+                    & (UserUnreadMessage.uid == Message.receivedby)
+                ),
+            )
+            .where(UserUnreadMessage.mid.is_null())
+        ):
+            msg.read = now
+            msg.save()
+
+        query = Message.select().join(
+            UserMessageMailbox,
+            pw.JOIN.INNER,
+            on=(
+                (UserMessageMailbox.mid == Message.mid)
+                & (UserMessageMailbox.uid == Message.receivedby)
+            ),
+        )
+        for msg in query.where(UserMessageMailbox.mailbox == MessageMailbox.SAVED):
+            msg.mtype = 9
+            msg.save()
+        for msg in query.where(UserMessageMailbox.mailbox == MessageMailbox.DELETED):
+            msg.mtype = 6
+            msg.save()
+        for msg in query.where(UserMessageMailbox.mailbox == MessageMailbox.INBOX):
+            msg.mtype = 1
+            msg.save()
+
+        for msg in Message.select().join(
+            UserIgnores,
+            pw.JOIN.RIGHT_OUTER,
+            on=(
+                (UserIgnores.uid == Message.receivedby)
+                & (UserIgnores.target == Message.sentby)
+            ),
+        ):
+            msg.mtype = 41
+            msg.save()
+
+    migrator.add_fields("message", mlink=pw.CharField(null=True))
+
+    migrator.remove_fields("message", "reply_to")
+    migrator.remove_fields("message", "sub")
+    migrator.remove_fields("message", "replies")
+
+    migrator.remove_model("user_unread_message")
+    migrator.remove_model("user_message_mailbox")
+    migrator.remove_model("sub_message_mailbox")

--- a/migrations/029_message_read.py
+++ b/migrations/029_message_read.py
@@ -1,0 +1,27 @@
+"""Peewee migrations -- 029_message_read.py
+
+Remove an unused field from the Message model.
+
+"""
+
+import datetime as dt
+from enum import IntEnum
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    migrator.remove_fields("message", "read")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    migrator.add_fields("message", read=pw.DateTimeField(null=True))

--- a/test/specs/test_messages.py
+++ b/test/specs/test_messages.py
@@ -1,0 +1,348 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from app.models import User
+
+from test.utilities import csrf_token
+from test.utilities import register_user, log_in_user, log_out_current_user
+
+
+def substrings_present(data, snippets, exclude=False):
+    """Return True if all the strings in `snippets` are found in `data`.
+    If `exclude` is True, instead return True if none of the strings
+    in `snippets` are found.
+
+    """
+    results = (snip.encode("utf-8") in data for snip in snippets)
+    if exclude:
+        results = (not val for val in results)
+    return all(results)
+
+
+def test_send_and_receive_pm(client, user_info, user2_info):
+    """Send and receive a private message."""
+    username = user_info["username"]
+    register_user(client, user_info)
+    register_user(client, user2_info)
+
+    # User2 sends User a message.
+    rv = client.get(url_for("user.view", user=username))
+    assert rv.status == "200 OK"
+    client.post(
+        url_for("do.create_sendmsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data),
+            to=username,
+            subject="Testing",
+            content="Test Content",
+        ),
+        follow_redirects=True,
+    )
+
+    # User2 sees the message in Sent Messages.
+    rv = client.get(url_for("messages.view_messages_sent"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(rv.data, [username, "Testing", "Test Content"])
+
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user_info, expect_success=True)
+
+    # User has one new message.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "1"
+
+    # User sees the message on the inbox page.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"]
+    )
+
+    # User marks the message as read.
+    soup = BeautifulSoup(rv.data, "html.parser")
+    tag = soup.find(lambda tag: tag.has_attr("data-mid"))
+    mid = tag.attrs["data-mid"]
+
+    rv = client.post(
+        url_for("do.read_pm", mid=mid),
+        data=dict(csrf_token=csrf_token(rv.data)),
+    )
+
+    # User returns to home page; notifications count now 0.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "0"
+
+
+def test_block_pm(client, user_info, user2_info):
+    """Block and unblock private messages from a user."""
+    username = user_info["username"]
+    register_user(client, user_info)
+    register_user(client, user2_info)
+
+    # User2 sends User a message.
+    rv = client.get(url_for("user.view", user=username))
+    assert rv.status == "200 OK"
+    client.post(
+        url_for("do.create_sendmsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data),
+            to=username,
+            subject="Testing",
+            content="Test Content",
+        ),
+        follow_redirects=True,
+    )
+
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user_info, expect_success=True)
+
+    # User blocks User2.
+    user2 = User.get(User.name == user2_info["username"])
+    rv = client.post(
+        url_for("do.ignore_user", uid=user2.uid),
+        data=dict(csrf_token=csrf_token(rv.data)),
+    )
+
+    # User doesn't have a notification for blocked message.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "0"
+
+    # Message not visible in User's inbox.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"], exclude=True
+    )
+
+    # User2 shows up on User's ignore page.
+    rv = client.get(url_for("messages.view_ignores"))
+    assert rv.status == "200 OK"
+    assert user2_info["username"].encode("utf-8") in rv.data
+
+    # User unblocks User2.
+    rv = client.post(
+        url_for("do.ignore_user", uid=user2.uid),
+        data=dict(csrf_token=csrf_token(rv.data)),
+    )
+
+    # User now has a notification for message.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "1"
+
+    # Message now visible in User's inbox.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"]
+    )
+
+    # User2 does not show up on User's ignore page.
+    rv = client.get(url_for("messages.view_ignores"))
+    assert rv.status == "200 OK"
+    assert user2_info["username"].encode("utf-8") not in rv.data
+
+
+def test_save_and_delete_pm(client, user_info, user2_info):
+    """Save and delete a private message."""
+    username = user_info["username"]
+    register_user(client, user_info)
+    register_user(client, user2_info)
+
+    # User2 sends User a message.
+    rv = client.get(url_for("user.view", user=username))
+    assert rv.status == "200 OK"
+    client.post(
+        url_for("do.create_sendmsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data),
+            to=username,
+            subject="Testing",
+            content="Test Content",
+        ),
+        follow_redirects=True,
+    )
+
+    # Switch users.
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user_info, expect_success=True)
+
+    # Message visible in User's inbox.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"]
+    )
+
+    # User saves the message.
+    soup = BeautifulSoup(rv.data, "html.parser")
+    tag = soup.find(lambda tag: tag.has_attr("data-mid"))
+    mid = tag.attrs["data-mid"]
+    rv = client.post(
+        url_for("do.save_pm", mid=mid),
+        data=dict(csrf_token=csrf_token(rv.data)),
+        follow_redirects=True,
+    )
+    assert b"error" not in rv.data
+
+    # Message now no longer appears in inbox.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"], exclude=True
+    )
+
+    # Message appears in saved messages.
+    rv = client.get(url_for("messages.view_saved_messages"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"]
+    )
+
+    # User deletes message from saved messages.
+    rv = client.post(
+        url_for("do.delete_pm", mid=mid),
+        data=dict(csrf_token=csrf_token(rv.data)),
+        follow_redirects=True,
+    )
+    assert b"error" not in rv.data
+
+    # Message is no longer in saved messages.
+    rv = client.get(url_for("messages.view_saved_messages"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"], exclude=True
+    )
+
+    # Message is not in User's inbox either.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"], exclude=True
+    )
+
+
+def test_exchange_pm(client, user_info, user2_info):
+    """Send a private message and have an exchange of replies."""
+    username = user_info["username"]
+    register_user(client, user_info)
+    register_user(client, user2_info)
+
+    # User2 sends User a message.
+    rv = client.get(url_for("user.view", user=username))
+    assert rv.status == "200 OK"
+    rv = client.post(
+        url_for("do.create_sendmsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data),
+            to=username,
+            subject="Testing",
+            content="Test Content",
+        ),
+        follow_redirects=True,
+    )
+    assert b"error" not in rv.data
+
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user_info, expect_success=True)
+
+    # User sees the message on the inbox page.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Testing", "Test Content"]
+    )
+
+    # User replies to the message.
+    soup = BeautifulSoup(rv.data, "html.parser")
+    tag = soup.find(lambda tag: tag.has_attr("data-mid"))
+    mid = tag.attrs["data-mid"]
+
+    rv = client.post(
+        url_for("do.create_replymsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data), mid=mid, content="Test reply content"
+        ),
+    )
+    assert b"error" not in rv.data
+
+    # User sees the message in Sent Messages.
+    rv = client.get(url_for("messages.view_messages_sent"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user2_info["username"], "Re: Testing", "Test reply content"]
+    )
+
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user2_info, expect_success=True)
+
+    # User2 has one new message.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "1"
+
+    # User2 sees the message on the inbox page.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user_info["username"], "Re: Testing", "Test reply content"]
+    )
+
+    # User2 replies to the reply.
+    soup = BeautifulSoup(rv.data, "html.parser")
+    tag = soup.find(lambda tag: tag.has_attr("data-mid"))
+    mid = tag.attrs["data-mid"]
+    rv = client.post(
+        url_for("do.create_replymsg"),
+        data=dict(
+            csrf_token=csrf_token(rv.data), mid=mid, content="Test 2nd reply content"
+        ),
+    )
+    assert b"error" not in rv.data
+
+    # User2 sees reply in Sent Messages.
+    rv = client.get(url_for("messages.view_messages_sent"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert substrings_present(
+        rv.data, [user_info["username"], "Re: Testing", "Test 2nd reply content"]
+    )
+    assert b"Re: Re: Testing" not in rv.data
+
+    log_out_current_user(client, verify=True)
+    log_in_user(client, user_info, expect_success=True)
+
+    # User now has two new messages.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "2"
+
+    # User sees the message on the inbox page.
+    rv = client.get(url_for("messages.inbox_sort"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    assert b"Test 2nd reply content" in rv.data
+
+    # User uses the mark all as read link.
+    rv = client.post(url_for("do.readall_msgs"), data={})
+    assert b"error" not in rv.data
+
+    # User now has no new messages.
+    rv = client.get(url_for("home.index"), follow_redirects=True)
+    assert rv.status == "200 OK"
+    soup = BeautifulSoup(rv.data, "html.parser")
+    link = soup.find(href=url_for("messages.inbox_sort"))
+    assert link.get_text().strip() == "0"


### PR DESCRIPTION
Improve the database models pertaining to private messages to separate the concerns of the type of a message, its read or unread status, and which mailbox it is in.  Allow a message to have different read statuses and mailboxes for different users, which will allow for users to delete messages from their sent folders without deleting them from the recipient's inbox, and will allow messages to have multiple recipients who can mark them read independently.  Support a future Trash folder, add a field to connect replies to their original message which will permit a future threaded view of PM conversations, and add a related sub field and some new message types to support moderator mail, messaging between users and the mods of a sub as a group.

Simplify the message reply form on the inbox and saved message pages by removing the To and Subject fields.  Automatically attach the "Re:" to the subject on replies, make that "Re:" translatable, and fix the accumulation of "Re:"'s that could happen in the subjects of private message conversations.  Move the HTML for the reply form into a file shared by the inbox and saved message templates.  Add a markdown preview to the reply form as well as the send message modal on the user profile page.

On the inbox and saved message pages, reorder the buttons under each message.  Put the sender's name in a link instead of a button, next to the timeago.  Instead of showing a non-working "Read" button for messages which have been marked read, remove it.  Change the "Block" button to say "Block sender".

Improve the styling of the Blocked Users page, and fix a bug where the block function was comparing localized and non-localized text.

Remove some unused code pertaining to messages, and add some tests.
