### PR TITLE
Add a --dirname option to the migration commands

### DIFF
--- a/cli/migration.py
+++ b/cli/migration.py
@@ -8,14 +8,29 @@ from app.models import dbp as database
 migration = AppGroup("migration", help="Manages database migrations")
 
 
-def get_router():
+def get_router(migrate_dir):
     database.connect()
     logger = logging.getLogger("migration")
     logger.setLevel(logging.DEBUG)
+    migrate_table = (
+        "migratehistory" if migrate_dir == "migrations" else migrate_dir + "_history"
+    )
 
     return Router(
-        database, migrate_dir="migrations", ignore=["basemodel"], logger=logger
+        database,
+        migrate_table=migrate_table,
+        migrate_dir=migrate_dir,
+        ignore=["basemodel"],
+        logger=logger,
     )
+
+
+def dirname_option(f):
+    return click.option(
+        "--dirname",
+        default="migrations",
+        help='Name of directory containing migrations (the default is "migrations")',
+    )(f)
 
 
 @migration.command(help="Applies all pending migrations")
@@ -25,28 +40,46 @@ def get_router():
     is_flag=True,
     help="Marks the migrations as finished but does not run them",
 )
-def apply(fake):
-    router = get_router()
+@dirname_option
+def apply(fake, dirname):
+    router = get_router(dirname)
     router.run(fake=fake)
+
+
+@migration.command(help="Applies migrations up to and including the named one ")
+@click.argument("name")
+@click.option(
+    "--fake",
+    default=False,
+    is_flag=True,
+    help="Marks the migrations as finished but does not run them",
+)
+@dirname_option
+def apply_up_to(fake, dirname, name):
+    router = get_router(dirname)
+    router.run(name=name, fake=fake)
 
 
 @migration.command(help="Rolls back a migration")
 @click.argument("name")
-def rollback(name):
-    router = get_router()
+@dirname_option
+def rollback(name, dirname):
+    router = get_router(dirname)
     router.rollback(name)
 
 
 @migration.command(help="Creates a new migration")
 @click.argument("name")
-def create(name):
-    router = get_router()
+@dirname_option
+def create(name, dirname):
+    router = get_router(dirname)
     router.create(name, True)
 
 
 @migration.command(name="list", help="Lists all migrations")
-def list_admins():
-    router = get_router()
+@dirname_option
+def list_migrations(dirname):
+    router = get_router(dirname)
     all_migrations = router.todo
     applied_migrations = router.done
     for m in all_migrations:


### PR DESCRIPTION
Support multiple directories of migration files, by adding an option to the migration commands to specify the directory to look in for migration files.  Each directory will have its own associated migration history table in the database.  Also add a new command, `throat.py migration apply-up-to NAME` to run a partial sequence of migrations.

This will allow developers who are working on long-running branches which include migrations to periodically rebase or merge their branches with `master` without having to renumber the migrations they have under development each time.  Instead, they can keep their migrations under development in a separate directory, and move them to the `migrations` directory when they are ready to make a PR.  

This will also allow forks of this project to have their own local directory of migrations to support custom features, without experiencing migration number collisions.  It will still be up to the developer or the fork administrator to ensure that the migrations in the main directory and any additional directories are run in the desired order and do not conflict with each other.

