### PR TITLE
In user post and comment listings, show deleted items to mods and admins

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -966,6 +966,8 @@ def postListQueryBase(
     nofilter=False,
     noAllFilter=False,
     noDetail=False,
+    # include_deleted_posts is either True, False or a list of
+    # subs to include deleted posts from.
     include_deleted_posts=False,
     isSubMod=False,
 ):
@@ -1064,8 +1066,14 @@ def postListQueryBase(
             on=((SubUserFlair.sub == Sub.sid) & (SubUserFlair.user == SubPost.uid)),
         )
     )
-    if not include_deleted_posts:
+    if include_deleted_posts:
+        if isinstance(include_deleted_posts, list):
+            posts = posts.where(
+                (SubPost.deleted == 0) | (Sub.sid << include_deleted_posts)
+            )
+    else:
         posts = posts.where(SubPost.deleted == 0)
+
     if not noAllFilter and not nofilter:
         if current_user.is_authenticated and current_user.blocksid:
             posts = posts.where(SubPost.sid.not_in(current_user.blocksid))
@@ -1549,7 +1557,9 @@ def getMsgPostReplies(page):
 
 
 def getUserComments(uid, page, include_deleted_comments=False):
-    """ Returns comments for a user """
+    """Returns comments for a user.  'include_deleted_comments' may be
+    True, False or a list of subs, in which case deleted comments from
+    those subs will be included in the result."""
     try:
         com = (
             SubPostComment.select(
@@ -1572,7 +1582,13 @@ def getUserComments(uid, page, include_deleted_comments=False):
             .join(Sub, on=(Sub.sid == SubPost.sid))
             .where(SubPostComment.uid == uid)
         )
-        if not include_deleted_comments:
+        if include_deleted_comments:
+            if isinstance(include_deleted_comments, list):
+                com = com.where(
+                    SubPostComment.status.is_null()
+                    | (Sub.sid << include_deleted_comments)
+                )
+        else:
             com = com.where(SubPostComment.status.is_null())
 
         com = com.order_by(SubPostComment.time.desc()).paginate(page, 20).dicts()


### PR DESCRIPTION
When a sub mod has a troublesome user who they have to decide whether or not to ban, they should be able to look at that user's track record of contributions to their sub, including content that was deleted because it violated sub rules.  This change to the user post and comment listings will show admins all of a user's deleted posts and comments and will show sub mods the deleted posts and comments from their subs.

While I was at it, I removed the "reply" link from deleted comments, since the reply box would allow you to type but then always give an error on submit.