### PR TITLE
Remove links to edit and reply to deleted or archived posts and comments

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -56,7 +56,7 @@
     <div class="postbar post @{((post['visibility'] != '') and (post['visibility'] != 'none')) and 'deleted ' or ''} @{(post['distinguish'] == 1 and 'mod' or '')} @{(post['distinguish'] == 2 and 'admin' or '')} " pid="@{post['pid']}">
     <div class="misctainer">
       <div class="votebuttons">
-        @if post['userstatus'] != 10 and (datetime.datetime.utcnow() - post['posted'].replace(tzinfo=None)) < datetime.timedelta(days=config.site.archive_post_after):
+        @if post['userstatus'] != 10 and not post['is_archived']:
           <div title="@{_('Upvote')}" class="upvote @{(post.get('positive') == 1) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
           <div class="score">@{post['score']}</div>
           <div title="@{_('Downvote')}" class="downvote @{(post.get('positive') == 0) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>
@@ -316,7 +316,7 @@
   @end
   </div>
 
-  @if current_user.is_authenticated and post['deleted'] == 0 and not current_user.is_subban(sub) and not postmeta.get('lock-comments'):
+  @if current_user.is_authenticated and post['deleted'] == 0 and not current_user.is_subban(sub) and not postmeta.get('lock-comments') and not post['is_archived']:
   <form data-reset="true" data-redir="true" action="@{url_for('do.create_comment', pid=post['pid'])}" id="rcomm-0" class="comment-form ajaxform static pure-form">
     @{commentform.csrf_token()!!html}
     @{commentform.post(value=post['pid'])!!html}
@@ -335,7 +335,11 @@
   </form>
   @elif current_user.is_authenticated and post['deleted'] == 0 and postmeta.get('lock-comments'):
   <div class="comments-locked">
-    <h4>@{_('This post is closed to new comments.')}</h4>
+    <h4>@{_('This post is closed to new comments.  It has been locked by the moderators.')}</h4>
+  </div>
+  @elif current_user.is_authenticated and post['deleted'] == 0 and post['is_archived']:
+  <div class="comments-locked">
+    <h4>@{_('This post is closed to new comments.  It has been automatically archived.')}</h4>
   </div>
   @end
 

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -86,7 +86,7 @@
               <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
             @end
             <ul class="bottombar links @{(comment['visibility'] != '') and 'hidden' or ''}">
-              @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']) and not postmeta.get('lock-comments'):
+              @if current_user.is_authenticated and comment['visibility'] == '' and not current_user.is_subban(post['sid']) and not postmeta.get('lock-comments') and post['deleted'] == 0 and not post['is_archived']:
                 <li><a class="reply-comment" data-pid="@{comment['pid']}" data-to="@{comment['cid']}">@{_('reply')}</a></li>
               @end
               <li><a href="@{url_for('sub.view_perm', sub=post['sub'], cid=comment['cid'], pid=post['pid'], slug=post['slug'])}#comment-@{comment['cid']}">@{_('permalink')}</a></li>

--- a/app/misc.py
+++ b/app/misc.py
@@ -954,6 +954,10 @@ def getSinglePost(pid):
         .get()
     )
     posts["slug"] = slugify(posts["title"])
+    posts["is_archived"] = (
+        datetime.utcnow() - posts["posted"].replace(tzinfo=None)
+    ) > timedelta(days=config.site.archive_post_after)
+
     return posts
 
 
@@ -1561,6 +1565,7 @@ def getUserComments(uid, page, include_deleted_comments=False):
                 SubPostComment.score,
                 SubPostComment.parentcid,
                 SubPost.posted,
+                SubPost.deleted.alias("post_deleted"),
             )
             .join(SubPost)
             .switch(SubPostComment)

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -64,11 +64,13 @@
                     <!-- TODO needs peewee <li><a href="{# url_for('sub.view_perm', sub=sub.name, cid=comment.cid, pid=post.pid) #}">permalink</a></li>-->
                     <li><a href="{{url_for('sub.view_perm', sub=comment.sub, pid=comment.pid, cid=comment.cid)}}">permalink</a></li>
                     {%if current_user.is_authenticated%}
-                      {%if not postmeta[comment.pid].get('lock-comments') and not comment.archived %}
+                      {%if not postmeta[comment.pid].get('lock-comments') and not comment.archived and comment.status not in [1, 2] and comment.post_deleted == 0%}
                         <li><a class="reply-comment" data-pid="{{comment.pid}}" data-to="{{comment.cid}}">reply</a></li>
+                        {% if comment.uid == current_user.uid %}
+                          <li><a class="edit-comment" data-cid="{{comment.cid}}">edit</a></li>
+                        {% endif %}
                       {%endif%}
-                      {% if (comment.uid == session['user_id'] or current_user.is_admin()) %}
-                        <li><a class="edit-comment" data-cid="{{comment.cid}}">edit</a></li>
+                      {% if comment.uid == current_user.uid or current_user.is_admin() and comment.status not in [1, 2] %}
                         <li><a class="delete-comment" data-cid="{{comment.cid}}">delete</a></li>
                       {% endif %}
                     {%endif%}

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2623,7 +2623,7 @@ def edit_comment():
         except SubPostComment.DoesNotExist:
             return jsonify(status="error", error=[_("Comment does not exist")])
 
-        if comment.uid_id != current_user.uid and not current_user.is_admin():
+        if comment.uid_id != current_user.uid:
             return jsonify(status="error", error=[_("Not authorized")])
 
         post = SubPost.get(SubPost.pid == comment.pid)
@@ -2631,8 +2631,13 @@ def edit_comment():
         if current_user.is_subban(sub):
             return jsonify(status="error", error=[_("You are banned on this sub.")])
 
-        if comment.status == "1":
+        if comment.status in [1, 2]:
             return jsonify(status="error", error=_("You can't edit a deleted comment"))
+
+        if post.deleted in [1, 2]:
+            return jsonify(
+                status="error", error=_("You can't edit a comment on a deleted post")
+            )
 
         if post.is_archived():
             return jsonify(status="error", error=_("Post is archived"))


### PR DESCRIPTION
Remove the reply forms from posts and comments which are archived or deleted, to save users the trouble of typing in a long reply only to be given an error when they click the submit button.  Remove the option of editing or deleting comments on archived or deleted posts.  Fix the edit comment permission check so that comments can only be edited by their authors.