### PR TITLE
Squash two small bugs

### DIFF
--- a/app/html/user/password_reset.html
+++ b/app/html/user/password_reset.html
@@ -19,7 +19,7 @@
           <label for="confirm">@{_('Password (again)')}</label>@{lpform.confirm(required=True, autocomplete="off")!!html}
         </div>
         <div class="pure-controls">
-          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary" data-prog="@{_('Processing...')}'">@{_('Change password')}</button>
+          <button type="submit" style="margin-top: 4%" class="pure-button pure-button-primary" data-prog="@{_('Processing...')}">@{_('Change password')}</button>
         </div>
     </form>
   </div>

--- a/app/misc.py
+++ b/app/misc.py
@@ -2885,7 +2885,7 @@ def word_truncate(content, max_length, suffix="..."):
 
 def recent_activity(sidebar=True):
     if not config.site.recent_activity.enabled:
-        return False
+        return []
 
     # XXX: The queries below don't work on sqlite
     # TODO: Make em work?


### PR DESCRIPTION
Remove an extra quote from the button text that is shown while you are resetting your password, and fix the 500 that happens if you navigate to /activity when `site.recent_activity.enabled` set to `False`.