### PR TITLE
Change docker config to fix errors & improve caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !scripts
 
 !babel.cfg
+!config.yaml
 !package.json
 !package-lock.json
 !requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 
 # Whitelist files and folders that should be in the container
 !app
+!cli
 !migrations
 !scripts
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,9 @@
 !requirements.txt
 !throat.py
 !webpack.config.js
+
+# Disallow Python cache files
+**/__pycache__
+**/*.pyc
+**/*.pyd
+**/*.pyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pybabel compile --directory=translations
 
 FROM node:14-buster-slim as webpack
 # Install our npm requirements
-COPY package.json package-lock.json .
+COPY package.json package-lock.json /
 RUN npm ci
 # Build our static assets with webpack.
 COPY webpack.config.js .

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR /throat
 
 # Pull in the compiled translations and static files.
 COPY --from=translations --chown=app:app /translations /throat/app/translations
+COPY --from=webpack --chown=app:app /app/manifest.json /throat/app/manifest.json
 COPY --from=webpack --chown=app:app /app/static/gen /throat/app/static/gen
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,30 @@
-FROM node:14-buster-slim
+# Compile the translations.
+# This is done in its own step as the translations are used by both
+# webpack and Flask.
+FROM python:3-slim-buster AS translations
+RUN pip install Babel
+COPY app/translations /translations
+RUN pybabel compile --directory=translations
 
-RUN useradd -ms /bin/bash app
 
+FROM node:14-buster-slim as webpack
+# Install our npm requirements
+COPY package.json package-lock.json .
+RUN npm ci
+# Build our static assets with webpack.
+COPY webpack.config.js .
+RUN mkdir /app
+COPY app/static /app/static
+COPY --from=translations /translations /app/translations
+RUN npm run build
+
+
+FROM python:3-slim-buster
+
+# Install system packages.
 RUN \
   apt-get update && apt-get install -yqq \
      build-essential \
-     python3-dev \
-     python3-pip \
      libgirepository1.0-dev \
      libcairo2-dev \
      libgexiv2-dev \
@@ -14,27 +32,18 @@ RUN \
      postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /requirements.txt
 # Install our python requirements
-RUN pip3 install -r requirements.txt && rm requirements.txt 
+COPY requirements.txt /requirements.txt
+RUN pip3 install -r requirements.txt && rm requirements.txt
 
-COPY package.json /package.json
-COPY package-lock.json /package-lock.json
-# Install our npm requirements
-RUN npm ci && rm package.json && rm package-lock.json 
-
-COPY . /throat
+# Create the app user and the application directory.
+RUN useradd -ms /bin/bash app
+COPY --chown=app:app . /throat
 WORKDIR /throat
 
-# Compile the translations
-# This is done before `npm run build` so the .mo files
-# are available to webpack.
-RUN python3 throat.py translations compile
-
-RUN \
-  mv ../node_modules node_modules \
-  && npm run build \
-  && chown -R app:app .
+# Pull in the compiled translations and static files.
+COPY --from=translations --chown=app:app /translations /throat/app/translations
+COPY --from=webpack --chown=app:app /app/static/gen /throat/app/static/gen
 
 USER app
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ RUN npm ci && rm package.json && rm package-lock.json
 
 COPY . /throat
 WORKDIR /throat
+
+# Compile the translations
+# This is done before `npm run build` so the .mo files
+# are available to webpack.
+RUN python3 throat.py translations compile
+
 RUN \
   mv ../node_modules node_modules \
   && npm run build \

--- a/README.md
+++ b/README.md
@@ -26,17 +26,16 @@ We recommend using a virtualenv or Pyenv
 And you're done! You can run a test server by executing `./throat.py`. For production instances we recommend setting up `gunicorn`
 
 ### Production deployments
-Please read [doc/gunicorn_deploy.md](doc/gunicorn_deploy.md) for instructions to deploy on gunicorn. 
+Please read [doc/gunicorn_deploy.md](doc/gunicorn_deploy.md) for instructions to deploy on gunicorn.
 
 ## Develop on Docker
 If you prefer to develop on docker
  - The provided Docker resources only support Postgres
  - You still must copy `example.config.yaml` to `config.yaml` and make any changes you want
- - Create an initial manifest.json by using `NPM_CMD="run build" make docker-npm`
  - In addition, configs are overridden by environment variables set in docker-compose.yml
    which reference the redis and postgres services created by docker-compose.
 
-`make up` will bring the containerized site up and mount your current working directory
+`make up` will bring the containerized site up and mount the app/html and app/template directories
 inside the container for dev. It also runs the migrations on start-up. `make down` will spin down the containerized services.
 
 To add an admin user to a running docker-compose application:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - .:/throat
+      - app/html:/throat/app/html
+      - app/templates:/throat/app/templates
     environment:
       # Configs set here will override your config.yaml
       APP_HOST: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       POSTGRES_USER: throat
       POSTGRES_PASSWORD: dev
       POSTGRES_DATABASE: throat
+      PGUSER: throat  # Needed for pg_isready; POSTGRES_* are docker-specific.
     volumes:
       - db-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     image: throat_throat
     command: ["python3", "throat.py", "migration", "apply"]
     environment:
+      CACHE_TYPE: "null"
       DATABASE_ENGINE: PostgresqlDatabase
       DATABASE_HOST: db
       DATABASE_PORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,6 @@ services:
       DATABASE_NAME: throat
       DATABASE_AUTOCOMMIT: "true"
     volumes:
-      - ./config.yaml:/throat/config.yaml
       - ./migrations:/throat/migrations
     depends_on:
       - db


### PR DESCRIPTION
Most importantly, this PR updates the docker configuration to allow [migration 27] to succeed (it could throw depending on cache configuration) and account for the change to the CLI structure in a6496f7771056ffb856a3fb5ac7de4d20765c77e.

Additionally, there's a small fix so that the database health check can succeed, and that Python cache (`.pyc`) files are not copied from the host into the built image.

It also ensures that the translations are compiled into `.mo` files and made available to both webpack and Flask.

The largest change is in the most-recent-but-one commit (8e50dd8), where the Dockerfile is changed to use multi-stage builds. This should reduce the need to reinstall the node modules and re-run webpack when other files in the project change. This is contained in that one commit so it can be excluded if anyone spots any problems without affecting the more straightforward changes.

The change in commit 0d70f97 is also consequential in that it stops mounting the entire repo directory at /throat, as this unfortunately masks everything in the container’s /throat — including, importantly, files that are created or changed as part of the Docker build process. This is why, for instance, it was necessary to create a manifest.json file locally (#287) before being able to bring up the containers. The compose file now only mounts app/html and app/templates into the container, so files in those directories can still be edited live.

[migration 27]: https://github.com/Phuks-co/throat/commit/f841183dc3c87fb34103d6913b4be62c8124f6c9#diff-16180f7780b5103acfe07b6b9977dc0dcf18212c865b0a2c2e4d6dec55b7ccc0