### PR TITLE
Automate testing under Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,16 @@ down:
 docker-shell: docker-compose-build
 	docker-compose run --rm throat /bin/bash
 	@$(DONE)
+
+.PHONY: test
+test:
+	docker-compose up --detach redis
+	docker-compose run \
+		--name=throat_tests \
+		--rm \
+		--no-deps \
+		--volume $(CUR_DIR)/test:/throat/test \
+		-e TEST_CONFIG=/throat/test/test_config_docker_compose.yaml \
+		throat \
+		pytest $(ARGS)
+	@$(DONE)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We recommend using a virtualenv or Pyenv
 And you're done! You can run a test server by executing `./throat.py`. For production instances we recommend setting up `gunicorn`
 
 ### Production deployments
-Please read [doc/gunicorn_deploy.md](doc/gunicorn_deploy.md) for instructions to deploy on gunicorn. 
+Please read [doc/gunicorn_deploy.md](doc/gunicorn_deploy.md) for instructions to deploy on gunicorn.
 
 ## Develop on Docker
 If you prefer to develop on docker
@@ -100,6 +100,12 @@ authentication servers (instead of the defaults, which are sqlite and
 local authentication), you may put configuration settings in
 `test_config.yaml` and run the tests with
 `TEST_CONFIG=test_config.yaml python -m pytest`
+
+### Testing under Docker
+
+You can run pytest in a Docker container via docker-compose with `make test`.
+
+To pass arguments to pytest, invoke make like so: `make test ARGS="-x -k my_test"`
 
 ## Chat
 

--- a/test/test_config_docker_compose.yaml
+++ b/test/test_config_docker_compose.yaml
@@ -1,0 +1,5 @@
+app:
+    redis_url: redis://redis:6379
+
+cache:
+    redis_url: redis://redis:6379


### PR DESCRIPTION
This set of changes will make it easier for people developing via Docker to run the tests.

The whole pytest suite can be run with `make test`, and you can pass arguments to pytest by adding `ARGS="pytest args"` afterwards. I’ve added a couple of lines to the readme to explain this.

I’ve added a docker-compose-specific testing config file under /test/ which sets the Redis host correctly, as otherwise most of the tests fail with a connection error when the app tries to connect to Redis on 127.0.0.1.

There’s also a minor whitespace change in the readme that was picked up by pre-commit.

Previously this PR used a docker-compose service for the tests, but I’ve force-pushed a new set of changes after realising this causes the tests to be run when `docker-compose up` is invoked. Now the tests run as a one-off command using the throat docker-compose service as the base.