### PR TITLE
Guard against missing SubmitEvent API support

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -195,7 +195,8 @@ u.ready(function() {
   // TODO: Get rid of this.
   u.addEventForChild(document, 'submit', '.ajaxform', function(e, target){
     e.preventDefault();
-    var button = e.submitter;
+    // The SubmitEvent API isn’t supported in Safari, so work around it.
+    var button = e.submitter || target.querySelector("[type=submit]");
     var btnorm = button.innerHTML;
     var data = new FormData(target);
 
@@ -204,8 +205,8 @@ u.ready(function() {
       button.innerHTML = button.getAttribute('data-prog');
     }
     let action = target.getAttribute('action')
-    if(e.submitter.getAttribute("formaction")) {
-        action = e.submitter.getAttribute("formaction");
+    if (e.submitter && e.submitter.getAttribute("formaction")) {
+      action = e.submitter.getAttribute("formaction");
     }
     u.rawpost(action, data,
       function(data){ // success


### PR DESCRIPTION
PR #283 switched to the SubmitEvent API for handling button transitions, but
there is no support for SubmitEvent in Safari.

This resulted in an exception being thrown when we try to access the event
submitter’s properties (as there is no `submitter` in Safari). In turn, this
interferes with the submission of the form itself.

This change guards against missing support, and uses the previous behaviour in
that case.