### PR TITLE
Fix expando when author is viewing a text post that was deleted by a mod

### DIFF
--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1001,7 +1001,7 @@ def get_txtpost(pid):
         if (
             current_user.is_admin()
             or current_user.is_mod(post["sid"], 1)
-            or current_user.uid == post[""]
+            or current_user.uid == post["uid"]
         ):
             post["visibility"] = "mod-del"
         else:


### PR DESCRIPTION
When viewing the list of your own posts accessible from your user page, if one of them was a text post deleted by a mod, the expando would just give you a blank line because /do/get_textpost was returning a 500.  Fix the error (which was introduced in #311) so the expando will work.