### PR TITLE
docker-compose: fix throat service bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - app/html:/throat/app/html
-      - app/templates:/throat/app/templates
+      - ./app/html:/throat/app/html
+      - ./app/templates:/throat/app/templates
     environment:
       # Configs set here will override your config.yaml
       APP_HOST: 0.0.0.0


### PR DESCRIPTION
Relative volume paths in a docker-compose config file need a leading ./ otherwise they're treated as named volumes.

Since there are no named volumes with these names, this causes `docker-compose up` to fail to start the service.

This error was introduced in #346 with the change from mounting . at /throat to mounting specific subdirectories only.