### PR TITLE
Docker: ensure image is rebuilt for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker-shell: docker-compose-build
 	@$(DONE)
 
 .PHONY: test
-test:
+test: docker-compose-build
 	docker-compose up --detach redis
 	docker-compose run \
 		--name=throat_tests \


### PR DESCRIPTION
Fixes a bug from #347 where `make test` may not incorporate new changes, by depending on the docker-compose-build target in the makefile.