### PR TITLE
Docker: Pin to Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Compile the translations.
 # This is done in its own step as the translations are used by both
 # webpack and Flask.
-FROM python:3-slim-buster AS translations
+FROM python:3.7-slim-buster AS translations
 RUN pip install Babel
 COPY app/translations /translations
 RUN pybabel compile --directory=translations
@@ -19,7 +19,7 @@ COPY --from=translations /translations /app/translations
 RUN npm run build
 
 
-FROM python:3-slim-buster
+FROM python:3.7-slim-buster
 
 # Install system packages.
 RUN \


### PR DESCRIPTION
The python:3 image uses the latest stable version of Python 3, whereas Throat's minimum supported version is currently 3.7. In particular, testing with a version > 3.7 can give misleading results. The Docker image should be bumped in line with Throat’s MSV.