### PR TITLE
Include the LICENSE file in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 
 !babel.cfg
 !config.yaml
+!LICENSE
 !package.json
 !package-lock.json
 !requirements.txt


### PR DESCRIPTION
Fix the docker image so that if it is used for deployment, it shows the `/license` page correctly.