### PR TITLE
Improve Sub Logs

### DIFF
--- a/app/html/sub/log.html
+++ b/app/html/sub/log.html
@@ -9,8 +9,9 @@
             <thead>
             <tr>
                 <th>@{_('Time')}</th>
-                <th>@{_('User')}</th>
+                <th>@{_('Moderator')}</th>
                 <th>@{_('Action')}</th>
+                <th>@{_('User')}</th>
                 <th></th>
             </tr>
             </thead>
@@ -35,7 +36,11 @@
                     @elif log.action == 21:
                         @{_('Changed sub settings')}
                     @elif log.action == 22:
-                        @{_('Banned <a href="/u/%(username)s">%(username)s</a> with reason <code>%(reason)s</code>', username=log.target.name, reason=e(log.desc))!!html}
+                        @if log.link:
+                            @{_('Temporarily banned <a href="/u/%(username)s">%(username)s</a> %(days)s with reason <code>%(reason)s</code>', username=log.target.name, days=_('for 1 day') if log.link == '1' else _('for %(num)s days', num=log.link), reason=e(log.desc))!!html}
+                        @else:
+                            @{_('Banned <a href="/u/%(username)s">%(username)s</a> with reason <code>%(reason)s</code>', username=log.target.name, reason=e(log.desc))!!html}
+                        @end
                     @elif log.action == 23:
                         @{_('Unbanned <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
                     @elif log.action == 24:
@@ -71,7 +76,12 @@
                     @end
                 </td>
                 <td>
-                    @if log.link:
+                    @if log.action in [22, 23, 24, 26, 27, 28]:
+                        <a href="/u/@{log.target.name}">@{log.target.name}</a>
+                    @end
+                </td>
+                <td>
+                    @if log.link and log.action != 22:
                         <a href="@{log.link}">@{_('Link')}</a> \
                     @end
                 </td>

--- a/app/models.py
+++ b/app/models.py
@@ -250,7 +250,7 @@ class SubLog(BaseModel):
     action = IntegerField(null=True)
     desc = CharField(null=True)
     lid = PrimaryKeyField()
-    link = CharField(null=True)
+    link = CharField(null=True)  # link or extra description depending on action
     sid = ForeignKeyField(db_column="sid", null=True, model=Sub, field="sid")
     uid = ForeignKeyField(db_column="uid", null=True, model=User, field="uid")
     target = ForeignKeyField(db_column="target_uid", null=True, model=User, field="uid")

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1428,18 +1428,20 @@ def ban_user_sub(sub):
         #    pass
 
         expires = None
+        days = ""
         if form.expires.data:
             try:
                 expires = datetime.datetime.strptime(
                     form.expires.data, "%Y-%m-%dT%H:%M:%S.%fZ"
                 )
-                if (expires - datetime.datetime.utcnow()) > datetime.timedelta(
-                    days=365
-                ):
+                seconds = (expires - datetime.datetime.utcnow()).total_seconds()
+                days = int(round(seconds / (60 * 60 * 24), 0))
+                if days > 365:
                     return jsonify(
                         status="error",
                         error=[_("Expiration time too far into the future")],
                     )
+                days = str(days)
             except ValueError:
                 return jsonify(status="error", error=[_("Invalid expiration time")])
 
@@ -1485,6 +1487,7 @@ def ban_user_sub(sub):
             sub.sid,
             target=user.uid,
             comment=form.reason.data,
+            link=days,
         )
 
         related_post_reports = (


### PR DESCRIPTION
Label temporary bans differently than permanent bans and show the ban duration.  Make it more clear who is the moderator and who is the target user, and add a column for target users, to make it easier for mods to scan down the page looking for someone.