### PR TITLE
Restrict destructive routes to POST requests

### DIFF
--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -5,7 +5,7 @@ from .admin import *  # noqa
 from flask_wtf import FlaskForm
 
 
-class DummyForm(FlaskForm):
+class CsrfTokenOnlyForm(FlaskForm):
     """ This is here only for the csrf token. """
 
     pass

--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -132,7 +132,6 @@ class LiteralBooleanField(SelectField):
 
     @staticmethod
     def _literally_true_or_false(value: str) -> bool:
-        print(repr(value))
         if value == "True":
             return True
         elif value == "False":

--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -4,7 +4,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField, TextAreaField, FileField
 from wtforms import IntegerField, RadioField, FieldList, SelectField
 from wtforms import HiddenField
-from wtforms.validators import DataRequired, Length, Regexp
+from wtforms.validators import DataRequired, InputRequired, Length, Regexp
 from flask_babel import lazy_gettext as _l
 
 
@@ -118,3 +118,27 @@ class SetSubOfTheDayForm(FlaskForm):
 class ChangeConfigSettingForm(FlaskForm):
     setting = HiddenField()
     value = StringField()
+
+
+class LiteralBooleanField(SelectField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            choices=["True", "False"],
+            coerce=self._literally_true_or_false,
+            validators=[InputRequired()],
+            **kwargs,
+        )
+
+    @staticmethod
+    def _literally_true_or_false(value: str) -> bool:
+        print(repr(value))
+        if value == "True":
+            return True
+        elif value == "False":
+            return False
+        raise ValueError("Value is not either 'True' or 'False'.")
+
+
+class LiteralBooleanForm(FlaskForm):
+    value = LiteralBooleanField()

--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -1,7 +1,7 @@
 """ Sub-related forms """
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, BooleanField, HiddenField
+from wtforms import StringField, TextAreaField, BooleanField, HiddenField, IntegerField
 from wtforms import RadioField, SelectField, FieldList
 from wtforms.validators import DataRequired, Length, URL
 from wtforms.validators import Optional
@@ -253,6 +253,12 @@ class UndeletePost(FlaskForm):
 
     post = HiddenField()
     reason = StringField()
+
+
+class AnnouncePostForm(FlaskForm):
+    """Form to mark a post as an announcement."""
+
+    post = IntegerField(validators=[DataRequired()])
 
 
 class VoteForm(FlaskForm):

--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -96,7 +96,7 @@ Mod |\
             @end
             @if current_user.is_admin() and reported_user.status != 5:
                 <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=report['reported'])}">
-                    @{form.DummyForm().csrf_token()!!html}
+                    @{form.CsrfTokenOnlyForm().csrf_token()!!html}
                   <a id="banuser-button" class="sbm-post pure-button button-secondary" >@{_('Ban %(reported)s from %(site)s', reported=report['reported'], site=config.site.name)}</a>
                 </form>
             @end

--- a/app/html/shared/sidebar/user.html
+++ b/app/html/shared/sidebar/user.html
@@ -3,17 +3,17 @@
 @if current_user.is_admin() and user.name != current_user.name:
     @if user.status in (0, 1):
       <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=user.name)}">
-          @{form.DummyForm().csrf_token()!!html}
+          @{form.CsrfTokenOnlyForm().csrf_token()!!html}
         <a id="banuser-button" class="sbm-post pure-button pure-button-primary">@{_('Ban user')}</a>
       </form>
     @elif user.status == 5:
       <form method="POST" data-reload="true" id="unbanuser" action="@{url_for('do.unban_user', username=user.name)}">
-        @{form.DummyForm().csrf_token()!!html}
+        @{form.CsrfTokenOnlyForm().csrf_token()!!html}
         <a id="unbanuser-button" class="sbm-post pure-button pure-button-primary">@{_('Un-ban user')}</a>
       </form>
     @end
     <form  method="POST" data-reload="true" id="wipevotes" action="@{url_for('do.admin_undo_votes', uid=user.uid)}">
-        @{form.DummyForm().csrf_token()!!html}
+        @{form.CsrfTokenOnlyForm().csrf_token()!!html}
       <a id="wipevotes-button" class="sbm-post pure-button pure-button-primary">@{_('Remove votes')}</a>
     </form>
     <hr>

--- a/app/html/user/settings/invitecode.html
+++ b/app/html/user/settings/invitecode.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(codes, avail)
+@require(codes, avail, csrf_form)
 @def sidebar():
   @include('shared/sidebar/user.html')
 @end
@@ -8,8 +8,11 @@
 <div id="container">
   <h1>@{_('Invite codes')}</h1>
   @if avail > 0:
-    @{_('You can create <b>%(num)i</b> invite codes.', num=avail)!!html}
-    <a href="/do/create_invite" class="pure-button pure-button-primary">@{_('Create new')}</a>
+    <form action="@{ url_for('do.invite_codes') }" method="post" id="createinvite">
+      @{_('You can create <b>%(num)i</b> invite codes.', num=avail)!!html}
+      @{ csrf_form.csrf_token()!!html }
+      <input type="submit" name="createinvite-button" class="pure-button pure-button-primary" value="@{_('Create new')}">
+    </form>
   @else:
     @{_('You cannot create invite codes.')}
   @end
@@ -40,7 +43,7 @@
           @else:
             @{_('N/A')}
           @end
-         
+
         </td>
         <td>
           @{code.uses}

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ import datetime
 from enum import IntEnum
 import functools
 import sys
+import uuid
 from flask import g
 from flask_redis import FlaskRedis
 from peewee import IntegerField, DateTimeField, BooleanField, Proxy, Model, Database
@@ -187,7 +188,8 @@ class Sub(BaseModel):
     #     link=url_for("sub.view_post", sub=post.sid.name, pid=post.pid),
     # causes an error in the Flask URL construction process when name is None.
     nsfw = BooleanField(default=False)
-    sid = CharField(primary_key=True, max_length=40)
+    sid = CharField(primary_key=True, max_length=40, default=uuid.uuid4)
+    # Default for sid taken from subs.create_sub.
     sidebar = TextField(default="")
     status = IntegerField(null=True)
     title = CharField(null=True, max_length=50)

--- a/app/templates/admin/admin.html
+++ b/app/templates/admin/admin.html
@@ -47,8 +47,11 @@
           {%if not ann %}<h4>No active announcements</h4>
           {%else%}
           <div class="post">
-            <a href="{{url_for('do.deleteannouncement')}}" class="btn btn-red">Nuke!</a> |
-            <a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time>
+            <form method="POST" id="deleteannouncement" action="{{ url_for('do.deleteannouncement') }}">
+              {{ deleteAnnouncementForm.csrf_token() }}
+              <input id="deleteannouncement-button" type="submit" value="Nuke!" class="pure-button">
+              <a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time>
+            </form>
           </div>
 
           {%endif%}

--- a/app/templates/admin/admin.html
+++ b/app/templates/admin/admin.html
@@ -48,7 +48,7 @@
           {%else%}
           <div class="post">
             <form method="POST" id="deleteannouncement" action="{{ url_for('do.deleteannouncement') }}">
-              {{ deleteAnnouncementForm.csrf_token() }}
+              {{ csrf_form.csrf_token() }}
               <input id="deleteannouncement-button" type="submit" value="Nuke!" class="pure-button">
               <a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time>
             </form>
@@ -64,11 +64,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.enable_posting %}
-          <div>Disable posting for non-admin users</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_posting', value='False')}}">Disable Posting</a>
+          <form method="POST" id="disableposting" action="{{ url_for('do.enable_posting') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <label for="disableposting-button">Disable posting for non-admin users</label>
+            <input type="submit" name="disableposting-button" class="pure-button button-warning" value="Disable Posting">
+          </form>
           {% else %}
-          <div>Enable posting for non-admin users</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_posting', value='True')}}">Enable Posting</a>
+          <form method="POST" id="enableposting" action="{{ url_for('do.enable_posting') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <label for="enableposting-button">Enable posting for non-admin users</label>
+            <input type="submit" name="enableposting-button" class="pure-button button-warning" value="Enable Posting">
+          </form>
           {% endif %}
         </div>
       </div>
@@ -78,11 +86,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.enable_registration %}
-          <div>Disable registration for new users</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_registration', value='False')}}">Disable Registration</a>
+          <form method="POST" id="disableregistration" action="{{ url_for('do.enable_registration') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <label for="disableregistration-button">Disable registration for new users</label>
+            <input type="submit" name="disableregistration-button" class="pure-button button-warning" value="Disable Registration">
+          </form>
           {% else %}
-          <div>Enable registration for new users</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_registration', value='True')}}">Enable Registration</a>
+          <form method="POST" id="enableregistration" action="{{ url_for('do.enable_registration') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <label for="enableregistration-button">Enable registration for new users</label>
+            <input type="submit" id="enableregistration-button" class="pure-button button-warning" value="Enable Registration">
+          </form>
           {% endif %}
         </div>
       </div>
@@ -92,11 +108,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.require_captchas %}
-          <div>Disable captchas for registration, password recovery and post creation</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_captchas', value='False')}}">Disable Captchas</a>
+          <form method="POST" id="disablecaptchas" action="{{ url_for('do.enable_captchas') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <label for="disablecaptchas-button">Disable captchas for registration, password recovery and post creation</label>
+            <input type="submit" name="disablecaptchas-button" class="pure-button button-error" value="Disable Captchas">
+          </form>
           {% else %}
-          <div>Enable captchas for registration, password recovery and post creation</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_captchas', value='True')}}">Enable Captchas</a>
+          <form method="POST" id="enablecaptchas" action="{{ url_for('do.enable_captchas') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <label for="enablecaptchas-button">Enable captchas for registration, password recovery and post creation</label>
+            <input type="submit" name="disablecaptchas-button" class="pure-button button-error" value="Enable Captchas">
+          </form>
           {% endif %}
         </div>
       </div>

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -23,6 +23,7 @@ from flask_babel import _
 from .. import misc
 from ..config import config
 from ..forms import (
+    DummyForm,
     TOTPForm,
     LogOutForm,
     UseInviteCodeForm,
@@ -183,6 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
+        deleteAnnouncementForm=DummyForm(),
     )
 
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -184,7 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
-        deleteAnnouncementForm=DummyForm(),
+        csrf_form=DummyForm(),
     )
 
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -23,7 +23,7 @@ from flask_babel import _
 from .. import misc
 from ..config import config
 from ..forms import (
-    DummyForm,
+    CsrfTokenOnlyForm,
     TOTPForm,
     LogOutForm,
     UseInviteCodeForm,
@@ -184,7 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
-        csrf_form=DummyForm(),
+        csrf_form=CsrfTokenOnlyForm(),
     )
 
 

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2302,11 +2302,14 @@ def use_invite_code():
     return jsonify(status="ok")
 
 
-@do.route("/do/create_invite")
+@do.route("/do/create_invite", methods=["POST"])
 @login_required
 def invite_codes():
     if not config.site.require_invite_code:
         return redirect("/settings")
+
+    if not DummyForm().validate():
+        abort(400)
 
     created = InviteCode.select().where(InviteCode.user == current_user.uid).count()
     maxcodes = int(misc.getMaxCodes(current_user.uid))

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2039,12 +2039,16 @@ def save_pm(mid):
         return jsonify(status="error", error=_("Message does not exist"))
 
 
-@do.route("/do/admin/deleteannouncement")
+@do.route("/do/admin/deleteannouncement", methods=["POST"])
 @login_required
 def deleteannouncement():
     """ Removes the current announcement """
     if not current_user.is_admin():
         abort(403)
+
+    form = DummyForm()
+    if not form.validate():
+        abort(400)
 
     try:
         ann = SiteMetadata.get(SiteMetadata.key == "announcement")

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -33,7 +33,7 @@ from ..forms import SearchForm, EditMod2Form, SetSubOfTheDayForm, AssignSubUserF
 from ..forms import DeleteSubFlair, DeleteSubRule, CreateReportNote
 from ..forms import UseInviteCodeForm, SecurityQuestionForm, DistinguishForm
 from ..forms import BanDomainForm, SetOwnUserFlairForm, ChangeConfigSettingForm
-from ..forms import AnnouncePostForm
+from ..forms import AnnouncePostForm, LiteralBooleanForm
 from ..badges import badges
 from ..misc import (
     cache,
@@ -2170,15 +2170,17 @@ def remove_banned_domain(domain_type, domain):
     return json.dumps({"status": "ok"})
 
 
-@do.route("/do/admin/enable_posting/<value>")
+@do.route("/do/admin/enable_posting", methods=["POST"])
 @login_required
-def enable_posting(value):
+def enable_posting():
     """ Emergency Mode: disable posting """
     if not current_user.is_admin():
         abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.enable_posting", state)
     misc.create_sitelog(
@@ -2190,15 +2192,17 @@ def enable_posting(value):
     return redirect(url_for("admin.index"))
 
 
-@do.route("/do/admin/enable_registration/<value>")
+@do.route("/do/admin/enable_registration", methods=["POST"])
 @login_required
-def enable_registration(value):
+def enable_registration():
     """ Isolation Mode: disable registration """
     if not current_user.is_admin():
         abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.enable_registration", state)
     misc.create_sitelog(
@@ -2210,15 +2214,17 @@ def enable_registration(value):
     return redirect(url_for("admin.index"))
 
 
-@do.route("/do/admin/require_captchas/<value>")
+@do.route("/do/admin/require_captchas", methods=["POST"])
 @login_required
-def enable_captchas(value):
+def enable_captchas():
     """ Enable or disable the captcha solving requirement. """
     if not current_user.is_admin():
-        return abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+        abort(404)
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.require_captchas", state)
     misc.create_sitelog(

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -23,7 +23,7 @@ from ..auth import (
     AuthError,
     normalize_email,
 )
-from ..forms import LogOutForm, CreateSubFlair, DummyForm, CreateSubRule
+from ..forms import LogOutForm, CreateSubFlair, CsrfTokenOnlyForm, CreateSubRule
 from ..forms import EditSubForm, EditUserForm, EditSubCSSForm
 from ..forms import EditModForm, BanUserSubForm, DeleteAccountForm, EditAccountForm
 from ..forms import EditSubTextPostForm, AssignUserBadgeForm
@@ -738,7 +738,7 @@ def assign_post_flair(sub, pid, fl):
     except SubPost.DoesNotExist:
         return jsonify(status="error", error=[_("Post does not exist")])
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.is_mod(sub.sid) or (
             post.uid_id == current_user.uid and sub.get_metadata("ucf")
@@ -887,7 +887,7 @@ def subscribe_to_sub(sid):
     if current_user.has_subscribed(sid):
         return jsonify(status="ok", message=_("already subscribed"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.has_blocked(sid):
             ss = SubSubscriber.get(
@@ -917,7 +917,7 @@ def unsubscribe_from_sub(sid):
     if not current_user.has_subscribed(sid):
         return jsonify(status="ok", message=_("not subscribed"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         ss = SubSubscriber.get(
             (SubSubscriber.uid == current_user.uid)
@@ -943,7 +943,7 @@ def block_sub(sid):
     if current_user.has_blocked(sid):
         return jsonify(status="ok", message=_("already blocked"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.has_subscribed(sub.name):
             ss = SubSubscriber.get(
@@ -973,7 +973,7 @@ def unblock_sub(sid):
     if not current_user.has_blocked(sid):
         return jsonify(status="ok", message=_("sub not blocked"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         ss = SubSubscriber.get(
             (SubSubscriber.uid == current_user.uid)
@@ -1638,7 +1638,7 @@ def remove_sub_ban(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.is_mod(sub.sid, 2) or current_user.is_admin():
             try:
@@ -1741,7 +1741,7 @@ def remove_mod2(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         isTopMod = current_user.is_mod(sub.sid, 0)
         if (
@@ -1790,7 +1790,7 @@ def revoke_mod2inv(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         isTopMod = current_user.is_mod(sub.sid, 0)
         if isTopMod or current_user.is_admin():
@@ -1831,7 +1831,7 @@ def accept_modinv(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             modi = SubMod.get(
@@ -1884,7 +1884,7 @@ def refuse_mod2inv(sub):
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             modi = SubMod.get(
@@ -2046,7 +2046,7 @@ def deleteannouncement():
     if not current_user.is_admin():
         abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         abort(400)
 
@@ -2308,7 +2308,7 @@ def invite_codes():
     if not config.site.require_invite_code:
         return redirect("/settings")
 
-    if not DummyForm().validate():
+    if not CsrfTokenOnlyForm().validate():
         abort(400)
 
     created = InviteCode.select().where(InviteCode.user == current_user.uid).count()
@@ -2832,7 +2832,7 @@ def undelete_comment():
 @do.route("/do/vote/<pid>/<value>", methods=["POST"])
 def upvote(pid, value):
     """ Logs an upvote to a post. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return json.dumps({"status": "error", "error": get_errors(form)}), 400
     if not current_user.is_authenticated:
@@ -2844,7 +2844,7 @@ def upvote(pid, value):
 @do.route("/do/votecomment/<cid>/<value>", methods=["POST"])
 def upvotecomment(cid, value):
     """ Logs an upvote to a post. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return json.dumps({"status": "error", "error": get_errors(form)})
 
@@ -2957,7 +2957,7 @@ def get_sibling(pid, cid, lim):
 @login_required
 def preview():
     """ Returns parsed markdown. Used for post and comment previews. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if request.json.get("text"):
             return jsonify(
@@ -3144,7 +3144,7 @@ def sub_upload_delete(sub, name):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         jsonify(status="error")  # descriptive errors where?
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return redirect(url_for("sub.edit_sub_css", sub=sub.name))
     if not current_user.is_mod(sub.sid, 1) and not current_user.is_admin():
@@ -3193,7 +3193,7 @@ def delete_question(xid):
     if not current_user.is_admin():
         abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return jsonify(status="error")
     try:
@@ -3212,7 +3212,7 @@ def ban_user(username):
     if not current_user.is_admin():
         return abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return abort(403)
 
@@ -3259,7 +3259,7 @@ def unban_user(username):
     if not current_user.is_admin():
         return abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return abort(403)
 
@@ -3305,7 +3305,7 @@ def unban_user(username):
 @do.route("/do/edit_top_bar", methods=["POST"])
 @login_required
 def edit_top_bar():
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return jsonify(status="error", error="no CSRF")
 
@@ -3345,7 +3345,7 @@ def admin_undo_votes(uid):
     except User.DoesNotExist:
         return abort(404)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return redirect(url_for("user.view", user=user.name))
 
@@ -3412,7 +3412,7 @@ def admin_undo_votes(uid):
 @do.route("/do/cast_vote/<pid>/<oid>", methods=["POST"])
 @login_required
 def cast_vote(pid, oid):
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             post = misc.getSinglePost(pid)
@@ -3475,7 +3475,7 @@ def cast_vote(pid, oid):
 @do.route("/do/remove_vote/<pid>", methods=["POST"])
 @login_required
 def remove_vote(pid):
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             post = misc.getSinglePost(pid)

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -33,6 +33,7 @@ from ..forms import SearchForm, EditMod2Form, SetSubOfTheDayForm, AssignSubUserF
 from ..forms import DeleteSubFlair, DeleteSubRule, CreateReportNote
 from ..forms import UseInviteCodeForm, SecurityQuestionForm, DistinguishForm
 from ..forms import BanDomainForm, SetOwnUserFlairForm, ChangeConfigSettingForm
+from ..forms import AnnouncePostForm
 from ..badges import badges
 from ..misc import (
     cache,
@@ -2070,12 +2071,12 @@ def make_announcement():
     if not current_user.is_admin():
         abort(403)
 
-    form = DeletePost()
+    form = AnnouncePostForm()
 
     if form.validate():
         try:
             curr_ann = SiteMetadata.get(SiteMetadata.key == "announcement")
-            if curr_ann.value == form.post.data:
+            if int(curr_ann.value) == form.post.data:
                 return jsonify(status="error", error=_("Post already announced"))
             deleteannouncement()
         except SiteMetadata.DoesNotExist:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2167,6 +2167,7 @@ def remove_banned_domain(domain_type, domain):
 
 
 @do.route("/do/admin/enable_posting/<value>")
+@login_required
 def enable_posting(value):
     """ Emergency Mode: disable posting """
     if not current_user.is_admin():
@@ -2186,6 +2187,7 @@ def enable_posting(value):
 
 
 @do.route("/do/admin/enable_registration/<value>")
+@login_required
 def enable_registration(value):
     """ Isolation Mode: disable registration """
     if not current_user.is_admin():
@@ -2205,6 +2207,7 @@ def enable_registration(value):
 
 
 @do.route("/do/admin/require_captchas/<value>")
+@login_required
 def enable_captchas(value):
     """ Enable or disable the captcha solving requirement. """
     if not current_user.is_admin():

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2064,6 +2064,7 @@ def deleteannouncement():
 
 
 @do.route("/do/makeannouncement", methods=["POST"])
+@login_required
 def make_announcement():
     """ Flagging post as announcement - not api """
     if not current_user.is_admin():

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -11,7 +11,7 @@ from ..auth import auth_provider, AuthError, normalize_email
 from ..misc import engine, gevent_required
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import (
-    DummyForm,
+    CsrfTokenOnlyForm,
     EditUserForm,
     CreateUserMessageForm,
     EditAccountForm,
@@ -208,7 +208,7 @@ def invite_codes():
             "max": maxcodes,
             "avail": avail,
             "user": User.get(User.uid == current_user.uid),
-            "csrf_form": DummyForm(),
+            "csrf_form": CsrfTokenOnlyForm(),
         }
     )
 

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -11,6 +11,7 @@ from ..auth import auth_provider, AuthError, normalize_email
 from ..misc import engine, gevent_required
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import (
+    DummyForm,
     EditUserForm,
     CreateUserMessageForm,
     EditAccountForm,
@@ -207,6 +208,7 @@ def invite_codes():
             "max": maxcodes,
             "avail": avail,
             "user": User.get(User.uid == current_user.uid),
+            "csrf_form": DummyForm(),
         }
     )
 

--- a/migrations/030_nullable_fields.py
+++ b/migrations/030_nullable_fields.py
@@ -1,0 +1,35 @@
+"""Peewee migrations -- 030_nullable fields.py.
+
+Add not-null constraints to columns on the sub and sub_post tables
+that in practice cannot be null as they cause obvious application
+errors by violating implicit assumptions.
+
+Because these failures are so obvious this migration does not include
+a data migration, only the schema change.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_not_null("sub", "name")
+
+    migrator.add_not_null("sub_post", "deleted")
+    migrator.add_not_null("sub_post", "posted")
+    migrator.add_not_null("sub_post", "score")
+    migrator.add_not_null("sub_post", "sid")
+    migrator.add_not_null("sub_post", "title")
+    migrator.add_not_null("sub_post", "uid")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.drop_not_null("sub", "name")
+
+    migrator.drop_not_null("sub_post", "deleted")
+    migrator.drop_not_null("sub_post", "posted")
+    migrator.drop_not_null("sub_post", "score")
+    migrator.drop_not_null("sub_post", "sid")
+    migrator.drop_not_null("sub_post", "title")
+    migrator.drop_not_null("sub_post", "uid")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ cryptography==3.3.2
 dnspython==2.0.0
 ecdsa==0.14.1
 email-validator==1.1.2
+factory-boy==3.2.0
 feedgen==0.9.0
 Faker==8.6.0
 Flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ dnspython==2.0.0
 ecdsa==0.14.1
 email-validator==1.1.2
 feedgen==0.9.0
+Faker==8.6.0
 Flask==1.1.2
 Flask-Babel==2.0.0
 Flask-Caching==1.9.0

--- a/test/factories.py
+++ b/test/factories.py
@@ -1,0 +1,46 @@
+from app.models import SiteMetadata, Sub, SubPost, User
+
+import factory
+
+
+class PeeweeBaseFactory(factory.Factory):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        return model_class.create(*args, **kwargs)
+
+
+class SubFactory(PeeweeBaseFactory):
+    class Meta:
+        model = Sub
+
+    name = factory.Faker("word")
+
+
+class UserFactory(PeeweeBaseFactory):
+    class Meta:
+        model = User
+
+    uid = factory.Faker("uuid4")
+    name = factory.Faker("user_name")
+    crypto = 0
+
+
+class PostFactory(PeeweeBaseFactory):
+    class Meta:
+        model = SubPost
+
+    sid = factory.SubFactory(SubFactory)
+    title = factory.Faker("sentence")
+    comments = 0
+    uid = factory.SubFactory(UserFactory)
+
+
+class AnnouncedPostFactory(PostFactory):
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs) -> SubPost:
+        post = super()._create(model_class, *args, **kwargs)
+        SiteMetadata.create(key="announcement", value=post.pid)
+        return post

--- a/test/factories.py
+++ b/test/factories.py
@@ -1,4 +1,4 @@
-from app.models import SiteMetadata, Sub, SubPost, User
+from app.models import SiteMetadata, Sub, SubPost, User, UserMetadata
 
 import factory
 
@@ -26,6 +26,21 @@ class UserFactory(PeeweeBaseFactory):
     uid = factory.Faker("uuid4")
     name = factory.Faker("user_name")
     crypto = 0
+
+
+def promote_user_to_admin(user: User):
+    UserMetadata.create(uid=user.uid, key="admin", value="1")
+
+
+class AdminFactory(UserFactory):
+    class Meta:
+        model = User
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        user = super()._create(model_class, *args, **kwargs)
+        promote_user_to_admin(user)
+        return user
 
 
 class PostFactory(PeeweeBaseFactory):

--- a/test/factories.py
+++ b/test/factories.py
@@ -1,6 +1,11 @@
-from app.models import SiteMetadata, Sub, SubPost, User, UserMetadata
+from typing import Type, TypeVar
 
 import factory
+from peewee import Model
+
+from app.models import SiteMetadata, Sub, SubPost, User, UserMetadata
+
+T = TypeVar("T", bound=Model)
 
 
 class PeeweeBaseFactory(factory.Factory):
@@ -8,7 +13,7 @@ class PeeweeBaseFactory(factory.Factory):
         abstract = True
 
     @classmethod
-    def _create(cls, model_class, *args, **kwargs):
+    def _create(cls, model_class: Type[T], *args, **kwargs) -> T:
         return model_class.create(*args, **kwargs)
 
 
@@ -28,7 +33,7 @@ class UserFactory(PeeweeBaseFactory):
     crypto = 0
 
 
-def promote_user_to_admin(user: User):
+def promote_user_to_admin(user: User) -> None:
     UserMetadata.create(uid=user.uid, key="admin", value="1")
 
 
@@ -37,7 +42,7 @@ class AdminFactory(UserFactory):
         model = User
 
     @classmethod
-    def _create(cls, model_class, *args, **kwargs):
+    def _create(cls, model_class: Type[User], *args, **kwargs) -> User:
         user = super()._create(model_class, *args, **kwargs)
         promote_user_to_admin(user)
         return user
@@ -55,7 +60,7 @@ class PostFactory(PeeweeBaseFactory):
 
 class AnnouncedPostFactory(PostFactory):
     @classmethod
-    def _create(cls, model_class, *args, **kwargs) -> SubPost:
+    def _create(cls, model_class: Type[SubPost], *args, **kwargs) -> SubPost:
         post = super()._create(model_class, *args, **kwargs)
         SiteMetadata.create(key="announcement", value=post.pid)
         return post

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -216,6 +216,28 @@ def test_announcing_a_nonexistent_post_gives_an_error_response(
         current_announcement_pid()
 
 
+def test_make_announcement_gives_error_response_for_invalid_form(
+    client, a_logged_in_admin
+) -> None:
+    # Given there is no announced post.
+    with pytest.raises(SiteMetadata.DoesNotExist):
+        current_announcement_pid()
+
+    # When the admin submits an invalid form.
+    announcement_response = client.post(
+        url_for("do.make_announcement"),
+        data={"csrf_token": g.csrf_token, "post": None},
+    )
+
+    # Then the request returns HTTP 200 but the JSON response notes an error.
+    assert http_status_ok(announcement_response)
+    assert json_status_error(announcement_response)
+
+    # And there remains no announced post.
+    with pytest.raises(SiteMetadata.DoesNotExist):
+        current_announcement_pid()
+
+
 def test_admin_can_delete_announcement(client, a_logged_in_admin: None):
     # Given a logged-in admin user.
     # And an announced post.

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -171,6 +171,29 @@ def test_announcing_an_announcement_gives_an_error_response(
     assert current_announcement_pid() == announced_post.pid
 
 
+def test_announcing_a_post_replaces_an_existing_announcement(
+    client, a_logged_in_admin: None
+) -> None:
+    # Given an existing post marked as an announcement.
+    existing_announcement: SubPost = AnnouncedPostFactory.create()
+    # Sanity check.
+    assert current_announcement_pid() == existing_announcement.pid
+    # And a new post.
+    new_post: SubPost = PostFactory.create()
+
+    # When the admin marks the new post as an announcement.
+    announcement_response = client.post(
+        url_for("do.make_announcement"),
+        data={"csrf_token": g.csrf_token, "post": new_post.pid},
+    )
+
+    # Then the request succeeds.
+    assert http_status_ok(announcement_response)
+    assert json_status_ok(announcement_response)
+    # And the announced post is unchanged.
+    assert current_announcement_pid() == new_post.pid
+
+
 def test_admin_can_delete_announcement(client, a_logged_in_admin: None):
     # Given a logged-in admin user.
     # And an announced post.

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -266,3 +266,19 @@ def test_normal_user_cant_access_delete_announcement_route(
 ) -> None:
     response = client.get(url_for("do.deleteannouncement"))
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "view_name",
+    [
+        "do.enable_captchas",
+        "do.enable_registration",
+        "do.enable_posting",
+    ],
+)
+def test_admin_config_toggle_routes_redirects_anonymous_users(
+    view_name: str, client
+) -> None:
+    response = client.get(url_for(view_name, value="True"))
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("auth.login"))

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -205,7 +205,7 @@ def test_announcing_a_nonexistent_post_gives_an_error_response(
     # When the admin marks the non-existent post as an announcement.
     announcement_response = client.post(
         url_for("do.make_announcement"),
-        data={"csrf_token": g.csrf_token, "post": 0},
+        data={"csrf_token": g.csrf_token, "post": 42},
     )
 
     # Then the request returns HTTP 200 but the JSON response notes an error.

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -2,7 +2,7 @@ from app.models import SiteMetadata, Sub, SubPost, User
 import json
 import pytest
 
-from flask import url_for
+from flask import g, url_for
 from app import mail
 from app.misc import getAnnouncementPid
 
@@ -135,11 +135,7 @@ def test_admin_can_make_announcement(client, a_logged_in_admin, a_post):
     # Given an existing post and a logged-in admin user.
 
     # When the admin marks the post as an announcement.
-    post_page_response = client.get(
-        url_for("sub.view_post", sub=a_post.sid.name, pid=a_post.pid),
-        follow_redirects=True,
-    )
-    csrf = csrf_token(post_page_response.data)
+    csrf = g.csrf_token
     announcement_response = client.post(
         url_for("do.make_announcement"), data={"csrf_token": csrf, "post": a_post.pid}
     )

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -2,7 +2,11 @@ from app.models import SiteMetadata, SubPost
 import json
 import pytest
 
+# g is imported so we can easily grab the csrf_token, but note that if
+# no request has been made (ie, in the test or one of its fixtures) then
+# g.csrf_token can fail with an exception.
 from flask import g, url_for
+
 from app import mail
 from app.misc import getAnnouncementPid
 

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -1,5 +1,6 @@
 from flask.globals import session
-from app.models import SiteMetadata, SubPost
+from app import misc
+from app.models import InviteCode, SiteMetadata, SubPost, User
 import json
 import pytest
 
@@ -258,6 +259,85 @@ def test_normal_user_cant_access_delete_announcement_route(
         url_for("do.deleteannouncement"), data={"csrf_token": csrf_token}
     )
     assert response.status_code == 403
+
+
+def test_create_invite_redirects_anonymous_users_to_login(client) -> None:
+    # Given the user is not logged in.
+    # When they attempt to create an invite code.
+    response = client.get(url_for("do.invite_codes"))
+    # They are redirected to the login page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("auth.login"))
+
+
+@pytest.mark.parametrize("test_config", [{"site": {"require_invite_code": False}}])
+def test_create_invite_redirects_to_settings_when_invites_are_diabled(
+    client, a_user
+) -> None:
+    # Given invite codes are not required.
+    # When the user attempts to create a code.
+    response = client.get(url_for("do.invite_codes"))
+    # Then they are directed to their settings page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("user.edit_user"))
+
+
+def number_of_invite_codes_created_by_user(user: User) -> int:
+    created = InviteCode.select().where(InviteCode.user == user.uid).count()  # type: ignore
+    return created
+
+
+def available_invite_codes_for_user(user: User) -> int:
+    created = number_of_invite_codes_created_by_user(user)
+    maxcodes = int(misc.getMaxCodes(user.uid))
+    return maxcodes - created
+
+
+def user_has_invite_codes_remaining(user: User) -> bool:
+    return available_invite_codes_for_user(user) > 0
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
+)
+def test_create_invite_code_successfully(client, a_user):
+    # Given that invite codes are required.
+    # And the user has created no codes.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user can create more codes.
+    assert user_has_invite_codes_remaining(a_user)
+
+    # When the user attempts to create a code.
+    response = client.get(url_for("do.invite_codes"))
+
+    # Then a new invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 1
+    # And the user is redirected to the invite settings page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("user.invite_codes"))
+
+
+def user_level(user: User) -> int:
+    level, _ = misc.get_user_level(user.uid)
+    return level
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 1}}]
+)
+def test_create_invite_code_fails_when_level_is_too_low(client, a_user):
+    # Given that invite codes are required.
+    # And the user has too low a level to create codes.
+    assert config.site.invite_level > user_level(a_user)
+
+    # When the user attempts to create a code.
+    response = client.get(url_for("do.invite_codes"))
+
+    # Then no invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user is redirected to the invite settings page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("user.invite_codes"))
 
 
 class TestCloseCSRFHole:

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -91,7 +91,7 @@ def a_sub(app) -> Sub:
 
 
 @pytest.fixture
-def a_post(a_sub, null_user):
+def a_post(a_sub, null_user) -> SubPost:
     """Create a bare-bones post."""
     return SubPost.create(
         sid=a_sub,
@@ -102,14 +102,14 @@ def a_post(a_sub, null_user):
 
 
 @pytest.fixture
-def an_announced_post(a_post):
+def an_announced_post(a_post: SubPost) -> SubPost:
     """Return a post marked as an announcement."""
     SiteMetadata.create(key="announcement", value=a_post.pid)
     return a_post
 
 
 @pytest.fixture
-def a_logged_in_admin(client, user2_info):
+def a_logged_in_admin(client, user2_info) -> None:
     """Register a new admin user, which is left logged-in."""
     register_user(client, user2_info)
     promote_user_to_admin(client, user2_info)
@@ -131,13 +131,13 @@ def current_announcement_pid() -> int:
     return int(getAnnouncementPid().value)
 
 
-def test_admin_can_make_announcement(client, a_logged_in_admin, a_post):
+def test_admin_can_make_announcement(client, a_logged_in_admin: None, a_post: SubPost):
     # Given an existing post and a logged-in admin user.
 
     # When the admin marks the post as an announcement.
-    csrf = g.csrf_token
     announcement_response = client.post(
-        url_for("do.make_announcement"), data={"csrf_token": csrf, "post": a_post.pid}
+        url_for("do.make_announcement"),
+        data={"csrf_token": g.csrf_token, "post": a_post.pid},
     )
 
     # Then the request succeeds.
@@ -147,7 +147,9 @@ def test_admin_can_make_announcement(client, a_logged_in_admin, a_post):
     assert current_announcement_pid() == a_post.pid
 
 
-def test_admin_can_delete_announcement(client, a_logged_in_admin, an_announced_post):
+def test_admin_can_delete_announcement(
+    client, a_logged_in_admin: None, an_announced_post: SubPost
+):
     # Given an announced post. (This is a sanity check.)
     assert current_announcement_pid() == an_announced_post.pid
     # And a logged-in admin user.
@@ -157,4 +159,4 @@ def test_admin_can_delete_announcement(client, a_logged_in_admin, an_announced_p
 
     # Then attempting to get the announcement post ID raises an exception.
     with pytest.raises(SiteMetadata.DoesNotExist):
-        getAnnouncementPid()
+        current_announcement_pid()

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -194,6 +194,28 @@ def test_announcing_a_post_replaces_an_existing_announcement(
     assert current_announcement_pid() == new_post.pid
 
 
+def test_announcing_a_nonexistent_post_gives_an_error_response(
+    client, a_logged_in_admin: None
+) -> None:
+    # Given there is no announced post.
+    with pytest.raises(SiteMetadata.DoesNotExist):
+        current_announcement_pid()
+
+    # When the admin marks the non-existent post as an announcement.
+    announcement_response = client.post(
+        url_for("do.make_announcement"),
+        data={"csrf_token": g.csrf_token, "post": 0},
+    )
+
+    # Then the request returns HTTP 200 but the JSON response notes an error.
+    assert http_status_ok(announcement_response)
+    assert json_status_error(announcement_response)
+
+    # And there remains no announced post.
+    with pytest.raises(SiteMetadata.DoesNotExist):
+        current_announcement_pid()
+
+
 def test_admin_can_delete_announcement(client, a_logged_in_admin: None):
     # Given a logged-in admin user.
     # And an announced post.

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -2,6 +2,7 @@ from app.models import SiteMetadata, Sub, SubPost, User
 import json
 import pytest
 
+from faker import Faker
 from flask import g, url_for
 from app import mail
 from app.misc import getAnnouncementPid
@@ -75,29 +76,29 @@ def test_admin_can_ban_email_domain(client, user_info, test_config):
 
 
 @pytest.fixture
-def null_user() -> User:
+def a_user(faker: Faker) -> User:
     """Create a bare-bones user."""
     return User.create(
-        uid="dummy-user",
-        name="abc",
+        uid=faker.pystr(),
+        name=faker.user_name(),
         crypto=0,
     )
 
 
 @pytest.fixture
-def a_sub(app) -> Sub:
+def a_sub(app, faker: Faker) -> Sub:
     """Create a bare-bones sub."""
-    return Sub.create(name="someSub")
+    return Sub.create(name=faker.word())
 
 
 @pytest.fixture
-def a_post(a_sub, null_user) -> SubPost:
+def a_post(a_sub: Sub, a_user: User, faker: Faker) -> SubPost:
     """Create a bare-bones post."""
     return SubPost.create(
         sid=a_sub,
-        title="A new post.",
+        title=faker.sentence(),
         comments=0,  # Required for some reason.
-        uid=null_user,
+        uid=a_user,
     )
 
 

--- a/test/specs/test_admin.py
+++ b/test/specs/test_admin.py
@@ -1,17 +1,21 @@
-from flask.globals import session
-from app import misc
-from app.models import InviteCode, SiteMetadata, SubPost, User
+from app.models import SiteMetadata, SubPost, User
 import json
 import pytest
 
 from flask import url_for
 
 from app import mail
-from app.misc import getAnnouncementPid
 from app.config import config
 
 from test.factories import AnnouncedPostFactory, PostFactory
-from test.utilities import csrf_token, promote_user_to_admin
+from test.utilities import (
+    csrf_token,
+    current_announcement_pid,
+    http_status_ok,
+    json_status_error,
+    json_status_ok,
+    promote_user_to_admin,
+)
 from test.utilities import register_user, log_in_user, log_out_current_user
 
 
@@ -79,55 +83,7 @@ def test_admin_can_ban_email_domain(client, user_info, test_config):
         assert b"Log out" not in rv.data
 
 
-def http_status_ok(response) -> bool:
-    """Test if response HTTP status was 200 OK."""
-    return response.status == "200 OK"
-
-
-def parse_json_response_body(response) -> dict:
-    return json.loads(response.data.decode("utf-8"))
-
-
-def check_json_status(response, expected_status: str) -> bool:
-    """Check the status field in the JSON contains the expected string."""
-    json_data = parse_json_response_body(response)
-    return json_data["status"] == expected_status
-
-
-def check_json_errors(response, *expected_error_messages: str) -> bool:
-    """Check that the expected error messages appear in the JSON."""
-    json_data = parse_json_response_body(response)
-    expected_errors = set(expected_error_messages)
-
-    error_data = json_data["error"]
-    if isinstance(error_data, list):
-        received_errors = set(error_data)
-    elif isinstance(error_data, str):
-        received_errors = {error_data}
-    else:
-        raise ValueError(f"Unexpected type for 'error': {type(error_data)}.")
-
-    return expected_errors.issubset(received_errors)
-
-
-def json_status_ok(response) -> bool:
-    """Test if the JSON body in the response has a status of 'ok'."""
-    return check_json_status(response, "ok")
-
-
-def json_status_error(response, *expected_errors: str) -> bool:
-    """Test if the JSON body in the response has a status of 'error'."""
-    return check_json_status(response, "error") and check_json_errors(
-        response, *expected_errors
-    )
-
-
-def current_announcement_pid() -> int:
-    """Get the pid of the currently announced post as an integer."""
-    return int(getAnnouncementPid().value)
-
-
-def test_admin_can_make_announcement(client, an_admin, csrf_token):
+def test_admin_can_make_announcement(client, an_admin: User, csrf_token: str) -> None:
     # Given an existing post and a logged-in admin user.
     a_post: SubPost = PostFactory.create()
 
@@ -139,12 +95,12 @@ def test_admin_can_make_announcement(client, an_admin, csrf_token):
 
     # Then the request succeeds.
     assert http_status_ok(announcement_response)
-    assert json_status_ok(announcement_response), session
+    assert json_status_ok(announcement_response)
     # And the ID of the post is stored as the announcement post ID.
     assert current_announcement_pid() == a_post.pid
 
 
-def test_normal_user_cant_access_make_announcement_route(client, a_user) -> None:
+def test_normal_user_cant_access_make_announcement_route(client, a_user: User) -> None:
     response = client.post(url_for("do.make_announcement"))
     assert response.status_code == 403
 
@@ -157,7 +113,7 @@ def test_anonymous_users_are_redirected_from_make_announcement_route(client) -> 
 
 
 def test_announcing_an_announcement_gives_an_error_response(
-    client, an_admin, csrf_token
+    client, an_admin: User, csrf_token: str
 ) -> None:
     # Given an existing announcement and a logged-in admin user.
     announced_post: SubPost = AnnouncedPostFactory.create()
@@ -176,7 +132,7 @@ def test_announcing_an_announcement_gives_an_error_response(
 
 
 def test_announcing_a_post_replaces_an_existing_announcement(
-    client, an_admin, csrf_token
+    client, an_admin: User, csrf_token: str
 ) -> None:
     # Given an existing post marked as an announcement.
     existing_announcement: SubPost = AnnouncedPostFactory.create()
@@ -199,7 +155,7 @@ def test_announcing_a_post_replaces_an_existing_announcement(
 
 
 def test_announcing_a_nonexistent_post_gives_an_error_response(
-    client, an_admin, csrf_token
+    client, an_admin: User, csrf_token: str
 ) -> None:
     # Given there is no announced post.
     with pytest.raises(SiteMetadata.DoesNotExist):
@@ -221,7 +177,7 @@ def test_announcing_a_nonexistent_post_gives_an_error_response(
 
 
 def test_make_announcement_gives_error_response_for_invalid_form(
-    client, an_admin, csrf_token
+    client, an_admin: User, csrf_token: str
 ) -> None:
     # Given there is no announced post.
     with pytest.raises(SiteMetadata.DoesNotExist):
@@ -243,7 +199,7 @@ def test_make_announcement_gives_error_response_for_invalid_form(
 
 
 def test_delete_announcement_redirects_if_there_is_no_announcement(
-    client, an_admin, csrf_token
+    client, an_admin: User, csrf_token: str
 ) -> None:
     response = client.post(
         url_for("do.deleteannouncement"), data={"csrf_token": csrf_token}
@@ -253,7 +209,7 @@ def test_delete_announcement_redirects_if_there_is_no_announcement(
 
 
 def test_normal_user_cant_access_delete_announcement_route(
-    client, a_user, csrf_token
+    client, a_user: User, csrf_token: str
 ) -> None:
     response = client.post(
         url_for("do.deleteannouncement"), data={"csrf_token": csrf_token}
@@ -261,248 +217,145 @@ def test_normal_user_cant_access_delete_announcement_route(
     assert response.status_code == 403
 
 
-def number_of_invite_codes_created_by_user(user: User) -> int:
-    created = InviteCode.select().where(InviteCode.user == user.uid).count()  # type: ignore
-    return created
+def test_admin_can_delete_announcement(client, an_admin: User, csrf_token: str) -> None:
+    # Given a logged-in admin user.
+    # And an announced post.
+    announced_post: SubPost = AnnouncedPostFactory.create()
+    # (This is a sanity check.)
+    assert current_announcement_pid() == announced_post.pid
 
-
-def available_invite_codes_for_user(user: User) -> int:
-    created = number_of_invite_codes_created_by_user(user)
-    maxcodes = int(misc.getMaxCodes(user.uid))
-    return maxcodes - created
-
-
-def user_has_invite_codes_remaining(user: User) -> bool:
-    return available_invite_codes_for_user(user) > 0
-
-
-def user_level(user: User) -> int:
-    level, _ = misc.get_user_level(user.uid)
-    return level
-
-
-class TestCloseCSRFHole:
-    # TODO: 2283:@do.route("/do/create_invite")
-
-    def test_admin_can_delete_announcement(self, client, an_admin, csrf_token):
-        # Given a logged-in admin user.
-        # And an announced post.
-        announced_post: SubPost = AnnouncedPostFactory.create()
-        # (This is a sanity check.)
-        assert current_announcement_pid() == announced_post.pid
-
-        # When the admin deletes the announced post with a POST request.
-        response = client.post(
-            url_for("do.deleteannouncement"), data={"csrf_token": csrf_token}
-        )
-
-        # Then attempting to get the announcement post ID raises an exception.
-        with pytest.raises(SiteMetadata.DoesNotExist):
-            current_announcement_pid()
-        # And the response redirects to the admin index.
-        assert response == 302
-        assert response.location == url_for("admin.index")
-
-    def test_delete_announcement_fails_without_csrf_token(self, client, an_admin):
-        # Given a logged-in admin user.
-        # And an announced post.
-        announced_post: SubPost = AnnouncedPostFactory.create()
-        # (This is a sanity check.)
-        assert current_announcement_pid() == announced_post.pid
-
-        # When the admin attempts to delete the announced post.
-        response = client.post(url_for("do.deleteannouncement"))
-
-        # The announced post does not change.
-        assert current_announcement_pid() == announced_post.pid
-        # And the response indicates a bad request.
-        assert response == 400
-
-    def test_delete_announcement_rejects_get_request(self, client, an_admin):
-        # Given a logged-in admin user.
-        # And an announced post.
-        _ = AnnouncedPostFactory.create()
-
-        # When the admin attempts to delete the announced post via GET.
-        response = client.get(url_for("do.deleteannouncement"))
-
-        # Then the response indicates the GET method is disallowed.
-        assert response == 405
-
-    @pytest.mark.parametrize(
-        "view_name",
-        [
-            "do.enable_captchas",
-            "do.enable_registration",
-            "do.enable_posting",
-        ],
+    # When the admin deletes the announced post with a POST request.
+    response = client.post(
+        url_for("do.deleteannouncement"), data={"csrf_token": csrf_token}
     )
-    def test_admin_config_toggle_routes_redirects_anonymous_users(
-        self, view_name: str, client, csrf_token
-    ) -> None:
-        response = client.post(
-            url_for(view_name), data={"csrf_token": csrf_token, "value": "True"}
-        )
-        assert response.status_code == 302
-        assert response.headers["location"].startswith(url_for("auth.login"))
 
-    @pytest.mark.parametrize(
-        "view_name",
-        [
-            "do.enable_captchas",
-            "do.enable_registration",
-            "do.enable_posting",
-        ],
+    # Then attempting to get the announcement post ID raises an exception.
+    with pytest.raises(SiteMetadata.DoesNotExist):
+        current_announcement_pid()
+    # And the response redirects to the admin index.
+    assert response == 302
+    assert response.location == url_for("admin.index")
+
+
+def test_delete_announcement_fails_without_csrf_token(client, an_admin: User) -> None:
+    # Given a logged-in admin user.
+    # And an announced post.
+    announced_post: SubPost = AnnouncedPostFactory.create()
+    # (This is a sanity check.)
+    assert current_announcement_pid() == announced_post.pid
+
+    # When the admin attempts to delete the announced post.
+    response = client.post(url_for("do.deleteannouncement"))
+
+    # The announced post does not change.
+    assert current_announcement_pid() == announced_post.pid
+    # And the response indicates a bad request.
+    assert response == 400
+
+
+def test_delete_announcement_rejects_get_request(client, an_admin: User) -> None:
+    # Given a logged-in admin user.
+    # And an announced post.
+    _ = AnnouncedPostFactory.create()
+
+    # When the admin attempts to delete the announced post via GET.
+    response = client.get(url_for("do.deleteannouncement"))
+
+    # Then the response indicates the GET method is disallowed.
+    assert response == 405
+
+
+@pytest.mark.parametrize(
+    "view_name",
+    [
+        "do.enable_captchas",
+        "do.enable_registration",
+        "do.enable_posting",
+    ],
+)
+def test_admin_config_toggle_routes_redirects_anonymous_users(
+    view_name: str, client, csrf_token
+) -> None:
+    response = client.post(
+        url_for(view_name), data={"csrf_token": csrf_token, "value": "True"}
     )
-    def test_admin_config_toggle_routes_deny_normal_users(
-        self, view_name: str, client, a_user, csrf_token
-    ) -> None:
-        response = client.post(
-            url_for(view_name), data={"csrf_token": csrf_token, "value": "True"}
-        )
-        # Check for 404 not found here for characterisation,
-        # but it should perhaps be 403 forbidden.
-        assert response.status_code == 404
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("auth.login"))
 
-    @pytest.mark.parametrize(
-        "view_name",
-        [
-            "do.enable_captchas",
-            "do.enable_registration",
-            "do.enable_posting",
-        ],
+
+@pytest.mark.parametrize(
+    "view_name",
+    [
+        "do.enable_captchas",
+        "do.enable_registration",
+        "do.enable_posting",
+    ],
+)
+def test_admin_config_toggle_routes_deny_normal_users(
+    view_name: str, client, a_user: User, csrf_token: str
+) -> None:
+    response = client.post(
+        url_for(view_name), data={"csrf_token": csrf_token, "value": "True"}
     )
-    @pytest.mark.parametrize(
-        "invalid_value",
-        [
-            "None",
-            "on",
-            "off",
-            "yes",
-            "no",
-            "1",
-            "0",
-        ],
+    # Check for 404 not found here for characterisation,
+    # but it should perhaps be 403 forbidden.
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "view_name",
+    [
+        "do.enable_captchas",
+        "do.enable_registration",
+        "do.enable_posting",
+    ],
+)
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "None",
+        "on",
+        "off",
+        "yes",
+        "no",
+        "1",
+        "0",
+    ],
+)
+def test_admin_config_toggle_routes_reject_invalid_values(
+    view_name: str, invalid_value: str, client, an_admin: User, csrf_token: str
+) -> None:
+    response = client.post(
+        url_for(view_name), data={"csrf_token": csrf_token, "value": invalid_value}
     )
-    def test_admin_config_toggle_routes_reject_invalid_values(
-        self, view_name: str, invalid_value: str, client, an_admin, csrf_token
-    ) -> None:
-        response = client.post(
-            url_for(view_name), data={"csrf_token": csrf_token, "value": invalid_value}
-        )
-        assert response.status_code == 400, response.location
+    assert response.status_code == 400, response.location
 
-    @pytest.mark.parametrize(
-        "view_name,config_key",
-        [
-            ("do.enable_captchas", "site.require_captchas"),
-            ("do.enable_registration", "site.enable_registration"),
-            ("do.enable_posting", "site.enable_posting"),
-        ],
+
+@pytest.mark.parametrize(
+    "view_name,config_key",
+    [
+        ("do.enable_captchas", "site.require_captchas"),
+        ("do.enable_registration", "site.enable_registration"),
+        ("do.enable_posting", "site.enable_posting"),
+    ],
+)
+@pytest.mark.parametrize("value", [True, False])
+def test_admin_config_toggle_routes_set_expected_values(
+    view_name: str,
+    config_key: str,
+    value: bool,
+    client,
+    an_admin: User,
+    csrf_token: str,
+) -> None:
+    # Given a logged-in admin.
+    # When the admin hits the URL.
+    response = client.post(
+        url_for(view_name), data={"csrf_token": csrf_token, "value": value}
     )
-    @pytest.mark.parametrize("value", [True, False])
-    def test_admin_config_toggle_routes_set_expected_values(
-        self, view_name: str, config_key: str, value: bool, client, an_admin, csrf_token
-    ) -> None:
-        # Given a logged-in admin.
-        # When the admin hits the URL.
-        response = client.post(
-            url_for(view_name), data={"csrf_token": csrf_token, "value": value}
-        )
 
-        # Then the config contains the expected value.
-        assert config.get_value(config_key) == value
-        # And the response redirects the user to the admin index.
-        assert response.status_code == 302
-        assert response.location == url_for("admin.index")
-
-
-class TestCreateInvitePost:
-    @pytest.mark.parametrize(
-        "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
-    )
-    def test_create_invite_code_successfully(self, client, a_user, csrf_token):
-        # Given that invite codes are required.
-        # And the user has created no codes.
-        assert number_of_invite_codes_created_by_user(a_user) == 0
-        # And the user can create more codes.
-        assert user_has_invite_codes_remaining(a_user)
-
-        # When the user attempts to create a code.
-        response = client.post(
-            url_for("do.invite_codes"), data={"csrf_token": csrf_token}
-        )
-
-        # Then a new invite code is created.
-        assert number_of_invite_codes_created_by_user(a_user) == 1
-        # And the user is redirected to the invite settings page.
-        assert response == 302
-        assert response.location.startswith(url_for("user.invite_codes"))
-
-    @pytest.mark.parametrize(
-        "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
-    )
-    def test_create_invite_code_rejects_requests_without_csrf_token(
-        self, client, a_user
-    ):
-        # Given that invite codes are required.
-        # And the user has created no codes.
-        assert number_of_invite_codes_created_by_user(a_user) == 0
-        # And the user can create more codes.
-        assert user_has_invite_codes_remaining(a_user)
-
-        # When the user attempts to create a code.
-        response = client.post(
-            url_for("do.invite_codes"), data={"csrf_token": csrf_token}
-        )
-
-        # Then no new invite code is created.
-        assert number_of_invite_codes_created_by_user(a_user) == 0
-        # And the response is a 400 error.
-        assert response == 400
-
-    @pytest.mark.parametrize("test_config", [{"site": {"require_invite_code": False}}])
-    def test_create_invite_redirects_to_settings_when_invites_are_disabled(
-        self, client, a_user, csrf_token
-    ) -> None:
-        # Given invite codes are not required.
-        # When the user attempts to create a code.
-        response = client.post(
-            url_for("do.invite_codes"), data={"csrf_token": csrf_token}
-        )
-        # Then they are directed to their settings page.
-        assert response == 302
-        assert response.location.startswith(url_for("user.edit_user"))
-
-    def test_create_invite_redirects_anonymous_users_to_login(
-        self, client, csrf_token
-    ) -> None:
-        # Given the user is not logged in.
-        # When they attempt to create an invite code.
-        response = client.post(
-            url_for("do.invite_codes"), data={"csrf_token": csrf_token}
-        )
-        # They are redirected to the login page.
-        assert response == 302
-        assert response.location.startswith(url_for("auth.login"))
-
-    @pytest.mark.parametrize(
-        "test_config", [{"site": {"require_invite_code": True, "invite_level": 1}}]
-    )
-    def test_create_invite_code_fails_when_level_is_too_low(
-        self, client, a_user, csrf_token
-    ):
-        # Given that invite codes are required.
-        # And the user has too low a level to create codes.
-        assert config.site.invite_level > user_level(a_user)
-
-        # When the user attempts to create a code.
-        response = client.post(
-            url_for("do.invite_codes"), data={"csrf_token": csrf_token}
-        )
-
-        # Then no invite code is created.
-        assert number_of_invite_codes_created_by_user(a_user) == 0
-        # And the user is redirected to the invite settings page.
-        assert response.status_code == 302
-        assert response.headers["location"].startswith(url_for("user.invite_codes"))
+    # Then the config contains the expected value.
+    assert config.get_value(config_key) == value
+    # And the response redirects the user to the admin index.
+    assert response.status_code == 302
+    assert response.location == url_for("admin.index")

--- a/test/test_login_helpers.py
+++ b/test/test_login_helpers.py
@@ -1,0 +1,25 @@
+from flask.helpers import url_for
+
+
+def test_admins_get_200_on_admin_index(client, an_admin):
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Admins receive a 200 OK response.
+    assert response == 200
+
+
+def test_non_admins_get_404_on_admin_index(client, a_user):
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Non-admin users receive a 404 Not Found response.
+    # (Perhaps it should be 403 really?)
+    assert response == 404
+
+
+def test_anonymous_users_get_302_on_admin_index(client):
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Anonymous users receive a 302 Found response
+    # and are redirected to the login page.
+    assert response == 302
+    assert response.location.startswith(url_for("auth.login"))

--- a/test/test_login_helpers.py
+++ b/test/test_login_helpers.py
@@ -1,14 +1,14 @@
 from flask.helpers import url_for
 
 
-def test_admins_get_200_on_admin_index(client, an_admin):
+def test_admins_get_200_on_admin_index(client, an_admin) -> None:
     # Attempt to get the admin page.
     response = client.get(url_for("admin.index"))
     # Admins receive a 200 OK response.
     assert response == 200
 
 
-def test_non_admins_get_404_on_admin_index(client, a_user):
+def test_non_admins_get_404_on_admin_index(client, a_user) -> None:
     # Attempt to get the admin page.
     response = client.get(url_for("admin.index"))
     # Non-admin users receive a 404 Not Found response.
@@ -16,7 +16,7 @@ def test_non_admins_get_404_on_admin_index(client, a_user):
     assert response == 404
 
 
-def test_anonymous_users_get_302_on_admin_index(client):
+def test_anonymous_users_get_302_on_admin_index(client) -> None:
     # Attempt to get the admin page.
     response = client.get(url_for("admin.index"))
     # Anonymous users receive a 302 Found response

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -135,3 +135,8 @@ def promote_user_to_admin(client, user_info):
     admin = User.get(fn.Lower(User.name) == user_info["username"])
     UserMetadata.create(uid=admin.uid, key="admin", value="1")
     log_in_user(client, user_info)
+
+
+def force_log_in(user: User, client) -> None:
+    with client.session_transaction() as session:
+        session["_user_id"] = user.uid

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,9 +1,11 @@
 from bs4 import BeautifulSoup
 from flask import url_for
+import json
 from peewee import fn
-from app import mail
+
+from app import mail, misc
 from app.auth import email_validation_is_required
-from app.models import User, UserMetadata, SiteMetadata
+from app.models import InviteCode, User, UserMetadata, SiteMetadata
 
 
 def csrf_token(data):
@@ -140,3 +142,71 @@ def promote_user_to_admin(client, user_info):
 def force_log_in(user: User, client) -> None:
     with client.session_transaction() as session:
         session["_user_id"] = user.uid
+
+
+def number_of_invite_codes_created_by_user(user: User) -> int:
+    created = InviteCode.select().where(InviteCode.user == user.uid).count()  # type: ignore
+    return created
+
+
+def available_invite_codes_for_user(user: User) -> int:
+    created = number_of_invite_codes_created_by_user(user)
+    maxcodes = int(misc.getMaxCodes(user.uid))
+    return maxcodes - created
+
+
+def user_has_invite_codes_remaining(user: User) -> bool:
+    return available_invite_codes_for_user(user) > 0
+
+
+def user_level(user: User) -> int:
+    level, _ = misc.get_user_level(user.uid)
+    return level
+
+
+def http_status_ok(response) -> bool:
+    """Test if response HTTP status was 200 OK."""
+    return response.status == "200 OK"
+
+
+def parse_json_response_body(response) -> dict:
+    return json.loads(response.data.decode("utf-8"))
+
+
+def check_json_status(response, expected_status: str) -> bool:
+    """Check the status field in the JSON contains the expected string."""
+    json_data = parse_json_response_body(response)
+    return json_data["status"] == expected_status
+
+
+def check_json_errors(response, *expected_error_messages: str) -> bool:
+    """Check that the expected error messages appear in the JSON."""
+    json_data = parse_json_response_body(response)
+    expected_errors = set(expected_error_messages)
+
+    error_data = json_data["error"]
+    if isinstance(error_data, list):
+        received_errors = set(error_data)
+    elif isinstance(error_data, str):
+        received_errors = {error_data}
+    else:
+        raise ValueError(f"Unexpected type for 'error': {type(error_data)}.")
+
+    return expected_errors.issubset(received_errors)
+
+
+def json_status_ok(response) -> bool:
+    """Test if the JSON body in the response has a status of 'ok'."""
+    return check_json_status(response, "ok")
+
+
+def json_status_error(response, *expected_errors: str) -> bool:
+    """Test if the JSON body in the response has a status of 'error'."""
+    return check_json_status(response, "error") and check_json_errors(
+        response, *expected_errors
+    )
+
+
+def current_announcement_pid() -> int:
+    """Get the pid of the currently announced post as an integer."""
+    return int(misc.getAnnouncementPid().value)

--- a/test/views/test_user.py
+++ b/test/views/test_user.py
@@ -1,8 +1,101 @@
+from app.config import config
+from app.models import User
 from flask import url_for
-from test.utilities import register_user
+from test.utilities import (
+    number_of_invite_codes_created_by_user,
+    register_user,
+    user_has_invite_codes_remaining,
+    user_level,
+)
+
+import pytest
 
 
 def test_settings_page(client, user_info):
     register_user(client, user_info)
     username = user_info["username"]
     assert client.get(url_for("user.edit_user", user=username)).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
+)
+def test_create_invite_code_successfully(client, a_user: User, csrf_token: str) -> None:
+    # Given that invite codes are required.
+    # And the user has created no codes.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user can create more codes.
+    assert user_has_invite_codes_remaining(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+
+    # Then a new invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 1
+    # And the user is redirected to the invite settings page.
+    assert response == 302
+    assert response.location.startswith(url_for("user.invite_codes"))
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
+)
+def test_create_invite_code_rejects_requests_without_csrf_token(
+    client, a_user: User
+) -> None:
+    # Given that invite codes are required.
+    # And the user has created no codes.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user can create more codes.
+    assert user_has_invite_codes_remaining(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": ""})
+
+    # Then no new invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the response is a 400 error.
+    assert response == 400
+
+
+@pytest.mark.parametrize("test_config", [{"site": {"require_invite_code": False}}])
+def test_create_invite_redirects_to_settings_when_invites_are_disabled(
+    client, a_user: User, csrf_token: str
+) -> None:
+    # Given invite codes are not required.
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+    # Then they are directed to their settings page.
+    assert response == 302
+    assert response.location.startswith(url_for("user.edit_user"))
+
+
+def test_create_invite_redirects_anonymous_users_to_login(
+    client, csrf_token: str
+) -> None:
+    # Given the user is not logged in.
+    # When they attempt to create an invite code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+    # They are redirected to the login page.
+    assert response == 302
+    assert response.location.startswith(url_for("auth.login"))
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 1}}]
+)
+def test_create_invite_code_fails_when_level_is_too_low(
+    client, a_user: User, csrf_token: str
+) -> None:
+    # Given that invite codes are required.
+    # And the user has too low a level to create codes.
+    assert config.site.invite_level > user_level(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+
+    # Then no invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user is redirected to the invite settings page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("user.invite_codes"))


### PR DESCRIPTION
This pull request converts a few outstanding routes that perform destructive actions to use POST requests only, requiring a valid CSRF token in the posted data. This closes a few unlikely and low-severity CSRF vulnerabilities.

## CSRF vulnerabilities

The routes in question are:

- `/do/admin/enable_posting`
- `/do/admin/enable_registration`
- `/do/admin/require_captchas`
- `/do/admin/deleteannouncement`
- `/do/create_invite`

Currently, should a malicious party convince an authenticated user to click a link to any of these, the corresponding action will be performed. For the first four routes, this user has to be an administrator, so this would have to be highly targeted.

While these are destructive in that they cause changes to the state of the application, for the first three routes which act as toggles, the user is redirected to the admin index page and a message is displayed describing the action taken, allowing the user to quickly reverse the action.

The announcement-deleting route also redirects the user to the admin index page, though it may not be so obvious that there is now no announcement set.

And while the final route will create a new invite code from the user’s pool, this is really just an annoyance.

## Contents of the pull request

This pull request looks quite large but the vast majority of the additions are in new tests for the routes and some additional helper functions.

**Please note** that this PR also includes changes to some Sub and SubPost model constraints to disallow null in some fields. This is only the case where such a null field would cause an exception in the application (or, for SubPost.title, cause its own `__repr__` to fail). (This came about while writing test helpers, which is why this change is present in this PR.)

I have written a migration to add the not-null constraints in the database, but this is a schema-only migration. I think it’s probably unlikely that nulls exist in these columns in the real world, given the effect on the application, but I would very much appreciate if this could be reviewed carefully. (It, er, also wasn’t clear to me how to perform an appropriate data migration for null fields in all cases.)

### Template changes

Most of the template changes are straightforwardly swapping links for forms. On the admin page the buttons display slightly differently than before; I’m not sure what is preferable and I’m not really familiar with the CSS so I’d appreciate some guidance here if it’s not quite right.

### Additional dependencies

I’ve added factory-boy and Faker as dependencies, but these are just test dependencies to make creating model instances easier and faster. I think there’s scope to extend the use of these factories, as well as some other helpers that I’ve written for this PR, to other tests. But I haven’t done that here, not least because there will need to be some consideration where the logic of the existing helpers (by, eg, registering a user by making requests to the application) is actually an important part of the behaviour tested and not just incidental complexity.
