### PR TITLE
Enforce in-practice not null constraints at the model & DB layer

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -181,7 +181,7 @@ class SiteMetadata(BaseModel):
 
 
 class Sub(BaseModel):
-    name = CharField(null=True, unique=True, max_length=32)
+    name = CharField(unique=True, max_length=32)
     nsfw = BooleanField(default=False)
     sid = CharField(primary_key=True, max_length=40)
     sidebar = TextField(default="")
@@ -281,26 +281,24 @@ class SubMetadata(BaseModel):
 
 class SubPost(BaseModel):
     content = TextField(null=True)
-    deleted = IntegerField(null=True)  # 1=self delete, 2=mod delete, 0=not deleted
+    deleted = IntegerField(default=0)  # 1=self delete, 2=mod delete, 0=not deleted
     distinguish = IntegerField(null=True)  # 1=mod, 2=admin, 0 or null = normal
     link = CharField(null=True)
     nsfw = BooleanField(null=True)
     pid = PrimaryKeyField()
-    posted = DateTimeField(null=True)
+    posted = DateTimeField(default=datetime.datetime.utcnow)
     edited = DateTimeField(null=True)
     ptype = IntegerField(null=True)  # 1=text, 2=link, 3=poll
 
-    score = IntegerField(null=True)  # XXX: Deprecated
+    score = IntegerField(default=1)  # XXX: Deprecated
     upvotes = IntegerField(default=0)
     downvotes = IntegerField(default=0)
 
-    sid = ForeignKeyField(db_column="sid", null=True, model=Sub, field="sid")
+    sid = ForeignKeyField(db_column="sid", model=Sub, field="sid")
     thumbnail = CharField(null=True)
-    title = CharField(null=True)
+    title = CharField()
     comments = IntegerField()
-    uid = ForeignKeyField(
-        db_column="uid", null=True, model=User, field="uid", backref="posts"
-    )
+    uid = ForeignKeyField(db_column="uid", model=User, field="uid", backref="posts")
     flair = CharField(null=True, max_length=25)
 
     def __repr__(self):

--- a/migrations/030_nullable_fields.py
+++ b/migrations/030_nullable_fields.py
@@ -1,0 +1,35 @@
+"""Peewee migrations -- 030_nullable fields.py.
+
+Add not-null constraints to columns on the sub and sub_post tables
+that in practice cannot be null as they cause obvious application
+errors by violating implicit assumptions.
+
+Because these failures are so obvious this migration does not include
+a data migration, only the schema change.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_not_null("sub", "name")
+
+    migrator.add_not_null("sub_post", "deleted")
+    migrator.add_not_null("sub_post", "posted")
+    migrator.add_not_null("sub_post", "score")
+    migrator.add_not_null("sub_post", "sid")
+    migrator.add_not_null("sub_post", "title")
+    migrator.add_not_null("sub_post", "uid")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.drop_not_null("sub", "name")
+
+    migrator.drop_not_null("sub_post", "deleted")
+    migrator.drop_not_null("sub_post", "posted")
+    migrator.drop_not_null("sub_post", "score")
+    migrator.drop_not_null("sub_post", "sid")
+    migrator.drop_not_null("sub_post", "title")
+    migrator.drop_not_null("sub_post", "uid")


### PR DESCRIPTION
This PR changes some fields on `Sub` and `SubPost` to disallow null, in cases where if the field is actually null (`None`) it violates assumptions elsewhere in the application and causes an exception to be thrown.

It includes a schema-only migration for the `sub` and `sub_post` tables to add these constraints. The failures are generally very obvious, so I think it’s probably unlikely that nulls exist in these columns in the wild. In any case, it’s not necessarily obvious what the right data migration would be in each case.

The commit message for 27fcca2 contains more information about the circumstances where having a null in a field causes a problem.

Thanks to @happy-river for their feedback in #366, from which this PR was extracted.