### PR TITLE
Ensure CSRF protection for destructive routes

### DIFF
--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -5,7 +5,7 @@ from .admin import *  # noqa
 from flask_wtf import FlaskForm
 
 
-class DummyForm(FlaskForm):
+class CsrfTokenOnlyForm(FlaskForm):
     """ This is here only for the csrf token. """
 
     pass

--- a/app/forms/admin.py
+++ b/app/forms/admin.py
@@ -4,7 +4,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField, TextAreaField, FileField
 from wtforms import IntegerField, RadioField, FieldList, SelectField
 from wtforms import HiddenField
-from wtforms.validators import DataRequired, Length, Regexp
+from wtforms.validators import DataRequired, InputRequired, Length, Regexp
 from flask_babel import lazy_gettext as _l
 
 
@@ -118,3 +118,26 @@ class SetSubOfTheDayForm(FlaskForm):
 class ChangeConfigSettingForm(FlaskForm):
     setting = HiddenField()
     value = StringField()
+
+
+class LiteralBooleanField(SelectField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            choices=["True", "False"],
+            coerce=self._literally_true_or_false,
+            validators=[InputRequired()],
+            **kwargs,
+        )
+
+    @staticmethod
+    def _literally_true_or_false(value: str) -> bool:
+        if value == "True":
+            return True
+        elif value == "False":
+            return False
+        raise ValueError("Value is not either 'True' or 'False'.")
+
+
+class LiteralBooleanForm(FlaskForm):
+    value = LiteralBooleanField()

--- a/app/forms/sub.py
+++ b/app/forms/sub.py
@@ -1,7 +1,7 @@
 """ Sub-related forms """
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, BooleanField, HiddenField
+from wtforms import StringField, TextAreaField, BooleanField, HiddenField, IntegerField
 from wtforms import RadioField, SelectField, FieldList
 from wtforms.validators import DataRequired, Length, URL
 from wtforms.validators import Optional
@@ -253,6 +253,12 @@ class UndeletePost(FlaskForm):
 
     post = HiddenField()
     reason = StringField()
+
+
+class AnnouncePostForm(FlaskForm):
+    """Form to mark a post as an announcement."""
+
+    post = IntegerField(validators=[DataRequired()])
 
 
 class VoteForm(FlaskForm):

--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -96,7 +96,7 @@ Mod |\
             @end
             @if current_user.is_admin() and reported_user.status != 5:
                 <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=report['reported'])}">
-                    @{form.DummyForm().csrf_token()!!html}
+                    @{form.CsrfTokenOnlyForm().csrf_token()!!html}
                   <a id="banuser-button" class="sbm-post pure-button button-secondary" >@{_('Ban %(reported)s from %(site)s', reported=report['reported'], site=config.site.name)}</a>
                 </form>
             @end

--- a/app/html/shared/sidebar/user.html
+++ b/app/html/shared/sidebar/user.html
@@ -3,17 +3,17 @@
 @if current_user.is_admin() and user.name != current_user.name:
     @if user.status in (0, 1):
       <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=user.name)}">
-          @{form.DummyForm().csrf_token()!!html}
+          @{form.CsrfTokenOnlyForm().csrf_token()!!html}
         <a id="banuser-button" class="sbm-post pure-button pure-button-primary">@{_('Ban user')}</a>
       </form>
     @elif user.status == 5:
       <form method="POST" data-reload="true" id="unbanuser" action="@{url_for('do.unban_user', username=user.name)}">
-        @{form.DummyForm().csrf_token()!!html}
+        @{form.CsrfTokenOnlyForm().csrf_token()!!html}
         <a id="unbanuser-button" class="sbm-post pure-button pure-button-primary">@{_('Un-ban user')}</a>
       </form>
     @end
     <form  method="POST" data-reload="true" id="wipevotes" action="@{url_for('do.admin_undo_votes', uid=user.uid)}">
-        @{form.DummyForm().csrf_token()!!html}
+        @{form.CsrfTokenOnlyForm().csrf_token()!!html}
       <a id="wipevotes-button" class="sbm-post pure-button pure-button-primary">@{_('Remove votes')}</a>
     </form>
     <hr>

--- a/app/html/user/settings/invitecode.html
+++ b/app/html/user/settings/invitecode.html
@@ -1,5 +1,5 @@
 @extends("shared/layout.html")
-@require(codes, avail)
+@require(codes, avail, csrf_form)
 @def sidebar():
   @include('shared/sidebar/user.html')
 @end
@@ -8,8 +8,11 @@
 <div id="container">
   <h1>@{_('Invite codes')}</h1>
   @if avail > 0:
-    @{_('You can create <b>%(num)i</b> invite codes.', num=avail)!!html}
-    <a href="/do/create_invite" class="pure-button pure-button-primary">@{_('Create new')}</a>
+    <form action="@{ url_for('do.invite_codes') }" method="post" id="createinvite">
+      @{_('You can create <b>%(num)i</b> invite codes.', num=avail)!!html}
+      @{ csrf_form.csrf_token()!!html }
+      <input type="submit" name="createinvite-button" class="pure-button pure-button-primary" value="@{_('Create new')}">
+    </form>
   @else:
     @{_('You cannot create invite codes.')}
   @end
@@ -40,7 +43,7 @@
           @else:
             @{_('N/A')}
           @end
-         
+
         </td>
         <td>
           @{code.uses}

--- a/app/templates/admin/admin.html
+++ b/app/templates/admin/admin.html
@@ -47,8 +47,11 @@
           {%if not ann %}<h4>No active announcements</h4>
           {%else%}
           <div class="post">
-            <a href="{{url_for('do.deleteannouncement')}}" class="btn btn-red">Nuke!</a> |
-            <a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time>
+            <form method="POST" id="deleteannouncement" action="{{ url_for('do.deleteannouncement') }}">
+              {{ deleteAnnouncementForm.csrf_token() }}
+              <p><a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time></p>
+              <input id="deleteannouncement-button" type="submit" value="Remove" class="pure-button">
+            </form>
           </div>
 
           {%endif%}

--- a/app/templates/admin/admin.html
+++ b/app/templates/admin/admin.html
@@ -48,7 +48,7 @@
           {%else%}
           <div class="post">
             <form method="POST" id="deleteannouncement" action="{{ url_for('do.deleteannouncement') }}">
-              {{ deleteAnnouncementForm.csrf_token() }}
+              {{ csrf_form.csrf_token() }}
               <p><a href="{{url_for('site.view_post_inbox', pid=ann.pid)}}">{{ann.title}}</a> by {{ann.user}}, <relative-time datetime="{{ann.posted.isoformat()}}Z"></relative-time></p>
               <input id="deleteannouncement-button" type="submit" value="Remove" class="pure-button">
             </form>
@@ -64,11 +64,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.enable_posting %}
-          <div>Disable posting for non-admin users</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_posting', value='False')}}">Disable Posting</a>
+          <form method="POST" id="disableposting" action="{{ url_for('do.enable_posting') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <div><label for="disableposting-button">Disable posting for non-admin users</label></div>
+            <input type="submit" name="disableposting-button" class="pure-button button-warning" value="Disable Posting">
+          </form>
           {% else %}
-          <div>Enable posting for non-admin users</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_posting', value='True')}}">Enable Posting</a>
+          <form method="POST" id="enableposting" action="{{ url_for('do.enable_posting') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <div><label for="enableposting-button">Enable posting for non-admin users</label></div>
+            <input type="submit" name="enableposting-button" class="pure-button button-warning" value="Enable Posting">
+          </form>
           {% endif %}
         </div>
       </div>
@@ -78,11 +86,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.enable_registration %}
-          <div>Disable registration for new users</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_registration', value='False')}}">Disable Registration</a>
+          <form method="POST" id="disableregistration" action="{{ url_for('do.enable_registration') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <div><label for="disableregistration-button">Disable registration for new users</label></div>
+            <input type="submit" name="disableregistration-button" class="pure-button button-warning" value="Disable Registration">
+          </form>
           {% else %}
-          <div>Enable registration for new users</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_registration', value='True')}}">Enable Registration</a>
+          <form method="POST" id="enableregistration" action="{{ url_for('do.enable_registration') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <div><label for="enableregistration-button">Enable registration for new users</label></div>
+            <input type="submit" id="enableregistration-button" class="pure-button button-warning" value="Enable Registration">
+          </form>
           {% endif %}
         </div>
       </div>
@@ -92,11 +108,19 @@
       <div class="col-12 admin-page-form">
         <div>
           {% if config.site.require_captchas %}
-          <div>Disable captchas for registration, password recovery and post creation</div>
-          <a class="pure-button button-error" href="{{url_for('do.enable_captchas', value='False')}}">Disable Captchas</a>
+          <form method="POST" id="disablecaptchas" action="{{ url_for('do.enable_captchas') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="False">
+            <div><label for="disablecaptchas-button">Disable captchas for registration, password recovery and post creation</label></div>
+            <input type="submit" name="disablecaptchas-button" class="pure-button button-error" value="Disable Captchas">
+          </form>
           {% else %}
-          <div>Enable captchas for registration, password recovery and post creation</div>
-          <a class="pure-button button-warning" href="{{url_for('do.enable_captchas', value='True')}}">Enable Captchas</a>
+          <form method="POST" id="enablecaptchas" action="{{ url_for('do.enable_captchas') }}">
+            {{ csrf_form.csrf_token() }}
+            <input type="hidden" name="value" value="True">
+            <div><label for="enablecaptchas-button">Enable captchas for registration, password recovery and post creation</label></div>
+            <input type="submit" name="disablecaptchas-button" class="pure-button button-error" value="Enable Captchas">
+          </form>
           {% endif %}
         </div>
       </div>

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -23,6 +23,7 @@ from flask_babel import _
 from .. import misc
 from ..config import config
 from ..forms import (
+    DummyForm,
     TOTPForm,
     LogOutForm,
     UseInviteCodeForm,
@@ -183,6 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
+        deleteAnnouncementForm=DummyForm(),
     )
 
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -184,7 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
-        deleteAnnouncementForm=DummyForm(),
+        csrf_form=DummyForm(),
     )
 
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -23,7 +23,7 @@ from flask_babel import _
 from .. import misc
 from ..config import config
 from ..forms import (
-    DummyForm,
+    CsrfTokenOnlyForm,
     TOTPForm,
     LogOutForm,
     UseInviteCodeForm,
@@ -184,7 +184,7 @@ def index():
         comms=comms,
         subOfTheDay=subOfTheDay,
         useinvitecodeform=invite,
-        csrf_form=DummyForm(),
+        csrf_form=CsrfTokenOnlyForm(),
     )
 
 

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2303,11 +2303,14 @@ def use_invite_code():
     return jsonify(status="ok")
 
 
-@do.route("/do/create_invite")
+@do.route("/do/create_invite", methods=["POST"])
 @login_required
 def invite_codes():
     if not config.site.require_invite_code:
         return redirect("/settings")
+
+    if not DummyForm().validate():
+        abort(400)
 
     created = InviteCode.select().where(InviteCode.user == current_user.uid).count()
     maxcodes = int(misc.getMaxCodes(current_user.uid))

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2064,6 +2064,7 @@ def deleteannouncement():
 
 
 @do.route("/do/makeannouncement", methods=["POST"])
+@login_required
 def make_announcement():
     """ Flagging post as announcement - not api """
     if not current_user.is_admin():
@@ -2165,6 +2166,7 @@ def remove_banned_domain(domain_type, domain):
 
 
 @do.route("/do/admin/enable_posting/<value>")
+@login_required
 def enable_posting(value):
     """ Emergency Mode: disable posting """
     if not current_user.is_admin():
@@ -2184,6 +2186,7 @@ def enable_posting(value):
 
 
 @do.route("/do/admin/enable_registration/<value>")
+@login_required
 def enable_registration(value):
     """ Isolation Mode: disable registration """
     if not current_user.is_admin():
@@ -2203,6 +2206,7 @@ def enable_registration(value):
 
 
 @do.route("/do/admin/require_captchas/<value>")
+@login_required
 def enable_captchas(value):
     """ Enable or disable the captcha solving requirement. """
     if not current_user.is_admin():

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -33,7 +33,7 @@ from ..forms import SearchForm, EditMod2Form, SetSubOfTheDayForm, AssignSubUserF
 from ..forms import DeleteSubFlair, DeleteSubRule, CreateReportNote
 from ..forms import UseInviteCodeForm, SecurityQuestionForm, DistinguishForm
 from ..forms import BanDomainForm, SetOwnUserFlairForm, ChangeConfigSettingForm
-from ..forms import AnnouncePostForm
+from ..forms import AnnouncePostForm, LiteralBooleanForm
 from ..badges import badges
 from ..misc import (
     cache,
@@ -2171,15 +2171,17 @@ def remove_banned_domain(domain_type, domain):
     return json.dumps({"status": "ok"})
 
 
-@do.route("/do/admin/enable_posting/<value>")
+@do.route("/do/admin/enable_posting", methods=["POST"])
 @login_required
-def enable_posting(value):
+def enable_posting():
     """ Emergency Mode: disable posting """
     if not current_user.is_admin():
         abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.enable_posting", state)
     misc.create_sitelog(
@@ -2191,15 +2193,17 @@ def enable_posting(value):
     return redirect(url_for("admin.index"))
 
 
-@do.route("/do/admin/enable_registration/<value>")
+@do.route("/do/admin/enable_registration", methods=["POST"])
 @login_required
-def enable_registration(value):
+def enable_registration():
     """ Isolation Mode: disable registration """
     if not current_user.is_admin():
         abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.enable_registration", state)
     misc.create_sitelog(
@@ -2211,15 +2215,17 @@ def enable_registration(value):
     return redirect(url_for("admin.index"))
 
 
-@do.route("/do/admin/require_captchas/<value>")
+@do.route("/do/admin/require_captchas", methods=["POST"])
 @login_required
-def enable_captchas(value):
+def enable_captchas():
     """ Enable or disable the captcha solving requirement. """
     if not current_user.is_admin():
-        return abort(404)
-    if value not in ["True", "False"]:
-        return abort(400)
-    state = value == "True"
+        abort(404)
+
+    form = LiteralBooleanForm()
+    if not form.validate():
+        abort(400)
+    state = form.value.data
 
     config.update_value("site.require_captchas", state)
     misc.create_sitelog(

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -2039,12 +2039,16 @@ def save_pm(mid):
         return jsonify(status="error", error=_("Message does not exist"))
 
 
-@do.route("/do/admin/deleteannouncement")
+@do.route("/do/admin/deleteannouncement", methods=["POST"])
 @login_required
 def deleteannouncement():
     """ Removes the current announcement """
     if not current_user.is_admin():
         abort(403)
+
+    form = DummyForm()
+    if not form.validate():
+        abort(400)
 
     try:
         ann = SiteMetadata.get(SiteMetadata.key == "announcement")

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -33,6 +33,7 @@ from ..forms import SearchForm, EditMod2Form, SetSubOfTheDayForm, AssignSubUserF
 from ..forms import DeleteSubFlair, DeleteSubRule, CreateReportNote
 from ..forms import UseInviteCodeForm, SecurityQuestionForm, DistinguishForm
 from ..forms import BanDomainForm, SetOwnUserFlairForm, ChangeConfigSettingForm
+from ..forms import AnnouncePostForm
 from ..badges import badges
 from ..misc import (
     cache,
@@ -2070,12 +2071,12 @@ def make_announcement():
     if not current_user.is_admin():
         abort(403)
 
-    form = DeletePost()
+    form = AnnouncePostForm()
 
     if form.validate():
         try:
             curr_ann = SiteMetadata.get(SiteMetadata.key == "announcement")
-            if curr_ann.value == form.post.data:
+            if int(curr_ann.value) == form.post.data:
                 return jsonify(status="error", error=_("Post already announced"))
             deleteannouncement()
         except SiteMetadata.DoesNotExist:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -23,7 +23,7 @@ from ..auth import (
     AuthError,
     normalize_email,
 )
-from ..forms import LogOutForm, CreateSubFlair, DummyForm, CreateSubRule
+from ..forms import LogOutForm, CreateSubFlair, CsrfTokenOnlyForm, CreateSubRule
 from ..forms import EditSubForm, EditUserForm, EditSubCSSForm
 from ..forms import EditModForm, BanUserSubForm, DeleteAccountForm, EditAccountForm
 from ..forms import EditSubTextPostForm, AssignUserBadgeForm
@@ -738,7 +738,7 @@ def assign_post_flair(sub, pid, fl):
     except SubPost.DoesNotExist:
         return jsonify(status="error", error=[_("Post does not exist")])
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.is_mod(sub.sid) or (
             post.uid_id == current_user.uid and sub.get_metadata("ucf")
@@ -887,7 +887,7 @@ def subscribe_to_sub(sid):
     if current_user.has_subscribed(sid):
         return jsonify(status="ok", message=_("already subscribed"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.has_blocked(sid):
             ss = SubSubscriber.get(
@@ -917,7 +917,7 @@ def unsubscribe_from_sub(sid):
     if not current_user.has_subscribed(sid):
         return jsonify(status="ok", message=_("not subscribed"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         ss = SubSubscriber.get(
             (SubSubscriber.uid == current_user.uid)
@@ -943,7 +943,7 @@ def block_sub(sid):
     if current_user.has_blocked(sid):
         return jsonify(status="ok", message=_("already blocked"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.has_subscribed(sub.name):
             ss = SubSubscriber.get(
@@ -973,7 +973,7 @@ def unblock_sub(sid):
     if not current_user.has_blocked(sid):
         return jsonify(status="ok", message=_("sub not blocked"))
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         ss = SubSubscriber.get(
             (SubSubscriber.uid == current_user.uid)
@@ -1638,7 +1638,7 @@ def remove_sub_ban(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if current_user.is_mod(sub.sid, 2) or current_user.is_admin():
             try:
@@ -1741,7 +1741,7 @@ def remove_mod2(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         isTopMod = current_user.is_mod(sub.sid, 0)
         if (
@@ -1790,7 +1790,7 @@ def revoke_mod2inv(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         isTopMod = current_user.is_mod(sub.sid, 0)
         if isTopMod or current_user.is_admin():
@@ -1831,7 +1831,7 @@ def accept_modinv(sub, user):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             modi = SubMod.get(
@@ -1884,7 +1884,7 @@ def refuse_mod2inv(sub):
     except Sub.DoesNotExist:
         return jsonify(status="error", error=[_("Sub does not exist")])
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             modi = SubMod.get(
@@ -2046,7 +2046,7 @@ def deleteannouncement():
     if not current_user.is_admin():
         abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         abort(400)
 
@@ -2309,7 +2309,7 @@ def invite_codes():
     if not config.site.require_invite_code:
         return redirect("/settings")
 
-    if not DummyForm().validate():
+    if not CsrfTokenOnlyForm().validate():
         abort(400)
 
     created = InviteCode.select().where(InviteCode.user == current_user.uid).count()
@@ -2833,7 +2833,7 @@ def undelete_comment():
 @do.route("/do/vote/<pid>/<value>", methods=["POST"])
 def upvote(pid, value):
     """ Logs an upvote to a post. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return json.dumps({"status": "error", "error": get_errors(form)}), 400
     if not current_user.is_authenticated:
@@ -2845,7 +2845,7 @@ def upvote(pid, value):
 @do.route("/do/votecomment/<cid>/<value>", methods=["POST"])
 def upvotecomment(cid, value):
     """ Logs an upvote to a post. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return json.dumps({"status": "error", "error": get_errors(form)})
 
@@ -2958,7 +2958,7 @@ def get_sibling(pid, cid, lim):
 @login_required
 def preview():
     """ Returns parsed markdown. Used for post and comment previews. """
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         if request.json.get("text"):
             return jsonify(
@@ -3145,7 +3145,7 @@ def sub_upload_delete(sub, name):
         sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
     except Sub.DoesNotExist:
         jsonify(status="error")  # descriptive errors where?
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return redirect(url_for("sub.edit_sub_css", sub=sub.name))
     if not current_user.is_mod(sub.sid, 1) and not current_user.is_admin():
@@ -3194,7 +3194,7 @@ def delete_question(xid):
     if not current_user.is_admin():
         abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return jsonify(status="error")
     try:
@@ -3213,7 +3213,7 @@ def ban_user(username):
     if not current_user.is_admin():
         return abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return abort(403)
 
@@ -3260,7 +3260,7 @@ def unban_user(username):
     if not current_user.is_admin():
         return abort(403)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return abort(403)
 
@@ -3306,7 +3306,7 @@ def unban_user(username):
 @do.route("/do/edit_top_bar", methods=["POST"])
 @login_required
 def edit_top_bar():
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return jsonify(status="error", error="no CSRF")
 
@@ -3346,7 +3346,7 @@ def admin_undo_votes(uid):
     except User.DoesNotExist:
         return abort(404)
 
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if not form.validate():
         return redirect(url_for("user.view", user=user.name))
 
@@ -3413,7 +3413,7 @@ def admin_undo_votes(uid):
 @do.route("/do/cast_vote/<pid>/<oid>", methods=["POST"])
 @login_required
 def cast_vote(pid, oid):
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             post = misc.getSinglePost(pid)
@@ -3476,7 +3476,7 @@ def cast_vote(pid, oid):
 @do.route("/do/remove_vote/<pid>", methods=["POST"])
 @login_required
 def remove_vote(pid):
-    form = DummyForm()
+    form = CsrfTokenOnlyForm()
     if form.validate():
         try:
             post = misc.getSinglePost(pid)

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -8,7 +8,7 @@ import uuid
 import random
 from collections import defaultdict
 from flask import Blueprint, redirect, url_for, session, abort, jsonify, current_app
-from flask import request
+from flask import request, flash, Markup
 from flask_login import login_user, login_required, logout_user, current_user
 from flask_babel import _
 from itsdangerous import URLSafeTimedSerializer
@@ -2056,6 +2056,7 @@ def deleteannouncement():
     except SiteMetadata.DoesNotExist:
         return redirect(url_for("admin.index"))
 
+    flash(_("Removed announcement") + f": {Markup.escape(post.title)}")
     ann.delete_instance()
     misc.create_sitelog(
         misc.LOG_TYPE_UNANNOUNCE,

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -11,7 +11,7 @@ from ..auth import auth_provider, AuthError, normalize_email
 from ..misc import engine, gevent_required
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import (
-    DummyForm,
+    CsrfTokenOnlyForm,
     EditUserForm,
     CreateUserMessageForm,
     EditAccountForm,
@@ -208,7 +208,7 @@ def invite_codes():
             "max": maxcodes,
             "avail": avail,
             "user": User.get(User.uid == current_user.uid),
-            "csrf_form": DummyForm(),
+            "csrf_form": CsrfTokenOnlyForm(),
         }
     )
 

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -11,6 +11,7 @@ from ..auth import auth_provider, AuthError, normalize_email
 from ..misc import engine, gevent_required
 from ..misc import ratelimit, AUTH_LIMIT, SIGNUP_LIMIT
 from ..forms import (
+    DummyForm,
     EditUserForm,
     CreateUserMessageForm,
     EditAccountForm,
@@ -207,6 +208,7 @@ def invite_codes():
             "max": maxcodes,
             "avail": avail,
             "user": User.get(User.uid == current_user.uid),
+            "csrf_form": DummyForm(),
         }
     )
 


### PR DESCRIPTION
This pull request converts a few outstanding routes that perform destructive actions to use POST requests only, requiring a valid CSRF token in the posted data. This closes a few unlikely and low-severity CSRF vulnerabilities.

This PR is spun off from #366, but incorporates the feedback to fix the display of the buttons on the admin page, and to improve the wording of the delete-announcement button.

One additional change I made that is not in #366 is to place the delete-announcement button below the details of the current announcement, for consistency with the other buttons on the page. (This also makes that line less cramped.)

**One question I have** but did not raise previously: the delete-announcement link was styled with the `btn-red` class, which is no longer in the CSS, and so it appeared as a plain link (and now a plain button). Should the delete-announcement button be red, similar to the disable-captchas button?

## CSRF vulnerabilities

The routes in question are:

- `/do/admin/enable_posting`
- `/do/admin/enable_registration`
- `/do/admin/require_captchas`
- `/do/admin/deleteannouncement`
- `/do/create_invite`

Currently, should a malicious party convince an authenticated user to click a link to any of these, the corresponding action will be performed. For the first four routes, this user has to be an administrator, so this would have to be highly targeted.

While these are destructive in that they cause changes to the state of the application, for the first three routes which act as toggles, the user is redirected to the admin index page and a message is displayed describing the action taken, allowing the user to quickly reverse the action.

The announcement-deleting route also redirects the user to the admin index page, though it may not be so obvious that there is now no announcement set.

And while the final route will create a new invite code from the user’s pool, this is really just an annoyance.