### PR TITLE
Tests for newly CSRF-protected routes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,9 @@ cryptography==3.3.2
 dnspython==2.0.0
 ecdsa==0.14.1
 email-validator==1.1.2
+factory-boy==3.2.0
 feedgen==0.9.0
+Faker==8.6.0
 Flask==1.1.2
 Flask-Babel==2.0.0
 Flask-Caching==1.9.0

--- a/test/factories.py
+++ b/test/factories.py
@@ -1,0 +1,69 @@
+from typing import Type, TypeVar
+
+import factory
+from peewee import Model
+
+from app.models import SiteMetadata, Sub, SubPost, User, UserMetadata
+
+T = TypeVar("T", bound=Model)
+
+
+class PeeweeBaseFactory(factory.Factory):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _create(cls, model_class: Type[T], *args, **kwargs) -> T:
+        return model_class.create(*args, **kwargs)
+
+
+class SubFactory(PeeweeBaseFactory):
+    class Meta:
+        model = Sub
+
+    name = factory.Faker("word")
+    sid = factory.Faker("uuid4")
+
+
+class UserFactory(PeeweeBaseFactory):
+    class Meta:
+        model = User
+
+    uid = factory.Faker("uuid4")
+    name = factory.Faker("user_name")
+    crypto = 0
+
+
+def promote_user_to_admin(user: User) -> None:
+    UserMetadata.create(uid=user.uid, key="admin", value="1")
+
+
+class AdminFactory(UserFactory):
+    class Meta:
+        model = User
+
+    @classmethod
+    def _create(cls, model_class: Type[User], *args, **kwargs) -> User:
+        user = super()._create(model_class, *args, **kwargs)
+        promote_user_to_admin(user)
+        return user
+
+
+class PostFactory(PeeweeBaseFactory):
+    class Meta:
+        model = SubPost
+
+    sid = factory.SubFactory(SubFactory)
+    title = factory.Faker("sentence")
+    comments = 0
+    uid = factory.SubFactory(UserFactory)
+    deleted = 0
+    posted = factory.Faker("date_time")
+
+
+class AnnouncedPostFactory(PostFactory):
+    @classmethod
+    def _create(cls, model_class: Type[SubPost], *args, **kwargs) -> SubPost:
+        post = super()._create(model_class, *args, **kwargs)
+        SiteMetadata.create(key="announcement", value=post.pid)
+        return post

--- a/test/test_login_helpers.py
+++ b/test/test_login_helpers.py
@@ -1,0 +1,25 @@
+from flask.helpers import url_for
+
+
+def test_admins_get_200_on_admin_index(client, an_admin) -> None:
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Admins receive a 200 OK response.
+    assert response == 200
+
+
+def test_non_admins_get_404_on_admin_index(client, a_user) -> None:
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Non-admin users receive a 404 Not Found response.
+    # (Perhaps it should be 403 really?)
+    assert response == 404
+
+
+def test_anonymous_users_get_302_on_admin_index(client) -> None:
+    # Attempt to get the admin page.
+    response = client.get(url_for("admin.index"))
+    # Anonymous users receive a 302 Found response
+    # and are redirected to the login page.
+    assert response == 302
+    assert response.location.startswith(url_for("auth.login"))

--- a/test/views/test_user.py
+++ b/test/views/test_user.py
@@ -1,8 +1,101 @@
+from app.config import config
+from app.models import User
 from flask import url_for
-from test.utilities import register_user
+from test.utilities import (
+    number_of_invite_codes_created_by_user,
+    register_user,
+    user_has_invite_codes_remaining,
+    user_level,
+)
+
+import pytest
 
 
 def test_settings_page(client, user_info):
     register_user(client, user_info)
     username = user_info["username"]
     assert client.get(url_for("user.edit_user", user=username)).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
+)
+def test_create_invite_code_successfully(client, a_user: User, csrf_token: str) -> None:
+    # Given that invite codes are required.
+    # And the user has created no codes.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user can create more codes.
+    assert user_has_invite_codes_remaining(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+
+    # Then a new invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 1
+    # And the user is redirected to the invite settings page.
+    assert response == 302
+    assert response.location.startswith(url_for("user.invite_codes"))
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 0}}]
+)
+def test_create_invite_code_rejects_requests_without_csrf_token(
+    client, a_user: User
+) -> None:
+    # Given that invite codes are required.
+    # And the user has created no codes.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user can create more codes.
+    assert user_has_invite_codes_remaining(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": ""})
+
+    # Then no new invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the response is a 400 error.
+    assert response == 400
+
+
+@pytest.mark.parametrize("test_config", [{"site": {"require_invite_code": False}}])
+def test_create_invite_redirects_to_settings_when_invites_are_disabled(
+    client, a_user: User, csrf_token: str
+) -> None:
+    # Given invite codes are not required.
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+    # Then they are directed to their settings page.
+    assert response == 302
+    assert response.location.startswith(url_for("user.edit_user"))
+
+
+def test_create_invite_redirects_anonymous_users_to_login(
+    client, csrf_token: str
+) -> None:
+    # Given the user is not logged in.
+    # When they attempt to create an invite code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+    # They are redirected to the login page.
+    assert response == 302
+    assert response.location.startswith(url_for("auth.login"))
+
+
+@pytest.mark.parametrize(
+    "test_config", [{"site": {"require_invite_code": True, "invite_level": 1}}]
+)
+def test_create_invite_code_fails_when_level_is_too_low(
+    client, a_user: User, csrf_token: str
+) -> None:
+    # Given that invite codes are required.
+    # And the user has too low a level to create codes.
+    assert config.site.invite_level > user_level(a_user)
+
+    # When the user attempts to create a code.
+    response = client.post(url_for("do.invite_codes"), data={"csrf_token": csrf_token})
+
+    # Then no invite code is created.
+    assert number_of_invite_codes_created_by_user(a_user) == 0
+    # And the user is redirected to the invite settings page.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(url_for("user.invite_codes"))


### PR DESCRIPTION
This commit squashes together a lot of work on tests for several destructive routes that were previously unprotected against CSRF attacks (plus the 'make announcement' route, which was fine, in order to better understand the 'delete announcement' route). This PR depends on #369, which was also spun out of the original #366 after feedback, for the tests to actually pass and so it’s marked as a draft PR for the moment.

Included are new tests for:

- Making and deleting announcements,
- Toggling registration/posting/captchas,
- User creation of invite codes.

In addition, there are new test helpers for creating models, logging-in users, retrieving CSRF tokens (without making a request) etc.

This is all squashed together as I couldn't arrive at a clean history separate from the rest of the work where the tests would still pass at every revision, so I thought it better to commit the final result. Please be assured these tests were _arrived at_ over the course of understanding, characterising and refactoring the routes, and not just conjured up after the fact.

The original history of the work, in case it’s needed for diagnosing problems, is at [robjwells/close-csrf-hole-for-do-actions](/robjwells/throat/tree/close-csrf-hole-for-do-actions).