### PR TITLE
Make the graphical display of notifications on the title icon optional

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -323,6 +323,14 @@ configurable_defaults = {
                 "doc": _l("Require an invite code to register."),
                 "value": False,
             },
+            "notifications_on_icon": {
+                "type": "bool",
+                "doc": _l(
+                    "If enabled, show the notification count on the page title icon.  "
+                    "Otherwise, show the notification count in parentheses in the page title."
+                ),
+                "value": True,
+            },
         },
     },
     "storage": {

--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -200,5 +200,6 @@
   @def pagefoot():
   @end
   @{pagefoot()!!html}
+  <label id="pagefoot-notifications-icon" data-value="@{config.site.notifications_on_icon}" class="hide"></label>
 </body>
 </html>

--- a/app/static/js/Socket.js
+++ b/app/static/js/Socket.js
@@ -8,14 +8,18 @@ RegExp.escape= function(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 };
 
-Tinycon.setOptions({
-    height: 11,
-	font: '10px arial',
-	color: '#ffffff',
-	background: '#000000',
-	fallback: true
-});
+function setupTinycon () {
+  const valueElem = document.getElementById("pagefoot-notifications-icon");
+  const onIcon = !valueElem || (valueElem.getAttribute("data-value") == "True");
 
+  Tinycon.setOptions({
+    height: 11,
+    font: '10px arial',
+    color: '#ffffff',
+    background: '#000000',
+    fallback: onIcon ? true : "force"
+  });
+}
 
 const socket = io('///snt', {transports: ['websocket'], upgrade: false});
 
@@ -57,6 +61,7 @@ function updateTitleNotifications() {
     count += Number(modcount.innerHTML);
   }
 
+  setupTinycon();
   Tinycon.setBubble(count)
 }
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -170,5 +170,6 @@
   <script src="{{ asset_url_for('main.js') }}"></script>
   <style>{{current_user.get_global_stylesheet()|safe}}</style>
   {%block pagefoot%}{%endblock%}
+  <label id="pagefoot-notifications-icon" data-value="{{config.site.notifications_on_icon}}" class="hide"></label>
 </body>
 </html>

--- a/migrations/031_notifications_on_icon.py
+++ b/migrations/031_notifications_on_icon.py
@@ -1,0 +1,23 @@
+"""Peewee migrations -- 031_notifications_on_icon
+
+Add a admin site configuration option to control whether notifications are
+shown graphically on the icon or textually in the page title.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.create(key="site.notifications_on_icon", value="1")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(
+            SiteMetadata.key == "site.notifications_on_icon"
+        ).execute()


### PR DESCRIPTION
Tinycon's graphical display of notification counts doesn't look good with our icon.  Make an admin site configuration option to display notification counts in the title within parentheses instead of graphically on the icon.