### PR TITLE
Make the tests work with Postgres, and add a test for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,23 @@ You can check out the [CDK Definition of Infrastructure](https://gitlab.com/femi
 ### Python tests
 
 1. Python, redis, and libmagic are required, but node and postgres are not.
+
 2. Install dependencies with `pip install -r requirements.txt`
+
 3. Run the tests with `python -m pytest`
+
 4. The tests are not affected by your configuration in `config.yaml`.
 If you wish to run the tests against production database or
 authentication servers (instead of the defaults, which are sqlite and
 local authentication), you may put configuration settings in
 `test_config.yaml` and run the tests with
-`TEST_CONFIG=test_config.yaml python -m pytest`
+`TEST_CONFIG=test_config.yaml python -m pytest`.  The tests *will
+erase* the database supplied in the test configuration.  You can also
+supply a logging configuration in `test_config.yaml` and then `pytest`
+will show you the logs from failing tests.
+
+Note: The tests currently work with Postgres and Sqlite.  Testing with
+MySQL is not yet supported.
 
 ### Testing under Docker
 

--- a/test/specs/test_migrations.py
+++ b/test/specs/test_migrations.py
@@ -1,0 +1,34 @@
+import logging
+from mock import Mock
+from peewee_migrate import Router
+
+from app.models import dbp
+
+
+def test_migrations(app_before_init_db):
+    """The database migrations complete successfully."""
+    app, conf_obj = app_before_init_db
+
+    dbp.connect()
+
+    if conf_obj.database.engine == "PostgresqlDatabase":
+        dbp.execute_sql("DROP SCHEMA public CASCADE;")
+        dbp.execute_sql("CREATE SCHEMA public;")
+        dbp.execute_sql("GRANT ALL ON SCHEMA public TO public;")
+
+    router = Router(dbp, migrate_dir="migrations", ignore=["basemodel"])
+    router.run()
+
+    applied_migrations = list(router.done)
+    applied_migrations.reverse()
+
+    # Shut up a warning in rollback that we can't do anything about.
+    logging.getLogger("peewee_migrate").warn = Mock()
+
+    # Make sure new rollbacks work.  The existing ones are what they are.
+    for m in applied_migrations:
+        if m == "029_message_read":
+            break
+        router.rollback(m)
+
+    dbp.close()


### PR DESCRIPTION
Fix the tests so that they pass if you supply Postgres database credentials to them, as described in `README.md`.  Add a test that checks that database migrations and newly added rollbacks complete without errors.
