### PR TITLE
Fix visible HTML on the email confirmation page

### DIFF
--- a/app/html/user/check-your-email.html
+++ b/app/html/user/check-your-email.html
@@ -9,7 +9,7 @@
         @if email == '':
           <p>@{_('Click the link in the email we sent to you. You may want to check your spam folder, just in case ;)')}</p>
         @else:
-          @{_('<p>We sent a confirmation email to:</p><p class="attention">%(email)s</p>', email=email)}
+          @{_('<p>We sent a confirmation email to:</p><p class="attention">%(email)s</p>', email=email)!!html}
           <p>@{_('Check your email and click on the confirmation link. You may want to check your spam folder, just in case ;)')}</p>
         @end
         @if reason == 'registration':


### PR DESCRIPTION
Fix a regression from afe7bdb55a which caused HTML tags to be shown on the page that confirms a user's email address after registration.