### PR TITLE
Add target user to sub log for post and comment delete/undelete

### DIFF
--- a/app/html/sub/log.html
+++ b/app/html/sub/log.html
@@ -76,7 +76,7 @@
                     @end
                 </td>
                 <td>
-                    @if log.action in [22, 23, 24, 26, 27, 28]:
+                    @if log.action in [22, 23, 24, 26, 27, 28, 52, 53, 58, 59] and log.target is not None:
                         <a href="/u/@{log.target.name}">@{log.target.name}</a>
                     @end
                 </td>

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -518,6 +518,7 @@ def delete_post(sub, pid):
             comment=reason,
             link=url_for("site.view_post_inbox", pid=post.pid),
             admin=False,
+            target=post.uid,
         )
 
     if (datetime.datetime.utcnow() - post.posted.replace(tzinfo=None)).seconds < 86400:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -349,6 +349,7 @@ def delete_post():
                 admin=True
                 if (not current_user.is_mod(post.sid) and current_user.is_admin())
                 else False,
+                target=post.uid,
             )
 
             related_reports = SubPostReport.select().where(
@@ -455,6 +456,7 @@ def undelete_post():
             admin=True
             if (not current_user.is_mod(post.sid) and current_user.is_admin())
             else False,
+            target=post.uid,
         )
 
         related_reports = SubPostReport.select().where(SubPostReport.pid == post.pid)
@@ -2765,6 +2767,7 @@ def delete_comment():
                 admin=True
                 if (not current_user.is_mod(sub.sid) and current_user.is_admin())
                 else False,
+                target=comment.uid,
             )
             related_reports = SubPostCommentReport.select().where(
                 SubPostCommentReport.cid == comment.cid
@@ -2822,6 +2825,7 @@ def undelete_comment():
             admin=True
             if (not current_user.is_mod(sub.sid) and current_user.is_admin())
             else False,
+            target=comment.uid,
         )
         related_reports = SubPostCommentReport.select().where(
             SubPostCommentReport.cid == comment.cid


### PR DESCRIPTION
Populate the user column on the sub log page with the author of the post or comment when a post or comment is deleted or undeleted by a mod or admin.  This will help mods see at a glance recent previous actions against a user.