### PR TITLE
Add an admin option to enable/disable archiving of sticky posts

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -250,6 +250,14 @@ configurable_defaults = {
                 "doc": _l("Number of days after which posts will be archived."),
                 "value": 60,
             },
+            "archive_sticky_posts": {
+                "type": "bool",
+                "doc": _l(
+                    "When enabled, archive sticky posts after 'archive_post_after' days, "
+                    "the same as regular posts. When disabled, sticky posts will not be archived."
+                ),
+                "value": True,
+            },
             "recent_activity": {
                 "type": "map",
                 "value": {

--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -3,7 +3,7 @@
 <div pid="@{post['pid']}" class="post @{(post['distinguish'] == 1 and 'mod' or '')} @{(post['distinguish'] == 2 and 'admin' or '')}">
     <div class="misctainer">
       <div class="votebuttons">
-        @if post['userstatus'] != 10 and (datetime.datetime.utcnow() - post['posted'].replace(tzinfo=None)) < datetime.timedelta(days=config.site.archive_post_after):
+        @if post['userstatus'] != 10 and not func.is_archived(post):
         <div title="@{_('Upvote')}" class="upvote @{(post.get('positive') == 1) and 'upvoted' or ''}" data-pid="@{post['pid']}" data-icon="upvote"></div>
         <div class="score">@{post['score']}</div>
         <div title="@{_('Downvote')}" class="downvote @{(post.get('positive') == 0) and 'downvoted' or ''}" data-pid="@{post['pid']}" data-icon="downvote"></div>

--- a/app/misc.py
+++ b/app/misc.py
@@ -942,10 +942,7 @@ def getSinglePost(pid):
         .get()
     )
     posts["slug"] = slugify(posts["title"])
-    posts["is_archived"] = (
-        datetime.utcnow() - posts["posted"].replace(tzinfo=None)
-    ) > timedelta(days=config.site.archive_post_after)
-
+    posts["is_archived"] = is_archived(posts)
     return posts
 
 
@@ -1172,6 +1169,19 @@ def getStickies(sid):
     posts = posts.where(SubPost.sid == sid)
     posts = posts.order_by(SubMetadata.xid.asc()).dicts()
     return [add_blur(p) for p in posts]
+
+
+def is_archived(post):
+    delta = timedelta(days=config.site.archive_post_after)
+    if isinstance(post, dict):
+        posted, pid, sid = post["posted"], post["pid"], post["sid"]
+    else:
+        posted, pid, sid = post.posted, post.pid, post.sid
+    return (
+        datetime.utcnow() - posted.replace(tzinfo=None) > delta
+        and str(pid) != getAnnouncementPid().value
+        and (config.site.archive_sticky_posts or pid not in getStickyPid(sid))
+    )
 
 
 def load_user(user_id):

--- a/app/models.py
+++ b/app/models.py
@@ -304,12 +304,6 @@ class SubPost(BaseModel):
     def __repr__(self):
         return f'<SubPost "{self.title[:20]}">'
 
-    def is_archived(self):
-        delta = datetime.timedelta(days=config.site.archive_post_after)
-        return (
-            datetime.datetime.utcnow() - self.posted.replace(tzinfo=None)
-        ) > delta  # noqa
-
     def is_title_editable(self):
         delta = datetime.timedelta(seconds=config.site.title_edit_timeout)
         return (

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -38,6 +38,7 @@ class Notifications(object):
                 Notification.type,
                 Notification.read,
                 Notification.created,
+                Sub.sid,
                 Sub.name.alias("sub_name"),
                 Sub.nsfw.alias("sub_nsfw"),
                 Notification.post.alias("pid"),

--- a/app/templates/indexpost.html
+++ b/app/templates/indexpost.html
@@ -1,7 +1,7 @@
 <div pid="{{post.pid}}" class="{% if post.deleted != 0 %}deletedpost {% endif %}post">
     <div class="misctainer">
       <div class="votebuttons">
-        {% if post.userstatus != 10 and (datetime.datetime.utcnow() - post.posted.replace(tzinfo=None)) < datetime.timedelta(days=config.site.archive_post_after) %}
+        {% if post.userstatus != 10 and not func.is_archived(post) %}
         <div title="Upvote" class="upvote{%if post.positive == 1%} upvoted{%endif%}" data-pid="{{post.pid}}" data-icon="upvote"></div>
         <div class="score">{{post.score}}</div>
         <div title="Downvote" class="downvote{%if post.positive == 0%} downvoted{%endif%}" data-pid="{{post.pid}}" data-icon="downvote"></div>

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -341,9 +341,7 @@ def get_post_list(target):
     for post in posts:
         if post["userstatus"] == 10:  # account deleted
             post["user"] = "[Deleted]"
-        post["archived"] = (
-            datetime.datetime.utcnow() - post["posted"].replace(tzinfo=None)
-        ) > datetime.timedelta(days=config.site.archive_post_after)
+        post["archived"] = misc.is_archived(post)
         del post["userstatus"]
         del post["uid"]
         post["content"] = (
@@ -418,9 +416,8 @@ def get_post(sub, pid):
     if post["userstatus"] == 10:
         post["user"] = "[Deleted]"
 
-    post["archived"] = (
-        datetime.datetime.utcnow() - post["posted"].replace(tzinfo=None)
-    ) > datetime.timedelta(days=config.site.archive_post_after)
+    post["archived"] = misc.is_archived(post)
+
     if post["ptype"] == 0:
         post["type"] = "text"
     elif post["ptype"] == 1:
@@ -465,7 +462,7 @@ def edit_post(sub, pid):
     if misc.is_sub_banned(sub, uid=uid):
         return jsonify(msg="You are banned on this sub."), 403
 
-    if post.is_archived():
+    if misc.is_archived(post):
         return jsonify(msg="Post is archived"), 403
 
     post.content = content
@@ -625,7 +622,7 @@ def create_comment(sub, pid):
     if post.deleted:
         return jsonify(msg="Post was deleted"), 404
 
-    if post.is_archived():
+    if misc.is_archived(post):
         return jsonify(msg="Post is archived"), 403
 
     postmeta = misc.metadata_to_dict(
@@ -796,7 +793,7 @@ def edit_comment(_sub, pid, cid):
     if comment.uid_id != uid:
         return jsonify(msg="Unauthorized"), 403
 
-    if post.is_archived():
+    if misc.is_archived(post):
         return jsonify(msg="Post is archived"), 400
 
     if len(content) > 16384:
@@ -859,7 +856,7 @@ def delete_comment(_sub, pid, cid):
     if comment.uid_id != uid:
         return jsonify(msg="Unauthorized"), 403
 
-    if post.is_archived():
+    if misc.is_archived(post):
         return jsonify(msg="Post is archived"), 400
 
     comment.status = 1

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1167,7 +1167,7 @@ def edit_txtpost(pid):
         if current_user.is_subban(post.sid):
             return jsonify(status="error", error=[_("You are banned on this sub.")])
 
-        if post.is_archived():
+        if misc.is_archived(post):
             return jsonify(status="error", error=[_("Post is archived")])
 
         dt = datetime.datetime.utcnow()
@@ -1221,7 +1221,7 @@ def create_comment(pid):
         if post.deleted:
             return jsonify(status="error", error=[_("Post was deleted")]), 400
 
-        if post.is_archived():
+        if misc.is_archived(post):
             return jsonify(status="error", error=[_("Post is archived")]), 400
 
         postmeta = misc.metadata_to_dict(
@@ -2708,7 +2708,7 @@ def edit_comment():
                 status="error", error=_("You can't edit a comment on a deleted post")
             )
 
-        if post.is_archived():
+        if misc.is_archived(post):
             return jsonify(status="error", error=_("Post is archived"))
 
         dt = datetime.datetime.utcnow()

--- a/app/views/messages.py
+++ b/app/views/messages.py
@@ -1,10 +1,9 @@
 """ Messages endpoints """
-from datetime import datetime, timedelta
+from datetime import datetime
 from flask import Blueprint, redirect, url_for, render_template, abort, jsonify
 from flask_login import login_required, current_user
 from .. import misc
 from ..notifications import Notifications
-from ..config import config
 from ..misc import engine, get_postmeta_dicts
 from ..models import Notification
 
@@ -32,12 +31,8 @@ def view_notifications(page):
         (n["pid"] for n in notifications if n["pid"] is not None)
     )
 
-    now = datetime.utcnow()
-    limit = timedelta(days=config.site.archive_post_after)
     for n in notifications:
-        n["archived"] = (
-            n["posted"] is not None and (now - n["posted"].replace(tzinfo=None)) > limit
-        )
+        n["archived"] = misc.is_archived(n)
         misc.add_blur(n)
 
     Notification.update(read=datetime.utcnow()).where(

--- a/migrations/032_archive_sticky_posts.py
+++ b/migrations/032_archive_sticky_posts.py
@@ -1,0 +1,23 @@
+"""Peewee migrations -- 032_archive_sticky_posts
+
+Add a admin site configuration option to control whether sticky
+posts are archived in the same way as regular posts.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.create(key="site.archive_sticky_posts", value="1")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(
+            SiteMetadata.key == "site.archive_sticky_posts"
+        ).execute()


### PR DESCRIPTION
Give the admin a new site configuration option, `site.archive_sticky_posts`, which stops making mods do the busy work of periodically replacing their sticky posts, when the only thing that is wrong with them is an old post date.  Mods still have the option of locking a sticky post if they don't want to see comments on it.  This new option defaults to enabled, which is the same as the previous behavior.

Improve the code by consolidating all the various checks for post age into one function in `misc.py`.

The announcement post, if there is one, is now not archived until it is removed as an announcement.