### PR TITLE
Fix post undelete reason and links in notifications

### DIFF
--- a/app/html/user/messages/notifications.html
+++ b/app/html/user/messages/notifications.html
@@ -117,7 +117,7 @@
             @if msg['comment_context']:
             </div> <!-- div.pchild -->
             @end
-          @elif msg['pid'] and msg['type'] != 'POST_DELETE':
+          @elif msg['pid'] and msg['type'] not in ('POST_DELETE', 'POST_UNDELETE'):
             <div class="container">@{markdown(msg['post_content'])!!html}</div>
             <ul class="bottombar links">
               <li><a href="@{url_for('sub.view_post', sub=msg['sub_name'], pid=msg['pid'])}">@{_('permalink')}</a></li>
@@ -142,13 +142,15 @@
             @end
             <ul class="bottombar links">
               <li><a class="deletenotif" data-mid="@{msg['id']}">@{_('delete notification')}</a></li>
-              <li><a class="block" data-uid="@{msg['senderuid']}">
-                @if msg['ignored']:
-                  @{_('unblock')} \
-                @else:
-                  @{_('block')} \
-                @end
-              </a></li>
+              @if msg['type'] not in ('POST_DELETE', 'POST_UNDELETE', 'SUB_BAN', 'SUB_UNBAN'):
+                <li><a class="block" data-uid="@{msg['senderuid']}">
+                  @if msg['ignored']:
+                    @{_('unblock')} \
+                  @else:
+                    @{_('block')} \
+                  @end
+                </a></li>
+              @end
             </ul>
           @end
         </div>


### PR DESCRIPTION
On the user notification page, in the notification sent when a mod undeletes the user's post, instead of showing the reason a post was undeleted, it was showing the post content.  Fixed that, and also removed the "reply" and "permalink" links for that notification type to make it match the deleted post notification. 

I also removed the "block" link for post delete and undelete and sub ban and unban notifications because blocking PMs from a sub moderator because of a moderation action doesn't make sense, and was a way to access the mod's name even with `config.site.anonymous_modding` enabled.