### PR TITLE
Add a migration to undo automatic enabling of nsfw_blur user preference

### DIFF
--- a/migrations/033_fix_nsfw_preferences.py
+++ b/migrations/033_fix_nsfw_preferences.py
@@ -1,0 +1,20 @@
+"""Peewee migrations -- 033_fix_nsfw_preferences.py
+
+The migration in 032_nsfw_preferences.py set the nsfw_blur
+user preference for all users who had the nsfw preference set.
+Turn nsfw_blur off for all users.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    UserMetadata = migrator.orm["user_metadata"]
+    if not fake:
+        UserMetadata.delete().where(UserMetadata.key == "nsfw_blur").execute()
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    pass


### PR DESCRIPTION
#379 included a database migration which added the `nsfw_blur` user preference for all users who had the `nsfw` preference set (the old Show NSFW in user preferences).  Undo that change by adding a migration to remove the `nsfw_blur` preference for all users.