### PR TITLE
Check notification type before doing archive and blur checks

### DIFF
--- a/app/views/messages.py
+++ b/app/views/messages.py
@@ -32,8 +32,10 @@ def view_notifications(page):
     )
 
     for n in notifications:
-        n["archived"] = misc.is_archived(n)
-        misc.add_blur(n)
+        n["archived"] = False
+        if n["cid"] or (n["pid"] and n["type"] not in ("POST_DELETE", "POST_UNDELETE")):
+            n["archived"] = misc.is_archived(n)
+            misc.add_blur(n)
 
     Notification.update(read=datetime.utcnow()).where(
         (Notification.read.is_null(True)) & (Notification.target == current_user.uid)


### PR DESCRIPTION
#379 and #380 caused some regressions on the notifications page. Mod invite notifications are causing a 500 error, and the mod's reason for deleting an NSFW post is shown blurred if the user has the blur NSFW preference selected.  Fix these problems by only doing the checks for blurring and archiving for the appropriate notification types.