### PR TITLE
Speed up tests by not making BeautifulSoup guess the encoding

### DIFF
--- a/test/specs/test_auth.py
+++ b/test/specs/test_auth.py
@@ -39,7 +39,7 @@ def test_registration_login(client, test_config):
         if email_validation_is_required():
             assert b"spam" in rv.data  # Telling user to go check it.
             message = outbox[-1]
-            soup = BeautifulSoup(message.html, "html.parser")
+            soup = BeautifulSoup(message.html, "html.parser", from_encoding="utf-8")
             token = soup.a["href"].split("/")[-1]
             rv = client.get(
                 url_for("auth.login_with_token", token=token), follow_redirects=True
@@ -140,14 +140,14 @@ def test_resend_registration_email(client, user_info, test_config):
     assert b"spam" in rv.data  # Telling user to go check it.
 
     # Find the resend link.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     links = soup.find_all(lambda tag: tag.name == "a" and tag.string == "Resend")
     url = links[0]["href"]
 
     # Request the resend form and verify the registered email is shown.
     rv = client.get(url)
     assert b"Resend account confirmation instructions" in rv.data
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find_all(lambda tag: tag.get("name") == "email")[0]
     assert tag["value"] == user_info["email"]
 
@@ -190,7 +190,7 @@ def test_resend_registration_email_after_confirmation(client, user_info, test_co
         assert b"spam" in rv.data  # Telling user to go check it.
 
         # Find the resend link.
-        soup = BeautifulSoup(rv.data, "html.parser")
+        soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
         link = soup.find_all(lambda tag: tag.name == "a" and tag.string == "Resend")[0]
         url = link["href"]
 
@@ -235,14 +235,14 @@ def test_fix_registration_email(client, user_info, user2_info, test_config):
         first_token = soup.a["href"].split("/")[-1]
 
     # Find the resend link.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     links = soup.find_all(lambda tag: tag.name == "a" and tag.string == "Resend")
     url = links[0]["href"]
 
     # Request the resend form and verify the registered email is shown.
     rv = client.get(url)
     assert b"Resend account confirmation instructions" in rv.data
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find_all(lambda tag: tag.get("name") == "email")[0]
     assert tag["value"] == user_info["email"]
 
@@ -267,7 +267,7 @@ def test_fix_registration_email(client, user_info, user2_info, test_config):
 
     # Verify that the user's confirmed email is the second one.
     rv = client.get(url_for("user.edit_account"))
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find_all(lambda tag: tag.get("name") == "email_required")[0]
     assert tag["value"] == user2_info["email"]
 

--- a/test/specs/test_messages.py
+++ b/test/specs/test_messages.py
@@ -50,7 +50,7 @@ def test_send_and_receive_pm(client, user_info, user2_info):
     # User has one new message.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "1"
 
@@ -62,7 +62,7 @@ def test_send_and_receive_pm(client, user_info, user2_info):
     )
 
     # User marks the message as read.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find(lambda tag: tag.has_attr("data-mid"))
     mid = tag.attrs["data-mid"]
 
@@ -74,7 +74,7 @@ def test_send_and_receive_pm(client, user_info, user2_info):
     # User returns to home page; notifications count now 0.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "0"
 
@@ -112,7 +112,7 @@ def test_block_pm(client, user_info, user2_info):
     # User doesn't have a notification for blocked message.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "0"
 
@@ -137,7 +137,7 @@ def test_block_pm(client, user_info, user2_info):
     # User now has a notification for message.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "1"
 
@@ -186,7 +186,7 @@ def test_save_and_delete_pm(client, user_info, user2_info):
     )
 
     # User saves the message.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find(lambda tag: tag.has_attr("data-mid"))
     mid = tag.attrs["data-mid"]
     rv = client.post(
@@ -265,7 +265,7 @@ def test_exchange_pm(client, user_info, user2_info):
     )
 
     # User replies to the message.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find(lambda tag: tag.has_attr("data-mid"))
     mid = tag.attrs["data-mid"]
 
@@ -290,7 +290,7 @@ def test_exchange_pm(client, user_info, user2_info):
     # User2 has one new message.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "1"
 
@@ -302,7 +302,7 @@ def test_exchange_pm(client, user_info, user2_info):
     )
 
     # User2 replies to the reply.
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     tag = soup.find(lambda tag: tag.has_attr("data-mid"))
     mid = tag.attrs["data-mid"]
     rv = client.post(
@@ -327,7 +327,7 @@ def test_exchange_pm(client, user_info, user2_info):
     # User now has two new messages.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "2"
 
@@ -343,6 +343,6 @@ def test_exchange_pm(client, user_info, user2_info):
     # User now has no new messages.
     rv = client.get(url_for("home.index"), follow_redirects=True)
     assert rv.status == "200 OK"
-    soup = BeautifulSoup(rv.data, "html.parser")
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
     link = soup.find(href=url_for("messages.inbox_sort"))
     assert link.get_text().strip() == "0"

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -7,20 +7,20 @@ from app.models import User, UserMetadata, SiteMetadata
 
 
 def csrf_token(data):
-    soup = BeautifulSoup(data, "html.parser")
+    soup = BeautifulSoup(data, "html.parser", from_encoding="utf-8")
     # print(soup.prettify())
     return soup.find(id="csrf_token")["value"]
 
 
 def get_value(data, key):
-    soup = BeautifulSoup(data, "html.parser")
+    soup = BeautifulSoup(data, "html.parser", from_encoding="utf-8")
     # print(soup.prettify())
     return soup.find(id=key)["value"]
 
 
 # pretty-print for debugging purposes
 def pp(data):
-    print(BeautifulSoup(data, "html.parser").prettify())
+    print(BeautifulSoup(data, "html.parser", from_encoding="utf-8").prettify())
 
 
 def recursively_update(dictionary, new_values):


### PR DESCRIPTION
If you pass a byte string to `BeautifulSoup`, without also giving it an encoding, it has to guess the encoding before parsing, which is computationally intensive.  `BeautifulSoup` is used frequently in our tests.  Passing an encoding to `BeautifulSoup` in the tests, where it is used on byte strings, made them complete 1.9% faster, in the average of several runs on my laptop.