### PR TITLE
Allow admins to set a limit on the length of usernames

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -339,6 +339,14 @@ configurable_defaults = {
                 ),
                 "value": True,
             },
+            "username_max_length": {
+                "type": "int",
+                "doc": _l(
+                    "The maximum length of a user name, applied to new registrations. "
+                    "This should be set to a number between 2 and 64."
+                ),
+                "value": 32,
+            },
             "nsfw": {
                 "type": "map",
                 "value": {

--- a/app/html/user/register.html
+++ b/app/html/user/register.html
@@ -21,7 +21,7 @@
                 </div>
                 @end
                 <div class="pure-control-group">
-                    <label for="username">@{regform.username.label.text}</label>@{regform.username(required=True, pattern="[a-zA-Z0-9_-]+", title=_('Alphanumeric characters plus \'-\' and \'_\''))!!html}
+                    <label for="username">@{regform.username.label.text}</label>@{regform.username(required=True, pattern="[a-zA-Z0-9_-]+", title=_('Alphanumeric characters plus \'-\' and \'_\'; between 2 and %(num)d characters long', num=config.site.username_max_length))!!html}
                 </div>
                 
                 <div class="pure-control-group">

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -155,8 +155,12 @@ def register():
     if email_validation_is_required() and email is None:
         return jsonify(msg="E-mail is mandatory"), 401
 
-    if not misc.allowedNames.match(username):
+    if (
+        not misc.allowedNames.match(username)
+        or len(username) > config.site.username_max_length
+    ):
         return jsonify(msg="Invalid username"), 401
+
     if email:
         try:
             email = normalize_email(email)

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -127,6 +127,7 @@ def register():
                 "captcha": captcha,
             }
         )
+
     # check if user or email are in use
     existing_user = None
     try:

--- a/migrations/034_user_name_length.py
+++ b/migrations/034_user_name_length.py
@@ -1,0 +1,23 @@
+"""Peewee migrations -- 034_user_name_length.py
+
+Add an admin site configuration option to limit the length of user names.
+
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.create(key="site.username_max_length", value="32")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(
+            SiteMetadata.key == "site.username_max_length"
+        ).execute()


### PR DESCRIPTION
Some of our users are using entire sentences for their usernames.  Our admins would like to be able to stop this behavior.  Add `site.username_max_length` to the admin site configuration panel, and enforce the limit at registration.