### PR TITLE
Only show self-deleted posts to mods and admins in user post lists

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -1066,6 +1066,8 @@ def postListQueryBase(
             posts = posts.where(
                 (SubPost.deleted == 0) | (Sub.sid << include_deleted_posts)
             )
+        elif not current_user.is_admin():
+            posts = posts.where(SubPost.deleted << [0, 2])
     else:
         posts = posts.where(SubPost.deleted == 0)
 


### PR DESCRIPTION
#343 caused users to be able to see posts that they deleted themselves in their own post lists, which was not intended.

When users are looking at the list of their own posts, show them the ones that were deleted by mods, so they can copy and paste their writing elsewhere, but don't show them the posts that they deleted themselves.

When mods and admins are looking at a user's list of posts, show the admins all deleted posts and show the mods all deleted posts in the subs that they mod.