### PR TITLE
Fix a ValueError when clearing image metadata

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -152,7 +152,9 @@ def clear_metadata(fileobj: FileStorage, mime_type: str):
             if tag == 274:
                 ifd[tag] = value
         newExif = b"Exif\x00\x00" + head + ifd.tobytes(8)
-        image.save(resultIO, exif=newExif)
+        image.save(
+            resultIO, format=Image.EXTENSION[EXTENSIONS[mime_type]], exif=newExif
+        )
         return resultIO
     elif mime_type == "video/mp4":
         video = MP4(fileobj)


### PR DESCRIPTION
Fix a regression from #371 which would sometimes cause a 500 error when uploading files, by passing the image format to `PIL.Image.save`.  That function falls back to using the extension in the filename to figure out the image format, but #371 changed `clear_metadata` to pass it a `BytesIO` object, with no filename, instead of a file.