### PR TITLE
Be consistent about use of target="_blank" in external links

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -113,7 +113,7 @@
             @if post['flair']:
               <span class="postflair">@{post['flair']!!e}</span>
             @end
-            <a rel="nofollow ugc @{(post['visibility'] == 'none') and 'noopener ' or ''}" href="@{((post['visibility'] != 'none') and post['link']) or '#'}" class="title">
+            <a rel="noopener nofollow ugc" href="@{((post['visibility'] != 'none') and post['link']) or '#'}" target="@{((post['visibility'] != 'none') and '_blank') or '_self'}" class="title">
               @if (post['visibility'] == ''):
                 <span class="@{post['blur']}">@{post['title']}</span>
               @elif (post['visibility'] == 'admin-self-del') or (post['visibility'] == 'user-self-del'):
@@ -141,7 +141,7 @@
                       @{old_title['title']}
                   </a></h1>
                 @else:
-                <h1><a rel="nofollow ugc @{(post['visibility'] == 'none') and 'noopener ' or ''}" href="@{(post['visibility'] != 'none') and post['link'] or '#'}" class="title">
+                <h1><a rel="noopener nofollow ugc" href="@{(post['visibility'] != 'none') and post['link'] or '#'}" target="@{((post['visibility'] != 'none') and '_blank') or '_self'}" class="title">
                   @{old_title['title']}
                 </a></h1>
                 @end

--- a/app/templates/indexpost.html
+++ b/app/templates/indexpost.html
@@ -45,7 +45,7 @@
         </a>
         {% else %}
           {% if post.link.startswith('http:') %}<span title="not https" class="p-icon" data-icon="exclaim"></span>{% endif %}
-          <a rel="noopener nofollow ugc" href="{{post.link}}" class="title">
+          <a rel="noopener nofollow ugc" target="_blank" href="{{post.link}}" class="title">
             {% if post.deleted == 1 %}
               {{_('[Deleted by User]')}}
             {% elif post.deleted == 2 %}


### PR DESCRIPTION
If you click on the title of a link post in the sub view, it opens the link in a new tab. If you click on the title of a link post in the view of a user's posts, it opens the link in the same tab.  Be consistent about this by always opening in a new tab, and fix a missing "noopener" in the single-post view.