### PR TITLE
Fix a couple issues with NSFW posts in single post view

### DIFF
--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -346,10 +346,10 @@
   @if len(comments) == 0:
     <div class="comments"><h3 id="cmnts" data-cnt="0">@{_('No comments, yet...')}</h3></div>
   @else:
-    @if post['nsfw'] or sub['nsfw'] and 'nsfw' not in current_user.prefs:
+    @if post['blur'] == 'nsfw-blur':
       <h3><a class="show-post-comments">@{_('Show comments')}</a></h3>
     @end
-    <div id="post-comments" class="comments @{'hide' if post['nsfw'] or sub['nsfw'] and 'nsfw' not in current_user.prefs else ''}">
+    <div id="post-comments" class="comments @{'hide' if post['blur'] == 'nsfw-blur' else ''}">
       <h2 id="cmnts" data-cnt="@{post['comments']}"><a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}">@{_('%(comments)i comments', comments=post['comments'])}</a></h2>
       <div class="pure-menu pure-menu-horizontal">
         <ul class="pure-menu-list">

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -650,7 +650,9 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
             if int(postmeta["poll_closes_time"]) < time.time():
                 pollData["poll_open"] = False
 
-    if (post["nsfw"] or sub["nsfw"]) and "nsfw_blur" in current_user.prefs:
+    if (post["nsfw"] or sub["nsfw"]) and (
+        "nsfw" not in current_user.prefs or "nsfw_blur" in current_user.prefs
+    ):
         post["blur"] = "nsfw-blur"
     else:
         post["blur"] = ""


### PR DESCRIPTION
In the single post view, fix the code that hides the comments behind a "Show Comments" link to not hide the comments when the user has their NSFW preference set to "Show without blur".

Change the single post view to add blur to the content and hide the comments when the user has their NSFW preference set to "Hide from lists" and they arrive at the single post view of a NSFW post anyway (presumably by following a link from elsewhere).