### PR TITLE
Stop rendering the sidebar three times per page render

### DIFF
--- a/app/html/shared/layout.html
+++ b/app/html/shared/layout.html
@@ -137,7 +137,10 @@
   <div class="th-body pure-g">
     @def sidebar():
     @end
-    <div class="pure-u-1 @{ sidebar() and 'pure-u-md-18-24' or '' }"> <!-- main -->
+    @(
+      rendered_sidebar = sidebar()
+    )
+    <div class="pure-u-1 @{ rendered_sidebar and 'pure-u-md-18-24' or '' }"> <!-- main -->
       @for err in get_flashed_messages(category_filter=["error"]):
         <div class="error" style="margin-top: 2em;">@{ err }</div>
       @end
@@ -148,9 +151,9 @@
       @end
       @{main()!!html}
     </div>
-    @if sidebar(): 
+    @if rendered_sidebar:
       <div id="sidebar" class="sidebar pure-u-1 pure-u-md-6-24"> <!-- sidebar -->
-        @{sidebar()!!html}
+        @{rendered_sidebar!!html}
       </div>
     @end
   </div>

--- a/app/misc.py
+++ b/app/misc.py
@@ -92,6 +92,7 @@ from werkzeug.local import LocalProxy
 
 from wheezy.template.engine import Engine
 from wheezy.template.ext.core import CoreExtension
+from wheezy.template.ext.code import CodeExtension
 from wheezy.template.loader import FileLoader
 
 # Regex that matches VALID user and sub names
@@ -118,7 +119,7 @@ class EscapeExtension(object):
 
 engine = Engine(
     loader=FileLoader([os.path.split(__file__)[0] + "/html"]),
-    extensions=[EscapeExtension(), CoreExtension()],
+    extensions=[EscapeExtension(), CoreExtension(), CodeExtension()],
 )
 
 mail = Mail()


### PR DESCRIPTION
`app/html/shared/layout.html` was rendering the sidebar once to determine which class to use on the main `div`, once to determine whether to create the sidebar `div`, and a third time to fill the sidebar `div`.  This is a lot of extra work, especially for the pages which have top posts and recent activity on the sidebar.

Add wheezy's `CodeExtension` to allow arbitrary Python code in the templates, and use that to store the rendered sidebar in a variable.

