### PR TITLE
Fix some configuration issues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -467,7 +467,12 @@ def get_environment_values(config, prefix=""):
         for var in os.environ.keys():
             if var.startswith(prefix):
                 env_key = var[len(prefix) :].lower()
-                new_items[env_key] = os.environ.get(var)
+                env_value = os.environ.get(var)
+                existing = config.get(env_key)
+                if existing is not None and type(existing["value"]) == int:
+                    new_items[env_key] = int(env_value)
+                else:
+                    new_items[env_key] = env_value
     for key, val in config.items():
         if val["type"] == "map":
             env_vals = get_environment_values(val["value"], prefix + key.upper() + "_")

--- a/app/static/js/Expando.js
+++ b/app/static/js/Expando.js
@@ -2,7 +2,7 @@ import u from './Util'
 import icon from './Icon';
 
 function get_hostname(url) {
-  if(!url){return;}
+  if(!url || url.charAt(0) == "/"){return;}
   var matches = url.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
   return matches[1];
 }

--- a/app/storage.py
+++ b/app/storage.py
@@ -110,6 +110,8 @@ def make_url(storage, cfg, name):
         obj = storage.get(name)
         if obj is None:
             return url_for("static", filename="img/1x1.gif")
+        elif "server_name" in config.site and config.storage.server:
+            return f"http://{config.site.server_name}{config.storage.server_url}/{name}"
         else:
             return obj.url
     else:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -232,6 +232,8 @@ def safe_request(
     the first max_size bytes, otherwise it will raise an error if
     max_size is exceeded."""
     # Returns (Response, File)
+    if url[0] == "/" and config.storage.server and "server_name" in config.site:
+        url = f"http://{config.site.server_name}{url}"
     try:
         r = requests.get(
             url,


### PR DESCRIPTION
Change the reading of configuration values from environment variables to parse integers if the default value for a configuration variable is an integer.  This makes it possible to set values such as `site.trusted_proxy_count` in the environment.

Fix the construction of URLs for thumbnails and images when you are using the dev server to host files.  This makes thumbnail generation work for developers without having to set up another server to serve uploads.  Fix expandos to work when a file is locally hosted.