### PR TITLE
Give the moderation UI a responsive layout for mobile 

### DIFF
--- a/app/html/mod/closed.html
+++ b/app/html/mod/closed.html
@@ -9,7 +9,7 @@ Mod |\
 @end
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="content">
     <h1>@{_('Closed Reports')}</h1>
     <p class="helper-text">@{_('Includes all closed reports for subs you can moderate.')}</p>
@@ -20,38 +20,45 @@ Mod |\
           @{_('Total Open Reports')} <a href="@{url_for('mod.reports')}">@reports['open_report_count']</a>  |  @{_('Total Closed Reports')} @reports['closed_report_count']
           <div class="div-error error alertbox"></div>
 
-          <table class="pure-table">
-            <thead>
-              <tr>
-                <th>@{_('Sub')}</th>
-                <th>@{_('Type')}</th>
-                <th>@{_('Reporter')}</th>
-                <th>@{_('Reason')}</th>
-                <th>@{_('User reported')}</th>
-                <th>@{_('Time')}</th>
-                <th>@{_('Reopen')}</th>
-              </tr>
-            </thead>
-            <tbody>
+          <ol class="mod-table">
+            <li class="mod-table-header pure-g">
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Sub')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Type')}</div>
+              <div class="header pure-u-1 pure-u-md-4-24">@{_('Reporter')}</div>
+              <div class="header pure-u-1 pure-u-md-5-24">@{_('Reason')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('User reported')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Time')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Reopen')}</div>
+            </li>
             @for report in reports['query']:
-            <tr>
-              <td><div class="sub"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div></td>
-              <td>
+            <li class="mod-table-row pure-g">
+              <div data-name="@{_('Sub:')}" class="elem sub pure-u-1 pure-u-md-3-24"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div>
+              <div data-name="@{_('Type:')}" class="elem pure-u-1 pure-u-md-3-24">
                 @if report['type'] == 'comment':
                   <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Comment')}</a>
                 @else:
                 <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Post')}</a>
                 @end
-              </td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a></div></td>
-              <td>@{report['reason']}</td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a></div></td>
-              <td><time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago></td>
-              <td class="close-report-button"><a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="close-report">@{_('[x]')}</a></td>
-            </tr>
+              </div>
+              <div data-name="@{_('Reported by:')}" class="elem username pure-u-1 pure-u-md-4-24">
+                <a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a>
+              </div>
+              <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-5-24">@{report['reason']}</div>
+              <div data-name="@{_('User reported:')}" class="elem username pure-u-1 pure-u-md-3-24">
+                <a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a>
+              </div>
+              <div data-name="@{_('Time:')}" class="elem pure-u-1 pure-u-md-3-24">
+                <time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago>
+              </div>
+              <div class="close-elem close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="close-report">@{_('[x]')}</a>
+              </div>
+              <div class="close-button close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="pure-button close-report">@{_('Reopen')}</a>
+              </div>
+            </li>
             @end
-            </tbody>
-          </table>
+          </ol>
         </div>
       </div>
       @if page > 1:

--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -9,7 +9,7 @@ Mod |\
 @end
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="mod report content">
     <h1>@{_('Report Details')}</h1>
     <div class="mod report header">
@@ -18,34 +18,37 @@ Mod |\
       @else:
         <h2>@{_('Post Report')} # @{report['id']}</h2>
       @end
-      <div class="mod report close buttons">
-        <!-- CLOSE REPORT -->
-        @if report['open'] == True:
+      <div class="mod report close buttons pure-g">
+        <div class="pure-u-1-2 pure-u-md-1-1">
+          <!-- CLOSE REPORT -->
+          @if report['open'] == True:
           <button class="pure-button pure-button-primary btn-editpost close-report"
-          data-type="@{report['type']}" data-id="@{report['id']!!s}" data-action="close">
+                  data-type="@{report['type']}" data-id="@{report['id']!!s}" data-action="close">
             @{_('Close Report')}
           </button>
-        @else:
+          @else:
           <button class="pure-button pure-button-primary btn-editpost close-report"
-          data-type="@{report['type']}" data-id="@{report['id']!!s}" data-action="reopen">
+                  data-type="@{report['type']}" data-id="@{report['id']!!s}" data-action="reopen">
             @{_('Reopen Report')}
           </button>
-        @end
-
-        <!-- CLOSE ALL REPORTS -->
-        @if related_reports['open_report_count'] == '0':
-          <button class="pure-button pure-button-primary btn-editpost disabled">@{_('All related reports are closed')}</button>
-        @else:
-          @if report['type'] == 'comment':
+          @end
+        </div>
+        <div class="pure-u-1-2 pure-u-md-1-1">
+          <!-- CLOSE ALL REPORTS -->
+          @if related_reports['open_report_count'] == '0':
+            <button class="pure-button pure-button-primary btn-editpost disabled">@{_('All related reports are closed')}</button>
+          @else:
+            @if report['type'] == 'comment':
             <button class="pure-button pure-button-primary btn-editpost close-related-reports" data-type="@{report['type']}" data-reports="@{related_reports_json}" data-original="@{report['id']!!s}" data-action="close">
               @{_('Close All Reports for this Comment')}
             </button>
-          @else:
+            @else:
             <button class="pure-button pure-button-primary btn-editpost close-related-reports" data-type="@{report['type']}" data-reports="@{related_reports_json}" data-original="@{report['id']!!s}" data-action="close">
               @{_('Close All Reports for this Post')}
             </button>
+            @end
           @end
-        @end
+        </div>
       </div>
     </div>
 
@@ -54,38 +57,36 @@ Mod |\
     <div class="mod section">
       <div class="col-12 admin-page-form">
           <div class="div-error error alertbox"></div>
-
-          <div class="mod report details">
-            <div class="report-details-row">
-              <span class="report-details-item"><span class="label">@{_('Sub')}:</span>
+          <div class="mod report details pure-g">
+            <div class="pure-u-1-1 pure-u-md-1-2">
+              <p class="report-details-item"><span class="label">@{_('Sub')}:</span>
                 <a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{report['sub'] }</a>
-              </span>
-              <span class="report-details-item"><span class="label">@{_('Reason')}:</span>
-                @{report['reason']!!e}
-              </span>
-            </div>
-            <div class="report-details-row">
-              <span class="report-details-item"><span class="label">@{_('Reported User')}:</span>
-                  <a href="@{ url_for('user.view', user=report['reported']) }">@{report['reported'] }</a>
-              </span>
-              <span class="report-details-item"><span class="label">@{_('Reporter')}:</span>
-                <a href="@{ url_for('user.view', user=report['reporter']) }">@{report['reporter'] }</a>
-              </span>
-            </div>
-            <div class="report-details-row">
-              <span class="report-details-item"><span class="label">@{_('Time')}:</span>
+              </p>
+              <p class="report-details-item"><span class="label">@{_('Reported User')}:</span>
+                <a href="@{ url_for('user.view', user=report['reported']) }">@{report['reported'] }</a>
+              </p>
+              <p class="report-details-item"><span class="label">@{_('Time')}:</span>
                 <time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago>
-              </span>
-              <span class="report-details-item"><span class="label">@{_('Status')}:</span>
+              </p>
+            </div>
+            <div class="pure-u-1-1 pure-u-md-1-2">
+              <p class="report-details-item"><span class="label">@{_('Reason')}:</span>
+                @{report['reason']!!e}
+              </p>
+              <p class="report-details-item"><span class="label">@{_('Reporter')}:</span>
+                <a href="@{ url_for('user.view', user=report['reporter']) }">@{report['reporter'] }</a>
+              </p>
+              <p class="report-details-item"><span class="label">@{_('Status')}:</span>
                 @if report['open'] == True:
-                  @{_('Open')}
+                @{_('Open')}
                 @else:
-                  @{_('Closed')}
+                @{_('Closed')}
                 @end
-              </span>
+              </p>
             </div>
           </div>
-          <div class="user-actions">
+          <div class="mod user-actions pure-g">
+            <div class="pure-u-1-2 pure-u-md-1-1">
             @if is_sub_banned:
               <button class="sbm-post pure-button pure-button-primary disabled">
                 @{_('%(reported)s has been banned from %(prefix)s/%(sub)s', reported=report['reported'], prefix=config.site.sub_prefix, sub=report['sub'])}
@@ -94,15 +95,19 @@ Mod |\
                 <button class="sbm-post pure-button pure-button-primary banuserbutton">
                   @{_('Ban %(reported)s from %(prefix)s/%(sub)s', reported=report['reported'], prefix=config.site.sub_prefix, sub=report['sub'])}</button>
             @end
+            </div>
+            <div class="pure-u-1-2 pure-u-md-1-1">
             @if current_user.is_admin() and reported_user.status != 5:
                 <form method="POST" data-reload="true" id="banuser" action="@{url_for('do.ban_user', username=report['reported'])}">
                     @{form.CsrfTokenOnlyForm().csrf_token()!!html}
-                  <a id="banuser-button" class="sbm-post pure-button button-secondary" >@{_('Ban %(reported)s from %(site)s', reported=report['reported'], site=config.site.name)}</a>
+                  <button id="banuser-button" class="sbm-post pure-button pure-button-primary" >@{_('Ban %(reported)s from %(site)s', reported=report['reported'], site=config.site.name)}</button>
                 </form>
             @end
             @if reported_user.status == 5:
               <button class="sbm-post pure-button pure-button-primary disabled">@{_('%(user)s has been banned from %(site)s', user=report['reported'], site=config.site.name)}</button>
-            @end
+              @end
+
+            </div>
           </div>
           <div id="report-ban-user-form" style="display: none;">
             <form id="ban-user-form" data-reload="true" data-sub="@{sub.name}" class="ajaxform pure-form" action="@{url_for('do.ban_user_sub', sub=sub.name)}">
@@ -177,35 +182,37 @@ Mod |\
             @end
 
             <div class="preview-meta-data">
-              <span class="meta-data-item">
+              <div>
                 @if report['type'] == 'comment':
                   @{_('Posted')} <time-ago datetime="@{comment['time'].isoformat()}Z"></time-ago>
                 @else:
                   @{_('Posted')} <time-ago datetime="@{post['posted'].isoformat()}Z"></time-ago>
                 @end
-              </span>
-              <span class="meta-data-item">
-                @if report['type'] == 'comment':
-                  <a href="@{url_for('sub.view_perm', sub=report['sub'], cid=report['cid'], pid=report['pid'])}">@{_('Go to comment')}</a>
-                @else:
-                <a href="@{url_for('sub.view_post', sub=report['sub'], pid=report['pid'])}">@{_('Go to post')}</a>
-                @end
-              </span>
-              <span>
-                @if report['type'] == 'comment':
-                  @if (comment['status'] != 1) and (comment['status'] != 2):
-                    <button class="pure-button pure-button-primary button-xsmall btn-editpost delete-comment" data-cid="@{report['cid']}">
-                      @{_('Delete Comment')}
-                    </button>
+              </div>
+              <div class="pure-g">
+                  <div class="pure-u-1-2 pure-u-md-1-6">
+                    @if report['type'] == 'comment':
+                      <a href="@{url_for('sub.view_perm', sub=report['sub'], cid=report['cid'], pid=report['pid'])}">@{_('Go to comment')}</a>
+                      @else:
+                      <a href="@{url_for('sub.view_post', sub=report['sub'], pid=report['pid'])}">@{_('Go to post')}</a>
+                      @end
+                  </div>
+                  <div class="pure-u-1-2 pure-u-md-1-6">
+                    @if report['type'] == 'comment':
+                      @if (comment['status'] != 1) and (comment['status'] != 2):
+                        <button class="pure-button pure-button-primary button-small btn-editpost delete-comment" data-cid="@{report['cid']}">
+                          @{_('Delete Comment')}
+                        </button>
+                      @end
+                    @else:
+                      @if post['deleted'] == 0:
+                        <button class="pure-button pure-button-primary button-small btn-editpost delete-post" data-pid="@{str(report['pid'])}">
+                          @{_('Delete Post')}
+                        </button>
+                      @end
                   @end
-                @else:
-                  @if post['deleted'] == 0:
-                    <button class="pure-button pure-button-primary button-xsmall btn-editpost delete-post" data-pid="@{str(report['pid'])}">
-                      @{_('Delete Post')}
-                    </button>
-                  @end
-                @end
-              </span>
+                  </div>
+              </div>
             </div>
           </div>
 
@@ -225,67 +232,63 @@ Mod |\
           @if len(logs) == 0:
             <p class="helper-text">@{_('No logs have been made yet on this report')}</p>
           @else:
-            <table class="pure-table">
-                <thead>
-                <tr>
-                    <th>@{_('Time')}</th>
-                    <th>@{_('Action Taken')}</th>
-                    <th>@{_('By')}</th>
-                    <th>@{_('Details')}</th>
-                </tr>
-                </thead>
-                <tbody>
-                @for log in logs:
-                <tr>
-                    <td>
-                        <time-ago datetime="@{log.time.isoformat()}Z">@{log.time.isoformat()}</time-ago>
-                    </td>
-                    <td>
-                        @if (log.action == 55) or (log.action == 57):
-                          @{_('Report closed')}
-                        @elif log.action == 56:
-                          @{_('Report reopened')}
-                        @elif log.action == 60:
-                          @{_('Post deleted')}
-                        @elif log.action == 61:
-                          @{_('Post un-deleted')}
-                        @elif log.action == 62:
-                          @{_('Comment deleted')}
-                        @elif log.action == 63:
-                          @{_('Comment un-deleted')}
-                        @elif log.action == 64:
-                          @{_('Banned user from site')}
-                        @elif log.action == 65:
-                          @{_('Banned user from sub')}
-                        @elif log.action == 66:
-                          @{_('Un-banned user from site')}
-                        @elif log.action == 67:
-                          @{_('Un-banned user from sub')}
-                        @elif log.action == 68:
-                          @{_('Left note')}
-                        @else:
-                            <i>[Type @{log.action}]</i>
-                        @end
-                    </td>
-                    <td>
-                        @if log.uid:
-                            <a href="/u/@{log.uid.name}">@{log.uid.name}</a>
-                        @else:
-                            --
-                        @end
-                    </td>
-                    <td>
-                      @if log.action == 57:
-                        @{_('Closed all reports related to: ')}<a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=log.desc)}">
-                          @{report['type']} @{_('report')} @{log.desc}</a>
-                      @elif log.desc:
-                          @{log.desc}
-                      @end
-                    </td>
-                </tr>
-                @end
-                </tbody>
-            </table>
+            <ol class="mod-table">
+              <li class="mod-table-header pure-g">
+                <div class="header pure-u-1 pure-u-md-4-24">@{_('Time')}</div>
+                <div class="header pure-u-1 pure-u-md-6-24">@{_('Action Taken')}</div>
+                <div class="header pure-u-1 pure-u-md-4-24">@{_('By')}</div>
+                <div class="header pure-u-1 pure-u-md-10-24">@{_('Details')}</div>
+              </li>
+              @for log in logs:
+              <li class="mod-table-row pure-g">
+                <div data-name="@{_('Time:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+                  <time-ago datetime="@{log.time.isoformat()}Z">@{log.time.isoformat()}</time-ago>
+                </div>
+                <div data-name="@{_('Action Taken:')}" class="elem sub pure-u-1 pure-u-md-6-24">
+                  @if (log.action == 55) or (log.action == 57):
+                    @{_('Report closed')}
+                  @elif log.action == 56:
+                    @{_('Report reopened')}
+                  @elif log.action == 60:
+                    @{_('Post deleted')}
+                  @elif log.action == 61:
+                    @{_('Post un-deleted')}
+                  @elif log.action == 62:
+                    @{_('Comment deleted')}
+                  @elif log.action == 63:
+                    @{_('Comment un-deleted')}
+                  @elif log.action == 64:
+                    @{_('Banned user from site')}
+                  @elif log.action == 65:
+                    @{_('Banned user from sub')}
+                  @elif log.action == 66:
+                    @{_('Un-banned user from site')}
+                  @elif log.action == 67:
+                    @{_('Un-banned user from sub')}
+                  @elif log.action == 68:
+                    @{_('Left note')}
+                  @else:
+                    <i>[Type @{log.action}]</i>
+                  @end
+                </div>
+                <div data-name="@{_('By:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+                  @if log.uid:
+                  <a href="/u/@{log.uid.name}">@{log.uid.name}</a>
+                  @else:
+                  --
+                  @end
+                </div>
+                <div data-name="@{_('Details:')}" class="elem sub pure-u-1 pure-u-md-10-24">
+                  @if log.action == 57:
+                  @{_('Closed all reports related to: ')}<a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=log.desc)}">
+                  @{report['type']} @{_('report')} @{log.desc}</a>
+                  @elif log.desc:
+                    @{log.desc}
+                  @end
+                </div>
+              </li>
+              @end
+            </ol>
           @end
 
           <hr>
@@ -299,38 +302,36 @@ Mod |\
             <!-- 1 instead of 0 because it includes the current report, which should always exist -->
               <p class="helper-text">@{_('There are no other reports on this post')}</p>
             @else:
-              <table class="pure-table">
-                <thead>
-                  <tr>
-                    <th>@{_('Time')}</th>
-                    <th>@{_('Reporter')}</th>
-                    <th>@{_('Reason')}</th>
-                    <th>@{_('Status')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for related_report in related_reports['query']:
-                    @if related_report['id'] != report['id']:
-                      <tr>
-                        <td>
-                          @if related_report['type'] == 'comment':
-                            <a href="@{url_for('mod.report_details', sub=related_report['sub'], report_type=related_report['type'], report_id=related_report['id'])}"><time-ago datetime="@{related_report['datetime'].isoformat()}Z"></time-ago></a>
-                          @else:
-                          <a href="@{url_for('mod.report_details', sub=related_report['sub'], report_type=related_report['type'], report_id=related_report['id'])}"><time-ago datetime="@{related_report['datetime'].isoformat()}Z"></time-ago></a>
-                          @end
-                        </td>
-                        <td><a href="@{ url_for('user.view', user=related_report['reporter']) }">@{ related_report['reporter'] }</a></td>
-                        <td>@{related_report['reason']!!e}</td>
-                        @if related_report['open'] == True:
-                          <td>@{_('Open')} </td>
-                        @else:
-                          <td>@{_('Closed')} </td>
-                        @end
-                      </tr>
+              <ol class="mod-table">
+                <li class="mod-table-header pure-g">
+                  <div class="header pure-u-1 pure-u-md-4-24">@{_('Time')}</div>
+                  <div class="header pure-u-1 pure-u-md-4-24">@{_('Reporter')}</div>
+                  <div class="header pure-u-1 pure-u-md-12-24">@{_('Reason')}</div>
+                  <div class="header pure-u-1 pure-u-md-4-24">@{_('Status')}</div>
+                </li>
+                @for related_report in related_reports['query']:
+                @if related_report['id'] != report['id']:
+                <li class="mod-table-row pure-g">
+                  <div data-name="@{_('Time:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+                    @if related_report['type'] == 'comment':
+                    <a href="@{url_for('mod.report_details', sub=related_report['sub'], report_type=related_report['type'], report_id=related_report['id'])}"><time-ago datetime="@{related_report['datetime'].isoformat()}Z"></time-ago></a>
+                    @else:
+                    <a href="@{url_for('mod.report_details', sub=related_report['sub'], report_type=related_report['type'], report_id=related_report['id'])}"><time-ago datetime="@{related_report['datetime'].isoformat()}Z"></time-ago></a>
                     @end
-                  @end
-                </tbody>
-              </table>
+                  </div>
+                  <div data-name="@{_('Reporter:')}" class="elem sub pure-u-1 pure-u-md-4-24"><a href="@{ url_for('user.view', user=related_report['reporter']) }">@{ related_report['reporter'] }</a></div>
+                  <div data-name="@{_('Reason:')}" class="elem sub pure-u-1 pure-u-md-12-24">@{related_report['reason']!!e}</div>
+                  <div data-name="@{_('Status:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+                    @if related_report['open'] == True:
+                    @{_('Open')}
+                    @else:
+                    @{_('Closed')}
+                    @end
+                  </div>
+                </li>
+                @end
+                @end
+              </ol>
             @end
           </div>
 

--- a/app/html/mod/reports.html
+++ b/app/html/mod/reports.html
@@ -9,7 +9,7 @@ Mod |\
 @end
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="content">
     <h1>@{_('Open Reports')}</h1>
     <p class="helper-text">@{_('Includes all open reports for subs you can moderate.')}</p>
@@ -19,39 +19,45 @@ Mod |\
         <div class="admin section stats">
           @{_('Total Open Reports:')} @reports['open_report_count']  |  @{_('Total Closed Reports:')} <a href="@{url_for('mod.closed')}">@reports['closed_report_count']</a>
           <div class="div-error error alertbox"></div>
-
-          <table class="pure-table">
-            <thead>
-              <tr>
-                <th>@{_('Sub')}</th>
-                <th>@{_('Type')}</th>
-                <th>@{_('Reporter')}</th>
-                <th>@{_('Reason')}</th>
-                <th>@{_('User reported')}</th>
-                <th>@{_('Time')}</th>
-                <th>@{_('Close')}</th>
-              </tr>
-            </thead>
-            <tbody>
+          <ol class="mod-table">
+            <li class="mod-table-header pure-g">
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Sub')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Type')}</div>
+              <div class="header pure-u-1 pure-u-md-4-24">@{_('Reporter')}</div>
+              <div class="header pure-u-1 pure-u-md-5-24">@{_('Reason')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('User reported')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Time')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Close')}</div>
+            </li>
             @for report in reports['query']:
-            <tr>
-              <td><div class="sub"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div></td>
-              <td>
+            <li class="mod-table-row pure-g">
+              <div data-name="@{_('Sub:')}" class="elem sub pure-u-1 pure-u-md-3-24"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div>
+              <div data-name="@{_('Type:')}" class="elem pure-u-1 pure-u-md-3-24">
                 @if report['type'] == 'comment':
                   <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Comment')}</a>
                 @else:
                 <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Post')}</a>
                 @end
-              </td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a></div></td>
-              <td>@{report['reason']}</td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a></div></td>
-              <td><time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago></td>
-              <td class="close-report-button"><a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="close-report">@{_('[x]')}</a></td>
-            </tr>
+              </div>
+              <div data-name="@{_('Reported by:')}" class="elem username pure-u-1 pure-u-md-4-24">
+                <a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a>
+              </div>
+              <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-5-24">@{report['reason']}</div>
+              <div data-name="@{_('User reported:')}" class="elem username pure-u-1 pure-u-md-3-24">
+                <a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a>
+              </div>
+              <div data-name="@{_('Time:')}" class="elem pure-u-1 pure-u-md-3-24">
+                <time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago>
+              </div>
+              <div class="close-elem close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="close-report">@{_('[x]')}</a>
+              </div>
+              <div class="close-button close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="pure-button close-report">@{_('Close')}</a>
+              </div>
+            </li>
             @end
-            </tbody>
-          </table>
+          </ol>
         </div>
       </div>
       @if page > 1:

--- a/app/html/mod/sub_reports.html
+++ b/app/html/mod/sub_reports.html
@@ -6,53 +6,59 @@ Mod |\
 
 @import 'shared/sidebar/sub_mod.html' as sb
 @def sidebar():
-  @{sb.render_sidebar('open-reports', sub=sub.name)!!html}
+@{sb.render_sidebar('open-reports', sub=sub.name)!!html}
 @end
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="content">
-    <h1>@{_('Open Reports for ')} @{config.site.sub_prefix}/@{sub.name}</h1>
-    <p class="helper-text">@{_('Includes all open reports this sub.')}</p>
+    <h1>@{_('Open Reports for ')}<a href="@{ url_for('sub.view_sub', sub=sub.name) }">@{config.site.sub_prefix}/@{sub.name}</a></h1>
+    <p class="helper-text">@{_('Includes all open reports for this sub.')}</p>
 
     <div class="admin section">
       <div class="col-12 admin-page-form">
         <div class="admin section stats">
           @{_('Total Open Reports:' )} @reports['open_report_count']  |  @{_('Total Closed Reports:' )} <a href="@{url_for('mod.reports_sub_closed', sub=sub.name)}">@reports['closed_report_count']</a>
           <div class="div-error error alertbox"></div>
-
-          <table class="pure-table">
-            <thead>
-              <tr>
-                <th>@{_('Sub')}</th>
-                <th>@{_('Type')}</th>
-                <th>@{_('Reporter')}</th>
-                <th>@{_('Reason')}</th>
-                <th>@{_('User reported')}</th>
-                <th>@{_('Time')}</th>
-                <th>@{_('Close')}</th>
-              </tr>
-            </thead>
-            <tbody>
+          <ol class="mod-table">
+            <li class="mod-table-header pure-g">
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Sub')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Type')}</div>
+              <div class="header pure-u-1 pure-u-md-4-24">@{_('Reporter')}</div>
+              <div class="header pure-u-1 pure-u-md-5-24">@{_('Reason')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('User reported')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Time')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Close')}</div>
+            </li>
             @for report in reports['query']:
-            <tr>
-              <td><div class="sub"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div></td>
-              <td>
+            <li class="mod-table-row pure-g">
+              <div data-name="@{_('Sub:')}" class="elem sub pure-u-1 pure-u-md-3-24"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div>
+              <div data-name="@{_('Type:')}" class="elem pure-u-1 pure-u-md-3-24">
                 @if report['type'] == 'comment':
                   <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Comment')}</a>
                 @else:
                 <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Post')}</a>
                 @end
-              </td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a></div></td>
-              <td>@{report['reason']}</td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a></div></td>
-              <td><time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago></td>
-              <td class="close-report-button"><a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="close-report">@{_('[x]')}</a></td>
-            </tr>
+              </div>
+              <div data-name="@{_('Reported by:')}" class="elem username pure-u-1 pure-u-md-4-24">
+                <a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a>
+              </div>
+              <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-5-24">@{report['reason']}</div>
+              <div data-name="@{_('User reported:')}" class="elem username pure-u-1 pure-u-md-3-24">
+                <a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a>
+              </div>
+              <div data-name="@{_('Time:')}" class="elem pure-u-1 pure-u-md-3-24">
+                <time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago>
+              </div>
+              <div class="close-elem close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="close-report">@{_('[x]')}</a>
+              </div>
+              <div class="close-button close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="close" class="pure-button close-report">@{_('Close')}</a>
+              </div>
+            </li>
             @end
-            </tbody>
-          </table>
+          </ol>
         </div>
       </div>
       @if page > 1:

--- a/app/html/mod/sub_reports_closed.html
+++ b/app/html/mod/sub_reports_closed.html
@@ -11,10 +11,10 @@ Mod |\
 
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="content">
-    <h1>@{_('Closed Reports for ')} @{config.site.sub_prefix}/@{sub.name}</h1>
-    <p class="helper-text">@{_('Includes all closed reports this sub.')}</p>
+    <h1>@{_('Closed Reports for ')}<a href="@{ url_for('sub.view_sub', sub=sub.name) }">@{config.site.sub_prefix}/@{sub.name}</a></h1>
+    <p class="helper-text">@{_('Includes all closed reports for this sub.')}</p>
 
     <div class="admin section">
       <div class="col-12 admin-page-form">
@@ -22,38 +22,45 @@ Mod |\
           @{_('Total Open Reports:' )} <a href="@{url_for('mod.reports_sub', sub=sub.name)}">@reports['open_report_count']</a>  |  @{_('Total Closed Reports:' )} @reports['closed_report_count']
           <div class="div-error error alertbox"></div>
 
-          <table class="pure-table">
-            <thead>
-              <tr>
-                <th>@{_('Sub')}</th>
-                <th>@{_('Type')}</th>
-                <th>@{_('Reporter')}</th>
-                <th>@{_('Reason')}</th>
-                <th>@{_('User reported')}</th>
-                <th>@{_('Time')}</th>
-                <th>@{_('Reopen')}</th>
-              </tr>
-            </thead>
-            <tbody>
+          <ol class="mod-table">
+            <li class="mod-table-header pure-g">
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Sub')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Type')}</div>
+              <div class="header pure-u-1 pure-u-md-4-24">@{_('Reporter')}</div>
+              <div class="header pure-u-1 pure-u-md-5-24">@{_('Reason')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('User reported')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Time')}</div>
+              <div class="header pure-u-1 pure-u-md-3-24">@{_('Reopen')}</div>
+            </li>
             @for report in reports['query']:
-            <tr>
-              <td><div class="sub"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div></td>
-              <td>
+            <li class="mod-table-row pure-g">
+              <div data-name="@{_('Sub:')}" class="elem sub pure-u-1 pure-u-md-3-24"><a href="@{ url_for('sub.view_sub', sub=report['sub']) }">@{ report['sub'] }</a></div>
+              <div data-name="@{_('Type:')}" class="elem pure-u-1 pure-u-md-3-24">
                 @if report['type'] == 'comment':
-                  <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Comment')}</a>
+                <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Comment')}</a>
                 @else:
-                <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Post')}</a>
+                  <a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=report['id'])}">@{_('Post')}</a>
                 @end
-              </td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a></div></td>
-              <td>@{report['reason']}</td>
-              <td><div class="username"><a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a></div></td>
-              <td><time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago></td>
-              <td class="close-report-button"><a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="close-report">@{_('[x]')}</a></td>
-            </tr>
+              </div>
+              <div data-name="@{_('Reported by:')}" class="elem username pure-u-1 pure-u-md-4-24">
+                <a href="@{ url_for('user.view', user=report['reporter']) }">@{ report['reporter'] }</a>
+              </div>
+              <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-5-24">@{report['reason']}</div>
+              <div data-name="@{_('User reported:')}" class="elem username pure-u-1 pure-u-md-3-24">
+                <a href="@{ url_for('user.view', user=report['reported']) }">@{ report['reported'] }</a>
+              </div>
+              <div data-name="@{_('Time:')}" class="elem pure-u-1 pure-u-md-3-24">
+                <time-ago datetime="@{report['datetime'].isoformat()}Z"></time-ago>
+              </div>
+              <div class="close-elem close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="close-report">@{_('[x]')}</a>
+              </div>
+              <div class="close-button close-report-button pure-u-1 pure-u-md-3-24">
+                <a data-type="@{report['type']}" data-id="@{report['id']}" data-action="reopen" class="pure-button close-report">@{_('Reopen')}</a>
+              </div>
+            </li>
             @end
-            </tbody>
-          </table>
+          </ol>
         </div>
       </div>
       @if page > 1:

--- a/app/html/sub/bans.html
+++ b/app/html/sub/bans.html
@@ -11,7 +11,7 @@
 
 
 @def main():
-<div id="center-container">
+<div id="container" class="mod-container">
   <div class="content mw-75">
     @if not current_user.is_mod(sub.sid, 2) and current_user.is_admin():
     <h3>@{_('Editing as Admin')}</h3>
@@ -50,58 +50,55 @@
       @if banned.count() < 1:
       @{_('none')}
       @else:
-      <table>
-        <thead>
-        <tr>
-          <th>@{_('By')}</th>
-          <th>@{_('Created')}</th>
-          <th>@{_('User')}</th>
-          <th>@{_('Reason')}</th>
-          <th>@{_('Expires')}</th>
+      <ol class="mod-table">
+        <li class="mod-table-header pure-g">
+          <div class="header pure-u-1 pure-u-md-3-24">@{_('By')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('Created')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('User')}</div>
+          <div class="header pure-u-1 pure-u-md-5-24">@{_('Reason')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('Expires')}</div>
           @if current_user.is_admin() or current_user.is_mod(sub.sid, 2):
-          <th>@{_('Actions')}</th>
-          \
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('Actions')}</div>
           @end
-        </tr>
-        </thead>
-        <tbody>
+        </li>
         @for ban in banned:
-        <tr>
-          <td>
+        <li class="mod-table-row pure-g">
+          <div data-name="@{_('By:')}" class="elem pure-u-1 pure-u-md-3-24">
             @if ban.created_by_id:
             <a href="@{url_for('user.view', user=ban.created_by.name)}">@{ban.created_by.name}</a> \
             @else:
             @{_('N/A')} \
             @end
-          </td>
-          <td>
+          </div>
+          <div data-name="@{_('Created:')}" class="elem pure-u-1 pure-u-md-4-24">
             @if ban.created:
             <time-ago datetime="@{ban.created.isoformat()}Z">@{ban.created.isoformat()}</time-ago>
             \
             @else:
             @{_('N/A')}\
             @end
-          </td>
-          <td><a href="@{url_for('user.view', user=ban.user.name)}">@{ban.user.name}</a></td>
-          <td>@{ban.reason}</td>
-          <td>
+          </div>
+          <div data-name="@{_('User:')}" class="elem pure-u-1 pure-u-md-4-24">
+            <a href="@{url_for('user.view', user=ban.user.name)}">@{ban.user.name}</a>
+          </div>
+          <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-5-24">@{ban.reason}</div>
+          <div data-name="@{_('Expires:')}" class="elem pure-u-1 pure-u-md-4-24">
             @if ban.expires:
-              <time-until datetime="@{ban.expires.isoformat()}Z">@{ban.expires.isoformat()}</time-until> \
+            <time-until datetime="@{ban.expires.isoformat()}Z">@{ban.expires.isoformat()}</time-until> \
             @else:
-              @{_('Never')}\
+            @{_('Never')}\
             @end
-          </td>
-          @if (current_user.is_admin() or current_user.is_mod(sub.sid, 2)):
-          <td>
+          </div>
+          <div data-name="@{_('Actions:')}" class="elem pure-u-1 pure-u-md-4-24">
             @if (current_user.uid in submods['janitors'] and ban.created_by.uid == current_user.uid) or current_user.is_mod(sub.sid, 1):
             <a data-sub="@{sub.name}" data-user="@{ban.user.name}" class="slink revoke-ban">@{_('unban')}</a>
+            @else:
+            @{_('N/A')}
             @end
-          </td>
-          @end
-        </tr>
+          </div>
+        </li>
         @end
-        </tbody>
-      </table>
+      </ol>
       @end
     </div>
     <hr>
@@ -110,48 +107,44 @@
       @if xbans.count() < 1:
       none\
       @else:
-      <table>
-        <thead>
-        <tr>
-          <th>@{_('By')}</th>
-          <th>@{_('Created')}</th>
-          <th>@{_('User')}</th>
-          <th>@{_('Reason')}</th>
-          <th>@{_('Removed')}</th>
-        </tr>
-        </thead>
-        <tbody>
+      <ol class="mod-table">
+        <li class="mod-table-header pure-g">
+          <div class="header pure-u-1 pure-u-md-3-24">@{_('By')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('Created')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('User')}</div>
+          <div class="header pure-u-1 pure-u-md-9-24">@{_('Reason')}</div>
+          <div class="header pure-u-1 pure-u-md-4-24">@{_('Removed')}</div>
+        </li>
         @for ban in xbans:
-        <tr>
-          <td>
+        <li class="mod-table-row pure-g">
+          <div data-name="@{_('By:')}" class="elem pure-u-1 pure-u-md-3-24">
             @if ban.created_by_id:
             <a href="@{url_for('user.view', user=ban.created_by.name)}">@{ban.created_by.name}</a>
             @else:
             @{_('N/A')} \
             @end
-          </td>
-          <td>
+          </div>
+          <div data-name="@{_('Created:')}" class="elem pure-u-1 pure-u-md-4-24">
             @if ban.created:
             <time-ago datetime="@{ban.created.isoformat()}Z">@{ban.created.isoformat()}</time-ago>
             \
             @else:
             @{_('N/A')}\
             @end
-          </td>
-          <td><a href="@{url_for('user.view', user=ban.user.name)}">@{ban.user.name}</a></td>
-          <td>@{ban.reason}</td>
-          <td>
+          </div>
+          <div data-name="@{_('User:')}" class="elem pure-u-1 pure-u-md-4-24"><a href="@{url_for('user.view', user=ban.user.name)}">@{ban.user.name}</a></div>
+          <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-9-24">@{ban.reason}</div>
+          <div data-name="@{_('Removed:')}" class="elem pure-u-1 pure-u-md-4-24">
             @if ban.expires:
             <time-ago datetime="@{ban.expires.isoformat()}Z">@{ban.expires.isoformat()}</time-ago>
             \
             @else:
             @{_('N/A')} \
             @end
-          </td>
-        </tr>
+          </div>
+        </li>
         @end
-        </tbody>
-      </table>
+      </ol>
       @end
       </ul>
     </div>

--- a/app/html/sub/log.html
+++ b/app/html/sub/log.html
@@ -1,101 +1,103 @@
 @extends("shared/layout.html")
-@require(sub, logs, page)
+@require(sub, logs, page, subInfo, subMods)
 
-@def content():
-<div id="center-container">
-    <div class="content">
-        <h2>@{_('Sub log for <a href="%(url)s">/%(prefix)s/%(sub)s</a>', url=url_for('sub.view_sub', sub=sub.name), prefix=config.site.sub_prefix, sub=sub.name)!!html}</h2>
-        <table class="pure-table">
-            <thead>
-            <tr>
-                <th>@{_('Time')}</th>
-                <th>@{_('Moderator')}</th>
-                <th>@{_('Action')}</th>
-                <th>@{_('User')}</th>
-                <th></th>
-            </tr>
-            </thead>
-            <tbody>
-            @for log in logs:
-            <tr>
-                <td>
-                    <time-ago datetime="@{log.time.isoformat()}Z">@{log.time.isoformat()}</time-ago>
-                </td>
-                <td>
-                    @if log.uid:
-                        @if log.uid.status != 10:
-                            <a href="/u/@{log.uid.name}">@{log.uid.name}</a>\
-                        @else:
-                            @{_('[Deleted]')}
-                        @end
-                    @end
-                </td>
-                <td>
-                    @if log.action == 20:
-                        @{_('Created the sub')}
-                    @elif log.action == 21:
-                        @{_('Changed sub settings')}
-                    @elif log.action == 22:
-                        @if log.link:
-                            @{_('Temporarily banned <a href="/u/%(username)s">%(username)s</a> %(days)s with reason <code>%(reason)s</code>', username=log.target.name, days=_('for 1 day') if log.link == '1' else _('for %(num)s days', num=log.link), reason=e(log.desc))!!html}
-                        @else:
-                            @{_('Banned <a href="/u/%(username)s">%(username)s</a> with reason <code>%(reason)s</code>', username=log.target.name, reason=e(log.desc))!!html}
-                        @end
-                    @elif log.action == 23:
-                        @{_('Unbanned <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
-                    @elif log.action == 24:
-                        @{_('Sent mod invite to <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
-                    @elif log.action == 25:
-                        @{_('Accepted mod invite')}
-                    @elif log.action == 26:
-                        @{_('Removed <a href="/u/%(username)s">%(username)s</a> from the mod team', username=log.target.name)!!html}
-                    @elif log.action == 27:
-                        @{_('Revoked mod invite for <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
-                    @elif log.action == 28:
-                        @{_('Mod invite declined by <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
-                    @elif log.action == 29:
-                        @{_('Edited the sub\'s stylesheet')}
-                    @elif log.action == 30:
-                        @{_('Sub was transferred to <a href="/u/%(username)s">%(username)s</a>', username=e(log.desc))!!html}
-                    @elif log.action == 50:
-                        @{_('Stickied a post')}
-                    @elif log.action == 51:
-                        @{_('Unstickied a post')}
-                    @elif log.action == 52:
-                        @{_('Deleted a post with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
-                    @elif log.action == 58:
-                        @{_('Un-deleted a post with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
-                    @elif log.action == 53:
-                        @{_('Deleted a comment with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
-                    @elif log.action == 59:
-                        @{_('Un-deleted a comment with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
-                    @elif log.action == 73 or log.action == 74:
-                        @{_('Changed the comment sort order of a sticky post')}
-                    @else:
-                        <i>@{_('[Type %(type)i]', type=log.action)!!html}</i> @{log.desc}
-                    @end
-                </td>
-                <td>
-                    @if log.action in [22, 23, 24, 26, 27, 28, 52, 53, 58, 59] and log.target is not None:
-                        <a href="/u/@{log.target.name}">@{log.target.name}</a>
-                    @end
-                </td>
-                <td>
-                    @if log.link and log.action != 22:
-                        <a href="@{log.link}">@{_('Link')}</a> \
-                    @end
-                </td>
-            </tr>
+@def sidebar():
+@include('shared/sidebar/sub.html')
+@end
+
+@def main():
+<div id="container" class="mod-container">
+  <div class="content">
+    <h2>@{_('Sub log for <a href="%(url)s">/%(prefix)s/%(sub)s</a>', url=url_for('sub.view_sub', sub=sub['name']), prefix=config.site.sub_prefix, sub=sub['name'])!!html}</h2>
+    <ol class="mod-table">
+      <li class="mod-table-header pure-g">
+        <div class="header pure-u-1 pure-u-md-3-24">@{_('Time')}</div>
+        <div class="header pure-u-1 pure-u-md-4-24">@{_('Moderator')}</div>
+        <div class="header pure-u-1 pure-u-md-11-24">@{_('Action')}</div>
+        <div class="header pure-u-1 pure-u-md-4-24">@{_('User')}</div>
+        <div class="header pure-u-1 pure-u-md-2-24"></div>
+      </li>
+      @for log in logs:
+      <li class="mod-table-row pure-g">
+        <div data-name="@{_('Time:')}" class="elem sub pure-u-1 pure-u-md-3-24">
+          <time-ago datetime="@{log.time.isoformat()}Z">@{log.time.isoformat()}</time-ago>
+        </div>
+        <div data-name="@{_('Moderator:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+          @if log.uid:
+          @if log.uid.status != 10:
+          <a href="/u/@{log.uid.name}">@{log.uid.name}</a>\
+          @else:
+          @{_('[Deleted]')}
+          @end
+          @end
+        </div>
+        <div data-name="@{_('Action:')}" class="elem sub pure-u-1 pure-u-md-11-24">
+          @if log.action == 20:
+            @{_('Created the sub')}
+          @elif log.action == 21:
+            @{_('Changed sub settings')}
+          @elif log.action == 22:
+            @if log.link:
+              @{_('Temporarily banned <a href="/u/%(username)s">%(username)s</a> %(days)s with reason <code>%(reason)s</code>', username=log.target.name, days=_('for 1 day') if log.link == '1' else _('for %(num)s days', num=log.link), reason=e(log.desc))!!html}
+            @else:
+              @{_('Banned <a href="/u/%(username)s">%(username)s</a> with reason <code>%(reason)s</code>', username=log.target.name, reason=e(log.desc))!!html}
             @end
-            </tbody>
-        </table>
-        @if page > 1:
-        <a href="@{url_for('sub.view_sublog', sub=sub.name, page=(page-1))}" class="btn">@{_('Previous page')}</a>
-        @end
+          @elif log.action == 23:
+            @{_('Unbanned <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
+          @elif log.action == 24:
+            @{_('Sent mod invite to <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
+          @elif log.action == 25:
+            @{_('Accepted mod invite')}
+          @elif log.action == 26:
+            @{_('Removed <a href="/u/%(username)s">%(username)s</a> from the mod team', username=log.target.name)!!html}
+          @elif log.action == 27:
+            @{_('Revoked mod invite for <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
+          @elif log.action == 28:
+            @{_('Mod invite declined by <a href="/u/%(username)s">%(username)s</a>', username=log.target.name)!!html}
+          @elif log.action == 29:
+            @{_('Edited the sub\'s stylesheet')}
+          @elif log.action == 30:
+            @{_('Sub was transferred to <a href="/u/%(username)s">%(username)s</a>', username=e(log.desc))!!html}
+          @elif log.action == 50:
+            @{_('Stickied a post')}
+          @elif log.action == 51:
+            @{_('Unstickied a post')}
+          @elif log.action == 52:
+            @{_('Deleted a post with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
+          @elif log.action == 58:
+            @{_('Un-deleted a post with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
+          @elif log.action == 53:
+            @{_('Deleted a comment with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
+          @elif log.action == 59:
+            @{_('Un-deleted a comment with reason <code>%(desc)s</code>', desc=e(log.desc))!!html}
+          @elif log.action == 73 or log.action == 74:
+            @{_('Changed the comment sort order of a sticky post')}
+          @else:
+            <i>@{_('[Type %(type)i]', type=log.action)!!html}</i> @{log.desc}
+          @end
+        </div>
+        <div data-name="@{_('User:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+          @if log.action in [22, 23, 24, 26, 27, 28, 52, 53, 58, 59] and log.target is not None:
+          <a href="/u/@{log.target.name}">@{log.target.name}</a>
+              @end
+        </div>
+        <div data-name="" class="last-elem sub pure-u-1 pure-u-md-2-24">
+          @if log.link and log.action != 22:
+          <a href="@{log.link}">@{_('Link')}</a> \
+          @else:
+          &nbsp;
+          @end
+        </div>
+      </li>
+      @end
+    </ol>
+      @if page > 1:
+      <a href="@{url_for('sub.view_sublog', sub=sub['name'], page=(page-1))}" class="btn">@{_('Previous page')}</a>
+      @end
 
-        @if len(logs) == 50:
-        <a href="@{url_for('sub.view_sublog', sub=sub.name, page=(page+1))}" class="btn">@{_('Next page')}</a>
-        @end
+      @if len(logs) == 50:
+      <a href="@{url_for('sub.view_sublog', sub=sub['name'], page=(page+1))}" class="btn">@{_('Next page')}</a>
+      @end
     </div>
 </div>
 @end

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -584,3 +584,22 @@ body.dark .admin-config-edit {
 body.dark .admin-config-edit:hover {
     fill: #d17262;
 }
+
+body.dark .mod-table .header {
+    border-color: #4e4e4e;
+    background-color: #5c5c5c;
+}
+
+body.dark .mod-table,
+body.dark .mod-table .header,
+body.dark .mod-table .elem,
+body.dark .mod-table .close-elem,
+body.dark .mod-table .last-elem {
+    border-color: #4e4e4e;
+}
+
+body.dark .mod-table .elem,
+body.dark .mod-table .close-elem,
+body.dark .mod-table .last-elem {
+    background-color: #222;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2684,3 +2684,79 @@ article.text-post.comment.deleted {
     white-space: normal;
     text-overflow: ellipsis;
 }
+
+/* Moderator reports */
+
+#container.mod-container {
+    padding-right: 0.5em;
+}
+
+.mod-table {
+    padding-inline-start: 0;
+    width: 100%;
+    border: none;
+}
+
+.mod-table .header {
+    color: #000;
+    font-weight: bold;
+    background-color: #e0e0e0;
+    border: 1px solid #cbcbcb;
+    padding: 0.5em;
+    vertical-align: text-bottom;
+}
+
+li.mod-table-header {
+    margin-top: 0px;
+    border: none;
+}
+
+.mod-table .elem, .mod-table .close-elem, .mod-table .last-elem {
+    background-color: #f7f7f7;
+    border: 1px solid #cbcbcb;
+    padding: 0.5em;
+    vertical-align: bottom;
+}
+
+.mod-table .header, .mod-table .close-elem {
+    display: none;
+}
+
+.mod-table .elem::before {
+    font-weight: bold;
+    padding: 0.5em;
+    content: attr(data-name);
+}
+
+.mod-table .close-button {
+    display: block;
+    margin-top: 2px;
+    margin-bottom: 15px;
+}
+
+.mod-table .last-elem {
+    margin-bottom: 15px;
+}
+
+@media screen and (min-width: 48em) {
+    .mod-table, li.mod-table-header {
+        border: 1px solid #cbcbcb;
+    }
+
+    .mod-table .header, .mod-table .close-elem {
+        display: block;
+    }
+
+    .mod-table .elem::before {
+        padding: 0em;
+        content: "";
+    }
+
+    .mod-table .close-button {
+        display: none;
+    }
+
+    .mod-table .last-elem {
+        margin-bottom: 0px;
+    }
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2385,13 +2385,11 @@ a.close-report {
   }
 }
 
-.mod.report.close.buttons {
-  display: flex;
-  align-items: flex-start;
-}
-
-.mod.report.close.buttons button {
-  margin: 10px 5px 10px 0;
+.mod.report.close.buttons button,
+.mod .user-actions .pure-button {
+    margin: 5px;
+    white-space: normal;
+    height: 90%;
 }
 
 .mod button.disabled {
@@ -2404,20 +2402,6 @@ a.close-report {
   width: 100%;
 }
 
-.report-details-row {
-  min-width: 500px;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin: 10px auto;
-  width: 100%;
-}
-
-.report-details-item {
-  min-width: 200px;
-  width: 50%;
-}
-
 .report-details-item .label {
   font-weight: bold;
 }
@@ -2426,23 +2410,14 @@ a.close-report {
   max-width: 600px;
 }
 
-.mod .user-actions {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.mod .user-actions .pure-button {
-  margin: 10px 5px 10px 0;
-}
-
 .mod.report.preview .preview-text-container {
   border-left: 3px solid gray;
   margin: 10px;
 }
 
 .mod.report.preview .preview-text-container .preview-text {
-  color: gray;
-  padding-left: 10px;
+  background-color: #f7f7f7;
+  padding: 0px 10px 10px 10px;
 }
 
 .mod.report.preview .preview-text-container.deleted {
@@ -2453,14 +2428,13 @@ a.close-report {
   background-color: #FDD8D4;
 }
 
-.mod.report.preview .preview-meta-data {
-  display: flex;
-  align-items: center;
-  color: gray;
+.mod.report.preview .preview-meta-data div {
+    color: gray;
+    margin-top: 5px;
 }
 
-.mod.report.preview .preview-meta-data span {
-  margin: 0 10px;
+.mod.report.preview .preview-meta-data a {
+    font-weight: bold;
 }
 
 .mod-sidebar.header {

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -222,27 +222,28 @@ def edit_sub(sub):
 def view_sublog(sub, page):
     """ Here we can see a log of mod/admin activity in the sub """
     try:
-        sub = Sub.get(fn.Lower(Sub.name) == sub.lower())
+        sub = Sub.select().where(fn.Lower(Sub.name) == sub.lower()).dicts().get()
     except Sub.DoesNotExist:
         abort(404)
 
-    subInfo = misc.getSubData(sub.sid)
+    subInfo = misc.getSubData(sub["sid"])
     if not config.site.force_sublog_public:
         log_is_private = subInfo.get("sublog_private", 0) == "1"
 
         if log_is_private and not (
-            current_user.is_mod(sub.sid, 1) or current_user.is_admin()
+            current_user.is_mod(sub["sid"], 1) or current_user.is_admin()
         ):
             abort(404)
 
+    subMods = misc.getSubMods(sub["sid"])
     logs = (
         SubLog.select()
-        .where(SubLog.sid == sub.sid)
+        .where(SubLog.sid == sub["sid"])
         .order_by(SubLog.lid.desc())
         .paginate(page, 50)
     )
     return engine.get_template("sub/log.html").render(
-        {"sub": sub, "logs": logs, "page": page}
+        {"sub": sub, "logs": logs, "page": page, "subInfo": subInfo, "subMods": subMods}
     )
 
 


### PR DESCRIPTION
Replace the tables on the moderation pages, which don't behave well on small screens, with pure-css's responsive grids, styled to look like tables on any page over `48em` wide.  On small screens such as phones, use the responsive grid and some width-dependent styles to show the information as a list of cards instead of as a table.

Make this change to the report listings, report details pages, sub logs, and sub ban listings.