### PR TITLE
Fix the top posts in 24 hours query

### DIFF
--- a/app/misc.py
+++ b/app/misc.py
@@ -838,7 +838,8 @@ def fetchTodaysTopPosts(uid, include_nsfw):
                 JOIN.LEFT_OUTER,
                 on=((SubMod.uid == uid) & (SubMod.sid == SubPost.sid) & ~SubMod.invite),
             ).where(
-                (UserContentBlock.method != UserContentBlockMethod.HIDE)
+                UserContentBlock.method.is_null(True)
+                | (UserContentBlock.method != UserContentBlockMethod.HIDE)
                 | SubMod.id.is_null(False)
             )
         )


### PR DESCRIPTION
Fix a regression from #396, which broke the Top Posts in 24 hours query.  Add an explicit check against null when checking the user content blocking method.