### PR TITLE
Improve sub ban listing layout on mobile

### DIFF
--- a/app/html/sub/bans.html
+++ b/app/html/sub/bans.html
@@ -37,7 +37,7 @@
           @end
           <input id="ban_expires" name="expires" type="text" class="date-picker-future" @{(current_user.uid in submods['janitors'])
           and 'style="display: inline-block;"' or 'style="display: none;"'} placeholder="@{_('Pick date')}">
-          <button type="submit" class="pure-button pure-button-primary" id="banuser-btnsubmit">@{_('Ban')}</button>
+          <div><button type="submit" class="pure-button pure-button-primary" id="banuser-btnsubmit">@{_('Ban')}</button></div>
         </p>
         <div class="alert div-error"></div>
       </form>
@@ -89,11 +89,16 @@
             @{_('Never')}\
             @end
           </div>
-          <div data-name="@{_('Actions:')}" class="elem pure-u-1 pure-u-md-4-24">
+          <div data-name="@{_('Actions:')}" class="close-elem pure-u-1 pure-u-md-4-24">
             @if (current_user.uid in submods['janitors'] and ban.created_by.uid == current_user.uid) or current_user.is_mod(sub.sid, 1):
             <a data-sub="@{sub.name}" data-user="@{ban.user.name}" class="slink revoke-ban">@{_('unban')}</a>
             @else:
             @{_('N/A')}
+            @end
+          </div>
+          <div data-name="@{_('Actions:')}" class="close-button pure-u-1 pure-u-md-4-24">
+            @if (current_user.uid in submods['janitors'] and ban.created_by.uid == current_user.uid) or current_user.is_mod(sub.sid, 1):
+            <a data-sub="@{sub.name}" data-user="@{ban.user.name}" class="pure-button revoke-ban">@{_('unban')}</a>
             @end
           </div>
         </li>
@@ -134,7 +139,7 @@
           </div>
           <div data-name="@{_('User:')}" class="elem pure-u-1 pure-u-md-4-24"><a href="@{url_for('user.view', user=ban.user.name)}">@{ban.user.name}</a></div>
           <div data-name="@{_('Reason:')}" class="elem pure-u-1 pure-u-md-9-24">@{ban.reason}</div>
-          <div data-name="@{_('Removed:')}" class="elem pure-u-1 pure-u-md-4-24">
+          <div data-name="@{_('Removed:')}" class="last-elem pure-u-1 pure-u-md-4-24">
             @if ban.expires:
             <time-ago datetime="@{ban.expires.isoformat()}Z">@{ban.expires.isoformat()}</time-ago>
             \

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2696,7 +2696,7 @@ li.mod-table-header {
     display: none;
 }
 
-.mod-table .elem::before {
+.mod-table .elem::before, .mod-table .last-elem::before {
     font-weight: bold;
     padding: 0.5em;
     content: attr(data-name);
@@ -2721,7 +2721,7 @@ li.mod-table-header {
         display: block;
     }
 
-    .mod-table .elem::before {
+    .mod-table .elem::before, .mod-table .last-elem::before {
         padding: 0em;
         content: "";
     }


### PR DESCRIPTION
When viewing sub bans on mobile, add small gaps between the ban cards. Convert the "unban" link to a button in the mobile view. The ban button on the top part of the page was misaligned in the mobile view, and moved when you enabled the datepicker, so solve both problems by putting it on its own line.