### PR TITLE
Remove block circle and report links for anonymous users

### DIFF
--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -92,11 +92,11 @@
             @{_('comment')} \
           @end
         </a>
-        @if not sub and not announcement:
+        @if current_user.uid and not sub and not announcement:
           <span><a data-ac="block" class="unblk">@{_('block sub')}</a></span>
         @end
-        @if post['uid'] != current_user.uid:
-        <a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a>
+        @if current_user.uid and post['uid'] != current_user.uid:
+          <a data-ac="report" data-pid="@{post['pid']}" class="report-post">@{_('report')}</a>
         @end
         @if post['open_report_id']:
           <li><a class="post-open-reports" href="@{url_for('mod.report_details', sub=post['sub'], report_type='post', report_id=post['open_report_id'])}">@{_('open reports (%(num)s)', num=post['open_reports'])}</a></li>


### PR DESCRIPTION
Remove the "block circle" and "report" links from post listings which an anonymous user is viewing.  The "block circle" link wasn't doing anything when an anonymous user clicked it, and the "report" link would bring up the report form modal which would then show "Error: undefined" if you used the submit button.
