### PR TITLE
Make profiles of deleted users say they are deleted, instead of 404

### DIFF
--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -80,7 +80,7 @@
         else:
             distinguish_text = ''
         blocked_text = _(' [Blocked]') if post['blur'] == 'block-blur' else ''
-        deleted_if_admin_view = (' ' + _('[Deleted]' if post['userstatus'] == 10 and current_user.is_admin() else ''))
+        deleted_if_admin_view = ' ' + _('[Deleted]') if post['userstatus'] == 10 and current_user.is_admin() else ''
 
         userlink = '<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + deleted_if_admin_view + distinguish_text + blocked_text + '</a>' + flairspan
         if post['userstatus'] != 10 or current_user.is_admin():

--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -70,11 +70,29 @@
         @elif post['content'] != '':
           <div class="expando" data-pid="@{post['pid']}" data-t="txt" title="@{_('Show post content')}" data-link="None"><div data-icon="text" class="icon expando-btn"></div></div>
         @end
-        @#{Crappy as shit}
+        @(
+        timeago = '<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>'
+        flairspan = (' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else '')
+        if post['distinguish'] == 1:
+            distinguish_text = _(' [speaking as mod]')
+        elif post['distinguish'] == 2:
+            distingush_text = _(' [speaking as admin]')
+        else:
+            distinguish_text = ''
+        blocked_text = _(' [Blocked]') if post['blur'] == 'block-blur' else ''
+        deleted_if_admin_view = (' ' + _('[Deleted]' if post['userstatus'] == 10 and current_user.is_admin() else ''))
+
+        userlink = '<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + deleted_if_admin_view + distinguish_text + blocked_text + '</a>' + flairspan
+        if post['userstatus'] != 10 or current_user.is_admin():
+            user_html = userlink
+        else:
+            user_html = '<a class="authorlink deleted">' + _('[Deleted]') + '</a>'
+        sublink = '<a href="/' + config.site.sub_prefix + '/' + post['sub'] + '">' + post['sub'] + '</a>'
+        )
         @if not sub:
-          @{_('posted %(timeago)s by %(user)s on %(sub)s', timeago='<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>', user='<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + (post['distinguish'] == 1 and _(' [speaking as mod]') or '') + (post['distinguish'] == 2 and _(' [speaking as admin]') or '') +(post['blur'] == 'block-blur' and _(' [Blocked]') or '') + '</a>' + (' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else '') if post['userstatus'] != 10 else '<a class="authorlink deleted">' + _('[Deleted]') + '</a>', sub='<a href="/' + config.site.sub_prefix + '/' + post['sub'] + '">' + post['sub'] + '</a>')!!html}
+          @{_('posted %(timeago)s by %(user)s on %(sub)s', timeago=timeago, user=user_html, sub=sublink)!!html}
         @else:
-          @{_('posted %(timeago)s by %(user)s', timeago='<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>', user='<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + (post['distinguish'] == 1 and _(' [speaking as mod]') or '') + (post['distinguish'] == 2 and _(' [speaking as admin]') or '') + (post['blur'] == 'block-blur' and _(' [Blocked]') or '') + '</a>' + (' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else '') if post['userstatus'] != 10 else '<a class="authorlink deleted">' + _('[Deleted]') + '</a>')!!html}
+          @{_('posted %(timeago)s by %(user)s', timeago=timeago, user=user_html)!!html}
         @end
 
         @if sub and post['pid'] in func.getStickyPid(sub['sid']):

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -26,7 +26,7 @@
     @end
 
     <meta property="og:site_name" content="@{config.site.lema}">
-    <meta property="og:description" content="@{_('Posted in %(prefix)s/%(sub)s by %(username)s', prefix=config.site.sub_prefix, sub=sub['name'], username=post['user'])}">
+    <meta property="og:description" content="@{_('Posted in %(prefix)s/%(sub)s by %(username)s', prefix=config.site.sub_prefix, sub=sub['name'], username=post['user'] if post['userstatus'] != 10 else _('[Deleted]'))}">
     <meta property="og:title" content="@{post['title']}">
     @if post['thumbnail'] != '' and post['thumbnail'] != 'deferred' and post['link'] != None:
     <meta property="og:image" content="@{thumbnail_url(post['thumbnail'])}">
@@ -39,8 +39,18 @@
 @def sidebar():
 <hr>
   <div class="author" style="padding:.5em;">
-    @# Line's long but we gotta keep it like that :(
-    @{_('Posted %(timeago)s by %(user)s', timeago='<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>', user=('<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + '</a>' + (' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else '')) if post['userstatus'] != 10 else '<a class="authorlink deleted">' + _('[Deleted]') + '</a>')!!html}
+    @(
+    timeago = '<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>'
+    deleted_if_admin_view = (' ' + _('[Deleted]' if post['userstatus'] == 10 and current_user.is_admin() else ''))
+    flair = ' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else ''
+    deleted_link = '<a class="authorlink deleted">' + _('[Deleted]') + '</a>'
+    user_link = ('<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + deleted_if_admin_view + '</a>' + flair)
+    if post['userstatus'] != 10 or current_user.is_admin():
+        user_html = user_link
+    else:
+        user_html = deleted_link
+    )
+    @{_('Posted %(timeago)s by %(user)s', timeago=timeago, user=user_html)!!html}
     <br/>
     @if post['edited']:
       @{_('edited %(timeago)s', timeago='<time-ago datetime="' + post['edited'].isoformat() + 'Z"></time-ago>')!!html}<br/>
@@ -169,7 +179,22 @@
             <div class="expando" data-pid="@{post['pid']}" data-t="lnk" data-link="@{post['link']}"><div class="icon expando-btn" data-icon="play"></div></div>
           @end
         @end
-        @{_('posted %(timeago)s by %(user)s on %(sub)s', timeago='<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>', user='<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + (post['distinguish'] == 1 and _(' [speaking as mod]') or '') + (post['distinguish'] == 2 and _(' [speaking as admin]') or '') + '</a>' + (' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else '') if post['userstatus'] != 10 else '<a class="authorlink deleted">' + _('[Deleted]') + '</a>', sub='<a href="/' + config.site.sub_prefix + '/' + post['sub'] + '">' + post['sub'] + '</a>')!!html}
+        @(
+        timeago = '<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>'
+        deleted_if_admin_view = ' ' + _('[Deleted]') if post['userstatus'] == 10 and current_user.is_admin() else ''
+        if post['distinguish'] == 1:
+            distinguish_text = _(' [speaking as mod]')
+        elif post['distinguish'] == 2:
+            distingush_text = _(' [speaking as admin]')
+        else:
+            distinguish_text = ''
+        flair = ' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else ''
+        user_link = '<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + deleted_if_admin_view + distinguish_text + '</a>' + flair
+        deleted_link = '<a class="authorlink deleted">' + _('[Deleted]') + '</a>'
+        user_html = user_link if (post['userstatus'] != 10 or current_user.is_admin()) else deleted_link
+        sublink = '<a href="/' + config.site.sub_prefix + '/' + post['sub'] + '">' + post['sub'] + '</a>'
+        )
+        @{_('posted %(timeago)s by %(user)s on %(sub)s', timeago=timeago, user=user_html, sub=sublink)!!html}
       </div>
       <ul class="links" data-pid="@{post['pid']}">
         @if current_user.is_authenticated and post['deleted'] == 0:
@@ -358,21 +383,21 @@
             <ul class="pure-menu-children">
               <li class="pure-menu-item">
                 <a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'], sort='top')}" class="pure-menu-link">
-		  @if sort == 'top':
-		    ✓
-		  @else:
-		    &nbsp;&nbsp;
-		  @end
-		  @{_('Top')}
+                  @if sort == 'top':
+                    ✓
+                  @else:
+                    &nbsp;&nbsp;
+                  @end
+                  @{_('Top')}
                 </a>
               </li>
               <li class="pure-menu-item">
                 <a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'], sort='new')}" class="pure-menu-link">
-		  @if sort == 'new':
-		    ✓
-		  @else:
-		    &nbsp;&nbsp;
-		  @end
+                  @if sort == 'new':
+                    ✓
+                  @else:
+                    &nbsp;&nbsp;
+                  @end
                   @{_('New')}
                 </a>
               </li>

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -41,7 +41,7 @@
   <div class="author" style="padding:.5em;">
     @(
     timeago = '<time-ago datetime="' + post['posted'].isoformat() + 'Z"></time-ago>'
-    deleted_if_admin_view = (' ' + _('[Deleted]' if post['userstatus'] == 10 and current_user.is_admin() else ''))
+    deleted_if_admin_view = ' ' + _('[Deleted]') if post['userstatus'] == 10 and current_user.is_admin() else ''
     flair = ' <span class="user_flair" data-flair-id="' + str(post['user_flair_id']) + '">' + e(post['user_flair']) + '</span>' if post['user_flair'] else ''
     deleted_link = '<a class="authorlink deleted">' + _('[Deleted]') + '</a>'
     user_link = ('<a class="authorlink" href="/u/' + post['user'] + '">' + post['user'] + deleted_if_admin_view + '</a>' + flair)

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -21,8 +21,11 @@
               @if comment['visibility'] == 'none':
                 <a class="poster deleted">@{comment['user']}</a>
               @else:
-                <a href="/u/@{comment['user']}" class="poster">
+                <a href="@{'/u/' + comment['user'] if current_user.is_admin() or comment['userstatus'] != 10 else '#'}" class="poster">
                   @{comment['user']}
+                  @if current_user.is_admin() and comment['userstatus'] == 10:
+                     @{_('[Deleted]')}
+                  @end
                   @if comment['distinguish']:
                     <span class="speaking-tag">@{(comment['distinguish'] == 1) and _(' [speaking as mod]') or ''} @{(comment['distinguish'] == 2) and _(' [speaking as admin]') or ''}</span>
                   @end

--- a/app/html/user/profile.html
+++ b/app/html/user/profile.html
@@ -27,46 +27,51 @@
 @def main():
     <div id="center-container">
         <div class="content">
-            @if user.status != 10:
-                <div class="uprofile-top">
-                    <h1 style="margin-right: 0; margin-left:0" class="noshit">@{user.name}</h1>
-                        <div class="pblock level">
-                            <div class="uprofile-level-box">
-                                <div class="mask left" style="transform: rotate(@{progress*1.8}deg)">
-                                    <div class="fill" style="transform: rotate(@{progress*1.8}deg)"></div>
-                                </div>
-                                <div class="mask right">
-                                    <div class="fill" style="transform: rotate(@{progress*1.8}deg)"></div>
-                                    <div class="fill fix" style="transform: rotate(@{progress*2.8}deg)"></div>
-                                </div>
-                                <div class="inset">
-                                    <div class="lv" style="line-height: 133%; padding-top: 0.4em">@{_('Level')}</div>
-                                    <div class="levelNo">@{level}</div>
-                                </div>
+            <div class="uprofile-top">
+                <h1 style="margin-right: 0; margin-left:0" class="noshit@{' deleted-user' if user.status == 10 else ''}">@{user.name}</h1>
+                @if user.status == 10:
+                    <div>@{_("This user account has been deleted.")}</div>
+                @end
+                @if user.status != 10 or current_user.is_admin():
+                    <div class="pblock level">
+                        <div class="uprofile-level-box">
+                            <div class="mask left" style="transform: rotate(@{progress*1.8}deg)">
+                                <div class="fill" style="transform: rotate(@{progress*1.8}deg)"></div>
+                            </div>
+                            <div class="mask right">
+                                <div class="fill" style="transform: rotate(@{progress*1.8}deg)"></div>
+                                <div class="fill fix" style="transform: rotate(@{progress*2.8}deg)"></div>
+                            </div>
+                            <div class="inset">
+                                <div class="lv" style="line-height: 133%; padding-top: 0.4em">@{_('Level')}</div>
+                                <div class="levelNo">@{level}</div>
                             </div>
                         </div>
-                        <div class="pblock">
-                            <div class="statdiv">
-                                <div class="ucount"><a href="@{url_for('user.view_user_posts', user=user.name)}">@{postCount}</a></div>
-                                <div>@{_('posts')}</div>
-                            </div>
-                            <div class="statdiv">
-                                <div class="ucount"><a href="@{url_for('user.view_user_comments', user=user.name)}">@{commentCount}</a></div>
-                                <div>@{_('comments')}</div>
-                            </div>
-                        </div>
-                        <div class="pblock">
-                            <div class="statdiv">
-                                <abbr class="ucount" title="+@{givenScore[0]}, -@{givenScore[1]}}">@{givenScore[2]}</abbr>
-                                <div>@{_('Phuks given')}</div>
-                            </div>
-                            <div class="statdiv">
-                                <div class="ucount">@{user.score}</div>
-                                <div>@{_('Total score')}</div>
-                            </div>
-                        </div>
-                        <p>@{_('Registered %(timeago)s', timeago='<time-ago datetime="'+ user.joindate.isoformat() + 'Z"></time-ago>')!!html}</p>
                     </div>
+                    <div class="pblock">
+                        <div class="statdiv">
+                            <div class="ucount"><a href="@{url_for('user.view_user_posts', user=user.name)}">@{postCount}</a></div>
+                            <div>@{_('posts')}</div>
+                        </div>
+                        <div class="statdiv">
+                            <div class="ucount"><a href="@{url_for('user.view_user_comments', user=user.name)}">@{commentCount}</a></div>
+                            <div>@{_('comments')}</div>
+                        </div>
+                    </div>
+                    <div class="pblock">
+                        <div class="statdiv">
+                            <abbr class="ucount" title="+@{givenScore[0]}, -@{givenScore[1]}}">@{givenScore[2]}</abbr>
+                            <div>@{_('Phuks given')}</div>
+                        </div>
+                        <div class="statdiv">
+                            <div class="ucount">@{user.score}</div>
+                            <div>@{_('Total score')}</div>
+                        </div>
+                    </div>
+                    <p>@{_('Registered %(timeago)s', timeago='<time-ago datetime="'+ user.joindate.isoformat() + 'Z"></time-ago>')!!html}</p>
+                @end
+            </div>
+            @if user.status != 10 or current_user.is_admin():
                 <div>
                     @if len(badges) > 0:
                         <div class="userrow">

--- a/app/misc.py
+++ b/app/misc.py
@@ -2574,7 +2574,8 @@ def get_comment_tree(
                     comm.update(remove_content)
 
         if comm["userstatus"] == 10:
-            comm["user"] = _("[Deleted]")
+            if not current_user.is_admin():
+                comm["user"] = _("[Deleted]")
             comm["uid"] = None
             if comm["status"] == 1:
                 comm.update(remove_content)

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -518,6 +518,11 @@ body.dark .poll-space.deleted {
   border: 1px solid red;
 }
 
+body.dark .deleted-user {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
 body.dark .browse-history {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1688,6 +1688,10 @@ td.subsentry.blocked {
   text-align: center;
 }
 
+.deleted-user {
+  background-color: #FDD8D4;
+}
+
 .uprofile-top .score {
   font-weight: bold;
 }

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -23,6 +23,9 @@
     <div id="center-container">
       <div class="inbox content">
         <h3>Recent comments</h3>
+        {% if user.status == 10 %}
+          <div class="helper-text deleted-user">{{_("%(user)s has deleted their account.", user=user.name)}}</div>
+        {% endif %}
         <div class="recent">
             {% if comments|length < 1 %}
             <p>

--- a/app/templates/userposts.html
+++ b/app/templates/userposts.html
@@ -21,6 +21,9 @@
 {% else %}
     {% if sort_type == 'user.view_user_posts' %}
       <h3>Recent posts</h3>
+      {% if user.status == 10 %}
+        <div class="helper-text deleted-user">{{_("%(user)s has deleted their account.", user=user.name)}}</div>
+      {% endif %}
     {% else %}
       <h3>Saved posts</h3>
     {% endif %}

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -39,6 +39,27 @@ from ..badges import badges as badges_module
 bp = Blueprint("user", __name__)
 
 
+def view_deleted_user(user):
+    return engine.get_template("user/profile.html").render(
+        {
+            "user": user,
+            "level": None,
+            "progress": None,
+            "postCount": None,
+            "commentCount": None,
+            "givenScore": None,
+            "invitecodeinfo": None,
+            "badges": None,
+            "owns": None,
+            "mods": None,
+            "habits": None,
+            "target_user_is_admin": None,
+            "msgform": None,
+            "ignform": None,
+        }
+    )
+
+
 @bp.route("/u/<user>")
 def view(user):
     """ WIP: View user's profile, posts, comments, badges, etc """
@@ -47,8 +68,8 @@ def view(user):
     except User.DoesNotExist:
         abort(404)
 
-    if user.status == 10:
-        abort(404)
+    if user.status == 10 and not current_user.is_admin():
+        return view_deleted_user(user)
 
     modsquery = (
         SubMod.select(Sub.name, SubMod.power_level)
@@ -156,8 +177,8 @@ def view_user_posts(user, page):
         user = User.get(fn.Lower(User.name) == user.lower())
     except User.DoesNotExist:
         abort(404)
-    if user.status == 10:
-        abort(404)
+    if user.status == 10 and not current_user.is_admin():
+        return view_deleted_user(user)
 
     include_deleted_posts = user.uid == current_user.uid or current_user.is_admin()
     if not include_deleted_posts and current_user.is_a_mod:
@@ -216,8 +237,8 @@ def view_user_comments(user, page):
         user = User.get(fn.Lower(User.name) == user.lower())
     except User.DoesNotExist:
         abort(404)
-    if user.status == 10:
-        abort(404)
+    if user.status == 10 and not current_user.is_admin():
+        return view_deleted_user(user)
 
     include_deleted_comments = user.uid == current_user.uid or current_user.is_admin()
     if not include_deleted_comments and current_user.is_a_mod:


### PR DESCRIPTION
Instead of showing a 404 page for a deleted user's profile and post and comment lists, show a page that says the user account has been deleted.

Allow admins to see full profiles of deleted users, and their post and comment lists.  Show admins the names of deleted users in all their posts and comments.

Since these changes took some of the longest lines of code in the project and made them longer, I used wheezy-template's code extension to dismantle them into smaller expressions.