### PR TITLE
Don't require users to type a reason for deleting their own comment

### DIFF
--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -77,7 +77,7 @@
                         {% endif %}
                       {%endif%}
                       {% if comment.uid == current_user.uid or current_user.is_admin() and comment.status not in [1, 2] %}
-                        <li><a class="delete-comment" data-cid="{{comment.cid}}">delete</a></li>
+                        <li><a {{ ((comment['uid'] == current_user.uid) and 'selfdel="true"' or '')|safe }} class="delete-comment" data-cid="{{comment.cid}}">delete</a></li>
                       {% endif %}
                     {%endif%}
                     <li><a class="comment-source" data-cid="{{comment.cid}}">source</a></li>


### PR DESCRIPTION
When users are looking at the list of their own comments, and use the delete link on one of them, they are then prompted to type a reason for the deletion.  The reason is then ignored by the code that does the deletion.  Set the `selfdel` attribute on the delete link to suppress the prompt.