### PR TITLE
Show poll options in the order they were entered

### DIFF
--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1032,18 +1032,20 @@ def get_txtpost(pid):
             SubPostMetadata.select().where(SubPostMetadata.pid == pid)
         )
         # poll. grab options and votes.
-        options = SubPostPollOption.select(
-            SubPostPollOption.id,
-            SubPostPollOption.text,
-            fn.Count(SubPostPollVote.id).alias("votecount"),
-        )
-        options = options.join(
-            SubPostPollVote,
-            JOIN.LEFT_OUTER,
-            on=(SubPostPollVote.vid == SubPostPollOption.id),
-        )
-        options = options.where(SubPostPollOption.pid == pid).group_by(
-            SubPostPollOption.id
+        options = (
+            SubPostPollOption.select(
+                SubPostPollOption.id,
+                SubPostPollOption.text,
+                fn.Count(SubPostPollVote.id).alias("votecount"),
+            )
+            .join(
+                SubPostPollVote,
+                JOIN.LEFT_OUTER,
+                on=(SubPostPollVote.vid == SubPostPollOption.id),
+            )
+            .where(SubPostPollOption.pid == pid)
+            .group_by(SubPostPollOption.id)
+            .order_by(SubPostPollOption.id)
         )
         pollData["options"] = options
         total_votes = SubPostPollVote.select().where(SubPostPollVote.pid == pid).count()

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -604,18 +604,20 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
     pollData = {"has_voted": False}
     if post["ptype"] == 3:
         # poll. grab options and votes.
-        options = SubPostPollOption.select(
-            SubPostPollOption.id,
-            SubPostPollOption.text,
-            fn.Count(SubPostPollVote.id).alias("votecount"),
-        )
-        options = options.join(
-            SubPostPollVote,
-            JOIN.LEFT_OUTER,
-            on=(SubPostPollVote.vid == SubPostPollOption.id),
-        )
-        options = options.where(SubPostPollOption.pid == pid).group_by(
-            SubPostPollOption.id
+        options = (
+            SubPostPollOption.select(
+                SubPostPollOption.id,
+                SubPostPollOption.text,
+                fn.Count(SubPostPollVote.id).alias("votecount"),
+            )
+            .join(
+                SubPostPollVote,
+                JOIN.LEFT_OUTER,
+                on=(SubPostPollVote.vid == SubPostPollOption.id),
+            )
+            .where(SubPostPollOption.pid == pid)
+            .group_by(SubPostPollOption.id)
+            .order_by(SubPostPollOption.id)
         )
         pollData["options"] = options
         total_votes = SubPostPollVote.select().where(SubPostPollVote.pid == pid).count()

--- a/test/views/test_subs.py
+++ b/test/views/test_subs.py
@@ -3,6 +3,7 @@ import re
 import pytest
 import mock
 import requests.exceptions
+from bs4 import BeautifulSoup
 from flask import url_for
 from test.utilities import register_user, csrf_token, create_sub
 from app.models import Sub, SubMetadata
@@ -213,6 +214,13 @@ def test_submit_poll_post(client, user_info, test_config):
     )
     assert get_error(rv.data) == b""
     assert "/s/test/1" == rv.location
+
+    rv = client.get(url_for("sub.view_post", sub="test", pid=1), follow_redirects=True)
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
+    options = [
+        s.string.strip() for s in soup.find_all("span", class_="poll-option-text")
+    ]
+    assert options == ["Test 1", "Test 2", "Test 3"]
 
 
 @pytest.mark.parametrize("test_config", [{"site": {"sub_creation_min_level": 0}}])


### PR DESCRIPTION
When polls have many options, they are frequently not displayed in the order they were entered (using Postgres).  Fix this by making the query sort them by `id`.