### PR TITLE
Fix the close related reports buttons

### DIFF
--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -278,7 +278,7 @@ Mod |\
                   --
                   @end
                 </div>
-                <div data-name="@{_('Details:')}" class="elem sub pure-u-1 pure-u-md-10-24">
+                <div data-name="@{_('Details:')}" class="last-elem sub pure-u-1 pure-u-md-10-24">
                   @if log.action == 57:
                   @{_('Closed all reports related to: ')}<a href="@{url_for('mod.report_details', sub=report['sub'], report_type=report['type'], report_id=log.desc)}">
                   @{report['type']} @{_('report')} @{log.desc}</a>
@@ -298,9 +298,13 @@ Mod |\
             @else:
               <h3>@{_('Other reports on this post:')}</h3>
             @end
+            @#{ 1 instead of 0 because it includes the current report, which should always exist }
             @if len(related_reports['query']) == 1:
-            <!-- 1 instead of 0 because it includes the current report, which should always exist -->
-              <p class="helper-text">@{_('There are no other reports on this post')}</p>
+              @if report['type'] == 'comment':
+                <p class="helper-text">@{_('There are no other reports on this comment')}</p>
+              @else:
+                <p class="helper-text">@{_('There are no other reports on this post')}</p>
+              @end
             @else:
               <ol class="mod-table">
                 <li class="mod-table-header pure-g">
@@ -321,7 +325,7 @@ Mod |\
                   </div>
                   <div data-name="@{_('Reporter:')}" class="elem sub pure-u-1 pure-u-md-4-24"><a href="@{ url_for('user.view', user=related_report['reporter']) }">@{ related_report['reporter'] }</a></div>
                   <div data-name="@{_('Reason:')}" class="elem sub pure-u-1 pure-u-md-12-24">@{related_report['reason']!!e}</div>
-                  <div data-name="@{_('Status:')}" class="elem sub pure-u-1 pure-u-md-4-24">
+                  <div data-name="@{_('Status:')}" class="last-elem sub pure-u-1 pure-u-md-4-24">
                     @if related_report['open'] == True:
                     @{_('Open')}
                     @else:

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -3922,49 +3922,53 @@ def close_comment_report(cid, action):
 )
 @login_required
 def close_post_related_reports(related_reports, original_report):
-    related_reports = json.loads(related_reports)
-    original_report = original_report
-    # ensure user is mod or admin and report, post, and sub exist
-    for related_report in related_reports:
-        try:
-            report = SubPostReport.get(SubPostReport.id == related_report["id"])
-        except SubPostReport.DoesNotExist:
-            return jsonify(status="error", error=_("Report does not exist"))
+    if not (current_user.is_a_mod or current_user.is_admin()):
+        abort(403)
 
-        try:
-            post = SubPost.get(SubPost.pid == report.pid)
-        except SubPost.DoesNotExist:
-            return jsonify(status="error", error=_("Post does not exist"))
+    related_report_ids = json.loads(related_reports)
+    OriginalSubPostReport = SubPostReport.alias()
 
-        try:
-            sub = Sub.get(Sub.sid == post.sid)
-        except Sub.DoesNotExist:
-            return jsonify(status="error", error=_("Sub does not exist"))
-
-        if not current_user.is_mod(sub.sid) and not current_user.is_admin():
-            return jsonify(status="error", error=_("Not authorized"))
-
-        SubPostReport.update(open=False).where(
-            SubPostReport.id == related_report["id"]
-        ).execute()
-        misc.notify_mods(sub.sid)
-
-        # check if report is closed and return status
-        updated_report = (
-            SubPostReport.select().where(SubPostReport.id == related_report["id"]).get()
+    # Select only the reports that are related and still need closing.
+    related_reports = (
+        SubPostReport.select(SubPostReport.id, SubPost.sid)
+        .join(SubPost)
+        .join(
+            OriginalSubPostReport,
+            JOIN.LEFT_OUTER,
+            on=(OriginalSubPostReport.pid == SubPostReport.pid),
         )
-        if not updated_report.open:
-            misc.create_reportlog(
-                misc.LOG_TYPE_REPORT_CLOSE_RELATED,
-                current_user.uid,
-                updated_report.id,
-                log_type="post",
-                related=True,
-                original_report=original_report,
-            )
-            return jsonify(status="ok")
-        # How?
-        return jsonify(status="error", error=_("Failed to update report"))
+        .where(
+            SubPostReport.open
+            & (SubPostReport.id << related_report_ids)
+            & (OriginalSubPostReport.id == original_report)
+        )
+    )
+    # Ensure user is mod or admin.
+    if not current_user.is_admin():
+        related_reports = related_reports.join(
+            SubMod, on=((SubMod.sid == SubPost.sid) & (~SubMod.invite))
+        ).where(SubMod.uid == current_user.uid)
+    related_reports = list(related_reports.dicts())
+
+    if len(related_reports) == 0:
+        return jsonify(status="error", error=_("No related reports to close"))
+
+    SubPostReport.update(open=False).where(
+        SubPostReport.id << [rep["id"] for rep in related_reports]
+    ).execute()
+    misc.notify_mods(related_reports[0]["sid"])
+
+    for rep in related_reports:
+        misc.create_reportlog(
+            misc.LOG_TYPE_REPORT_CLOSE_RELATED,
+            current_user.uid,
+            rep["id"],
+            log_type="post",
+            related=True,
+            original_report=original_report,
+        )
+
+    return jsonify(status="ok")
 
 
 @do.route(
@@ -3973,58 +3977,53 @@ def close_post_related_reports(related_reports, original_report):
 )
 @login_required
 def close_comment_related_reports(related_reports, original_report):
-    related_reports = json.loads(related_reports)
-    original_report = original_report
-    # ensure user is mod or admin and report, post, and sub exist
-    for related_report in related_reports:
-        try:
-            report = SubPostCommentReport.get(
-                SubPostCommentReport.id == related_report["id"]
-            )
-        except SubPostCommentReport.DoesNotExist:
-            return jsonify(status="error", error=_("Report does not exist"))
+    if not (current_user.is_a_mod or current_user.is_admin()):
+        abort(403)
 
-        try:
-            comment = SubPostComment.get(SubPostComment.cid == report.cid)
-        except SubPostCommentReport.DoesNotExist:
-            return jsonify(status="error", error=_("Comment does not exist"))
+    related_report_ids = json.loads(related_reports)
+    OriginalSubPostCommentReport = SubPostCommentReport.alias()
 
-        try:
-            post = SubPost.get(SubPost.pid == comment.pid)
-        except SubPost.DoesNotExist:
-            return jsonify(status="error", error=_("Post does not exist"))
-
-        try:
-            sub = Sub.get(Sub.sid == post.sid)
-        except Sub.DoesNotExist:
-            return jsonify(status="error", error=_("Sub does not exist"))
-
-        if not current_user.is_mod(sub.sid) and not current_user.is_admin():
-            return jsonify(status="error", error=_("Not authorized"))
-
-        SubPostCommentReport.update(open=False).where(
-            SubPostCommentReport.id == related_report["id"]
-        ).execute()
-        misc.notify_mods(sub.sid)
-
-        # check if report is closed and return status
-        updated_report = (
-            SubPostCommentReport.select()
-            .where(SubPostCommentReport.id == related_report["id"])
-            .get()
+    # Select only the reports that are related and still need closing.
+    related_reports = (
+        SubPostCommentReport.select(SubPostCommentReport.id, SubPost.sid)
+        .join(SubPostComment)
+        .join(SubPost)
+        .join(
+            OriginalSubPostCommentReport,
+            JOIN.LEFT_OUTER,
+            on=(OriginalSubPostCommentReport.cid == SubPostCommentReport.cid),
         )
-        if not updated_report.open:
-            misc.create_reportlog(
-                misc.LOG_TYPE_REPORT_CLOSE_RELATED,
-                current_user.uid,
-                updated_report.id,
-                log_type="comment",
-                related=True,
-                original_report=original_report,
-            )
-            return jsonify(status="ok")
-        # How?
-        return jsonify(status="error", error=_("Failed to close report"))
+        .where(
+            SubPostCommentReport.open
+            & (SubPostCommentReport.id << related_report_ids)
+            & (OriginalSubPostCommentReport.id == original_report)
+        )
+    )
+    # Ensure user is mod or admin.
+    if not current_user.is_admin():
+        related_reports = related_reports.join(
+            SubMod, on=((SubMod.sid == SubPost.sid) & (~SubMod.invite))
+        ).where(SubMod.uid == current_user.uid)
+    related_reports = list(related_reports.dicts())
+
+    if len(related_reports) == 0:
+        return jsonify(status="error", error=_("No related reports to close"))
+
+    SubPostCommentReport.update(open=False).where(
+        SubPostCommentReport.id << [rep["id"] for rep in related_reports]
+    ).execute()
+    misc.notify_mods(related_reports[0]["sid"])
+
+    for rep in related_reports:
+        misc.create_reportlog(
+            misc.LOG_TYPE_REPORT_CLOSE_RELATED,
+            current_user.uid,
+            rep["id"],
+            log_type="comment",
+            related=True,
+            original_report=original_report,
+        )
+    return jsonify(status="ok")
 
 
 @do.route("/do/create_report_note/<report_type>/<report_id>", methods=["POST"])

--- a/app/views/mod.py
+++ b/app/views/mod.py
@@ -178,6 +178,7 @@ def report_details(sub, report_type, report_id):
     related_reports = getReports(
         "mod", "all", 1, type=report_type, report_id=report_id, related=True
     )
+    related_report_ids = [rep["id"] for rep in related_reports["query"]]
 
     if report["type"] == "post":
         try:
@@ -215,7 +216,7 @@ def report_details(sub, report_type, report_id):
             "report": report,
             "reported_user": reported_user,
             "related_reports": related_reports,
-            "related_reports_json": json.dumps(related_reports["query"], default=str),
+            "related_reports_json": json.dumps(related_report_ids, default=str),
             "banuserform": BanUserSubForm(),
             "is_sub_banned": is_sub_banned,
             "post": post,


### PR DESCRIPTION
In the moderator view of an open post or comment report, there is a button to close all reports for the post or comment.  Clicking the button would close the report you were viewing, would not close any related reports, but would add a report log entry about closing all reports.   Fix the endpoints for the close all button to work as expected, and make a couple small improvements to the formatting of the related reports and report logs.