### PR TITLE
Fix up instead of reload the page when a mod deletes a comment

### DIFF
--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -55,7 +55,7 @@
               <br/>
             </div>
 
-            <div class="content  @{(comment['visibility'] != '') and 'hidden' or ''}" id="content-@{comment['cid']}">
+            <div class="content  @{(comment['visibility'] != '' and comment['visibility'] != 'mod-del' ) and 'hidden' or ''}" id="content-@{comment['cid']}">
               @if comment['visibility'] == 'none':
                 @{comment['user']} \
               @elif comment['visibility'] == 'admin-self-del':

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -491,7 +491,7 @@ u.addEventForChild(document, 'click', '.btn-preview', function (e, qelem) {
 // Delete comment
 u.addEventForChild(document, 'click', '.delete-comment', function (e, qelem) {
     // confirmation
-    const cid = qelem.getAttribute('data-cid'), tg = qelem;
+    const cid = qelem.getAttribute('data-cid'), tg = qelem.parentNode.parentNode;
     TextConfirm(qelem, function () {
         let reason = '';
         if (qelem.getAttribute('selfdel') != "true") {
@@ -503,10 +503,10 @@ u.addEventForChild(document, 'click', '.delete-comment', function (e, qelem) {
         u.post('/do/delete_comment', {cid: cid, 'reason': reason},
             function (data) {
                 if (data.status != "ok") {
-                    tg.parentNode.innerHTML = _('Error: %1', data.error);
+                    tg.innerHTML = _('Error: %1', data.error);
                 } else {
-                    tg.parentNode.innerHTML = _('comment removed');
-                    document.location.reload();
+                    document.getElementById(cid).classList.add('deleted');
+                    tg.innerHTML = '<span class="helper-text">' + _('comment removed') + '</span>';
                 }
             });
     });


### PR DESCRIPTION
If a mod has navigated deep into a comment discussion, and deletes a comment, we've been reloading the page, which causes the mod to have to re-navigate to the same place to review the next comment.  Remove the reload, and fix up the styling to show the comment as deleted.  The response callback was attempting to change the text of the delete link, but since this callback is wrapped in a call to `TextConfirm` which is doing its own modification of the targeted element, and which clobbers anything the response callback does to it, that wasn't working.  Instead I chose to replace the list of comment action links with "comment removed" or the error message if there is one.

Make it easier for mods to navigate to replies in discussions with deleted comments, by showing mods mod-deleted comments expanded instead of collapsed when the page is loaded.