### PR TITLE
Add a configuration option for modmail

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -298,7 +298,7 @@ configurable_defaults = {
                     "Show the 'Contact the Mods' button in sub sidebars, which provides "
                     "a link to the modmail server."
                 ),
-                "value": True,
+                "value": False,
             },
             "enable_posting": {
                 "type": "bool",

--- a/app/config.py
+++ b/app/config.py
@@ -292,6 +292,14 @@ configurable_defaults = {
                     },
                 },
             },
+            "enable_modmail": {
+                "type": "bool",
+                "doc": _l(
+                    "Show the 'Contact the Mods' button in sub sidebars, which provides "
+                    "a link to the modmail server."
+                ),
+                "value": True,
+            },
             "enable_posting": {
                 "type": "bool",
                 "doc": _l("Allow users to make posts and comments."),

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -97,6 +97,10 @@
     <li><a href="@{url_for('user.view', user=subMods['janitors'][janitor])}">@{subMods['janitors'][janitor]}</a></li>
   @end
   </ul>
+  @if config.site.enable_modmail and current_user.is_authenticated and not current_user.is_subban(sub) and not (current_user.uid in (subMods['all'])):
+  <a href="/s/@{sub['name']}/contact_mods" class="sbm-post pure-button">@{_('Message the Mods')}</a>
+  @endif
+
 </div>
 <div class="createdby">
   @{_('Created by <a href="/u/%(name)s">%(name)s</a>', name=subInfo['creator']['name'])!!html}

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -97,7 +97,7 @@
     <li><a href="@{url_for('user.view', user=subMods['janitors'][janitor])}">@{subMods['janitors'][janitor]}</a></li>
   @end
   </ul>
-  @if config.site.enable_modmail and current_user.is_authenticated and not current_user.is_subban(sub) and not (current_user.uid in (subMods['all'])):
+  @if config.site.enable_modmail and current_user.is_authenticated and not (current_user.uid in (subMods['all'])):
   <a href="/@{config.site.sub_prefix}/@{sub['name']}/contact_mods" class="sbm-post pure-button">@{_('Message the Mods')}</a>
   @endif
 

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -98,7 +98,7 @@
   @end
   </ul>
   @if config.site.enable_modmail and current_user.is_authenticated and not current_user.is_subban(sub) and not (current_user.uid in (subMods['all'])):
-  <a href="/s/@{sub['name']}/contact_mods" class="sbm-post pure-button">@{_('Message the Mods')}</a>
+  <a href="/@{config.site.sub_prefix}/@{sub['name']}/contact_mods" class="sbm-post pure-button">@{_('Message the Mods')}</a>
   @endif
 
 </div>

--- a/app/html/user/profile.html
+++ b/app/html/user/profile.html
@@ -9,11 +9,11 @@
 
     @if user.status != 10:
         @include('shared/sidebar/user.html')
-        @if current_user.is_authenticated and current_user.uid != user.uid: 
-            @if target_user_is_admin or current_user.can_pm_users() or current_user.is_admin():
+        @if current_user.is_authenticated and current_user.uid != user.uid:
+            @if target_user_is_admin or len(owns + mods) > 0 or current_user.can_pm_users() or current_user.is_admin():
                 <hr>
                 <div class="pmessage">
-                    <a href="#msg-form" data-replyto='@{user.name}' class="formpopmsg sbm-post pure-button">@{_('Send a message')}</a>
+                    <a href="#msg-form" data-replyto='@{user.name}' class="@{'modpopmsg' if config.site.enable_modmail and len(owns + mods) > 0 else 'formpopmsg'} sbm-post pure-button">@{_('Send a message')}</a>
                 </div>
             @end
             @if not target_user_is_admin and not current_user.can_admin:
@@ -144,6 +144,26 @@
                         </div>
                     @end
                 </div>
+
+                @if config.site.enable_modmail and len(owns + mods) > 0:
+                <div id="modpop" style="display:none;">
+                    <div class="modal-content">
+                        <span class="closepopmsg">&times;</span>
+                        <h3>@{_('Send a message')}</h3>
+                        <p>@{_('Please send all sub-related messages to the moderators of that sub.')}</p>
+                        <div>
+                            <ul>
+                                @for mod in sorted(owns + mods, key=str.lower):
+                                    <li><a href="/@{config.site.sub_prefix}/@{mod}/contact_mods">@{_('Contact the mods of %(mod)s', mod=mod)}</a></li>
+                                @end
+                                @if target_user_is_admin or current_user.can_pm_users() or current_user.is_admin():
+                                    <li><a href="#msg-form" class="formpopmsg" data-replyto="@{user.name}">@{_('Send a private message to %(name)s', name=user.name)}</a></li>
+                                @end
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                @end
 
                 <div id="formpop" style="display:none;">
                     <div class="modal-content">

--- a/app/misc.py
+++ b/app/misc.py
@@ -220,14 +220,8 @@ class SiteUser(object):
     @cache.memoize(1)
     def mod_notifications(self):
         if self.is_mod:
-            notification_counts = get_mod_notification_counts(self.uid)
-
-            counts = defaultdict(int)
-            for count in notification_counts:
-                for item in count:
-                    counts[item["sid"]] += item["count"]
-
-            return [[sid, count] for sid, count in counts.items()]
+            reports, comments, messages = get_mod_notification_counts(self.uid)
+            return {"reports": reports, "comments": comments, "messages": messages}
         else:
             return []
 
@@ -1326,16 +1320,15 @@ def get_locale_fallback():
 
 
 def get_modmail_count(uid):
-    counts = get_mod_notification_counts(uid)
-    result = 0
-    for count in counts:
-        for item in count:
-            result += item["count"]
-    return result
+    _, _, messages = get_mod_notification_counts(uid)
+    return messages
 
 
 def get_mod_notification_counts(uid):
-    post_report_counts = list(
+    def dictify(result):
+        return {r["sid"]: r["count"] for r in result}
+
+    post_report_counts = dictify(
         SubPostReport.select(Sub.sid, fn.COUNT(SubPostReport.id).alias("count"))
         .join(SubPost)
         .join(Sub)
@@ -1344,7 +1337,7 @@ def get_mod_notification_counts(uid):
         .group_by(Sub.sid)
         .dicts()
     )
-    comment_report_counts = list(
+    comment_report_counts = dictify(
         SubPostCommentReport.select(
             Sub.sid, fn.COUNT(SubPostCommentReport.id).alias("count")
         )
@@ -1378,7 +1371,7 @@ def get_mod_notification_counts(uid):
         )
         .group_by(conversation.c.convo_mid)
     )
-    unread_modmail_counts = list(
+    unread_modmail_counts = dictify(
         Message.select(Sub.sid, fn.COUNT(Message.mid).alias("count"))
         .join(Sub)
         .join(SubMod)
@@ -1811,7 +1804,7 @@ def notify_mods(sid):
     for mod in mods:
         socketio.emit(
             "mod-notification",
-            {"update": [sid, mod.reports + mod.comments]},
+            {"update": [sid, mod.reports, mod.comments]},
             namespace="/snt",
             room="user" + mod.uid,
         )
@@ -2001,14 +1994,14 @@ def create_message(mfrom, to, subject, content, mtype):
         mtype=mtype,
     )
     UserUnreadMessage.create(uid=to, mid=msg.mid)
+    UserMessageMailbox.create(uid=to, mid=msg.mid, mailbox=MessageMailbox.INBOX)
+    UserMessageMailbox.create(uid=mfrom, mid=msg.mid, mailbox=MessageMailbox.SENT)
     socketio.emit(
         "notification",
         {"count": get_notification_count(to)},
         namespace="/snt",
         room="user" + to,
     )
-    UserMessageMailbox.create(uid=to, mid=msg.mid, mailbox=MessageMailbox.INBOX)
-    UserMessageMailbox.create(uid=mfrom, mid=msg.mid, mailbox=MessageMailbox.SENT)
     return msg
 
 
@@ -2042,14 +2035,14 @@ def create_message_reply(message, content):
 
     if message.sub is None:
         UserUnreadMessage.create(uid=recipient, mid=msg.mid)
+        UserMessageMailbox.create(
+            uid=recipient, mid=msg.mid, mailbox=MessageMailbox.INBOX
+        )
         socketio.emit(
             "notification",
             {"count": get_notification_count(recipient)},
             namespace="/snt",
             room="user" + recipient,
-        )
-        UserMessageMailbox.create(
-            uid=recipient, mid=msg.mid, mailbox=MessageMailbox.INBOX
         )
     else:
         for mod_uid in getSubMods(message.sub)["all"]:

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1607,7 +1607,7 @@ form#msg-form {
   background-color: rgba(244, 194, 10, 0.35);
 }
 
-#formpop, #blockpop {
+#modpop, #formpop, #blockpop {
   position: fixed;
   z-index: 100;
   padding-top: 108px;
@@ -1620,7 +1620,7 @@ form#msg-form {
   background-color: rgba(0, 0, 0, 0.4);
 }
 
-#formpop .modal-content, #blockpop .modal-content {
+#formpop .modal-content, #modpop .modal-content, #blockpop .modal-content {
   background-color: #fefefe;
   margin: auto;
   padding: 20px;

--- a/app/static/js/Messages.js
+++ b/app/static/js/Messages.js
@@ -83,11 +83,21 @@ u.sub('.pmessage .replymsg', 'click', function(e){
   modal.style.display = "block";
 });
 
-u.sub('.pmessage .formpopmsg', 'click', function(e){
+u.sub('.pmessage .formpopmsg, #modpop .formpopmsg', 'click', function(e){
   e.preventDefault();
   var replyto = this.getAttribute('data-replyto')
   document.querySelector('#msg-form #to').setAttribute('value', replyto);
   var modal = document.getElementById('formpop');
+  modal.style.display = "block";
+  var modmodal = document.getElementById('modpop');
+  if (modmodal) {
+    modmodal.style.display = "none";
+  }
+});
+
+u.sub('.pmessage .modpopmsg', 'click', function(e){
+  e.preventDefault();
+  var modal = document.getElementById('modpop');
   modal.style.display = "block";
 });
 

--- a/app/static/js/Socket.js
+++ b/app/static/js/Socket.js
@@ -37,8 +37,10 @@ function updateModNotifications(notifications) {
   const modElem = document.getElementById('modcount');
   if (modElem) {
     let sum = 0;
-    for (let i=0; i < notifications.length; i++) {
-      sum = sum + notifications[i][1];
+    for (let m in notifications) {
+      for (let s in notifications[m]) {
+        sum += notifications[m][s];
+      }
     }
     if (sum == 0) {
       modElem.innerHTML = '';
@@ -144,20 +146,17 @@ u.ready(function () {
 
 socket.on('notification', function(d){
   updateNotifications(d.count.messages + d.count.notifications);
+  for (let sub in d.modmail) {
+    modData["messages"][sub] = d.modmail[sub];
+  }
+  updateModNotifications();
   updateTitleNotifications();
 });
 
 socket.on('mod-notification', function(d) {
-  var found = false;
-  for (var i=0; i < modData.length; i++) {
-    if (modData[i][0] == d.update[0]) {
-      modData[i][1] = d.update[1];
-      found = true;
-    }
-  }
-  if (!found){
-    modData.push(d.update);
-  }
+  const sub = d.update[0];
+  modData["reports"][sub] = d.update[1];
+  modData["comments"][sub] = d.update[2];
   updateModNotifications(modData);
   updateTitleNotifications();
 })

--- a/app/views/do.py
+++ b/app/views/do.py
@@ -1998,7 +1998,12 @@ def delete_pm(mid):
             (UserMessageMailbox.uid == current_user.uid)
             & (UserMessageMailbox.mid == mid)
         ).execute()
-
+        socketio.emit(
+            "notification",
+            {"count": misc.get_notification_count(current_user.uid)},
+            namespace="/snt",
+            room="user" + current_user.uid,
+        )
         return jsonify(status="ok")
     except Message.DoesNotExist:
         return jsonify(status="error", error=_("Message does not exist"))

--- a/migrations/036_modmail.py
+++ b/migrations/036_modmail.py
@@ -1,0 +1,85 @@
+"""Peewee migrations -- 036_modmail.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import datetime as dt
+from enum import IntEnum
+import peewee as pw
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+class MessageMailbox(IntEnum):
+    """Mailboxes for private messages."""
+
+    INBOX = 200
+    SENT = 201
+    SAVED = 202
+    ARCHIVED = 203  # Modmail only.
+    TRASH = 204
+    DELETED = 205
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    """Write your migrations here."""
+    Message = migrator.orm["message"]
+    User = migrator.orm["user"]
+    SiteMetadata = migrator.orm["site_metadata"]
+
+    @migrator.create_model
+    class SubMessageMailbox(pw.Model):
+        mid = pw.ForeignKeyField(db_column="mid", model=Message, field="mid")
+        mailbox = pw.IntegerField(default=MessageMailbox.INBOX)
+
+        class Meta:
+            table_name = "sub_message_mailbox"
+
+    @migrator.create_model
+    class SubMessageLog(pw.Model):
+        mid = pw.ForeignKeyField(db_column="mid", model=Message, field="mid")
+        uid = pw.ForeignKeyField(db_column="uid", model=User, field="uid")
+        mailbox = pw.IntegerField()
+        updated = pw.DateTimeField(default=dt.datetime.now)
+
+        class Meta:
+            table_name = "sub_message_log"
+
+    if not fake:
+        try:
+            SiteMetadata.get(SiteMetadata.key == "site.enable_modmail")
+        except SiteMetadata.DoesNotExist:
+            SiteMetadata.create(key="site.enable_modmail", value="0")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    """Write your rollback migrations here."""
+    migrator.remove_model("sub_message_mailbox")
+    migrator.remove_model("sub_message_log")
+
+    if not fake:
+        SiteMetadata = migrator.orm["site_metadata"]
+        SiteMetadata.delete().where(SiteMetadata.key == "site.enable_modmail").execute()


### PR DESCRIPTION
Add a new option to the admin Site Configuration page to enable or disable moderator mail, defaulting to disabled.  This option enables a "Contact the Mods" button on the sidebar of each sub, and a modal on the profile page of users who moderate subs, which gives people wanting to send a message to a mod the choice of sending a moderator mail or a normal private message.  It also turns on or off inclusion of moderator mail counts in the moderation notification count for moderators.

Include a few bug fixes for notifications, where sent or deleted messages would not be immediately reflected on the menu icons, and where the moderator report counts could cancel out the moderator mail counts.

The page that Contact the Mods links to, and the pages which moderators use to read and reply to moderator mail, are not implemented here.  For an implementation using a separate server which shares the Throat database (Postgres only), see https://gitlab.com/happyriver/throat-reframed.