### PR TITLE
Connect socketio messaging to Redis publish/subscribe

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -87,6 +87,7 @@ def create_app(config=None):
     babel.init_app(app)
     jwt.init_app(app)
     webpack.init_app(app)
+    rconn.init_app(app)
     socketio.init_app(
         app,
         message_queue=config.app.redis_url,
@@ -95,7 +96,6 @@ def create_app(config=None):
     )
     caching.cache.init_app(app)
     login_manager.init_app(app)
-    rconn.init_app(app)
     db_init_app(app)
     re_amention.init_app(app)
     if "MAIL_SERVER" in app.config:

--- a/app/socketio.py
+++ b/app/socketio.py
@@ -2,21 +2,45 @@ from flask_socketio import SocketIO, join_room
 from flask_login import current_user
 from flask_jwt_extended import decode_token
 from flask_jwt_extended.utils import verify_token_claims, UserClaimsVerificationError
-from flask import request, current_app
+from flask import request
 from .models import rconn
 from . import misc
+import gevent
+from gevent import monkey
 import json
+import random
+import re
 from wheezy.html.utils import escape_html
 import logging
 
+# Time in seconds for the expiration of the Redis keys used to decide
+# which instance should do the socketio.emit for messages received via
+# Redis subscription.  This should be somewhere in between the longest
+# time the gevent loop might get blocked and the acceptable time for
+# messages to not get delivered if the instance that was doing the
+# emitting goes down.
+NAME_KEY_KEEPALIVE = 1
+
 
 class SocketIOWithLogging(SocketIO):
-    @property
-    def __logger(self):
-        return logging.getLogger(current_app.logger.name + ".socketio")
+    def init_app(self, app, **kwargs):
+        super(SocketIOWithLogging, self).init_app(app, **kwargs)
+        self.__logger = logging.getLogger(app.logger.name + ".socketio")
+        if monkey.is_module_patched("os"):
+            self.instance_name_prefix = "throat-socketio-instance-name-"
+            self.instance_name = self.instance_name_prefix + "".join(
+                [chr(random.randrange(0, 26) + ord("a")) for i in range(6)]
+            )
+            gevent.spawn(self.refresh_name_key)
+            gevent.spawn(self.emit_messages)
 
     def emit(self, event, *args, **kwargs):
         self.__logger.debug("EMIT %s %s %s", event, args[0], kwargs)
+        if "room" in kwargs:
+            rconn.publish(
+                kwargs["namespace"] + ":" + event + ":" + str(kwargs["room"]),
+                json.dumps(args[0]),
+            )
         super(SocketIOWithLogging, self).emit(event, *args, **kwargs)
 
     def on(self, message, namespace=None):
@@ -28,6 +52,45 @@ class SocketIOWithLogging(SocketIO):
             return super(SocketIOWithLogging, self).on(message, namespace)(func)
 
         return decorator
+
+    def refresh_name_key(self):
+        """Keep a key set to expire in a few seconds alive on Redis."""
+        while True:
+            rconn.setex(
+                name=self.instance_name,
+                value="true",
+                time=NAME_KEY_KEEPALIVE,
+            )
+            gevent.sleep(NAME_KEY_KEEPALIVE * 0.9)
+
+    def emitting_instance(self):
+        """Return True if this is the first instance in alphabetical order by
+        instance name."""
+        keys = rconn.keys(self.instance_name_prefix + "*")
+        names = sorted([k.decode("utf-8") for k in keys])
+        return len(names) == 0 or names[0] == self.instance_name
+
+    def emit_messages(self):
+        """Emit SocketIO events for messages from Redis."""
+        pubsub = rconn.pubsub(ignore_subscribe_messages=True)
+        pubsub.psubscribe("/send:*")
+        for message in pubsub.listen():
+            if self.emitting_instance():
+                self.__logger.debug("PSUB %s", message)
+                if message["type"] == "pmessage":
+                    match = re.match(
+                        r"/send:(.+?):(.+)", message["channel"].decode("utf-8")
+                    )
+                    if match:
+                        try:
+                            data = json.loads(message["data"])
+                            self.emit(match[1], data, room=match[2], namespace="/snt")
+                        except json.JSONDecodeError:
+                            self.__logger.error(
+                                "Failed to decode message on channel %s: %s",
+                                message["channel"],
+                                message["data"],
+                            )
 
 
 socketio = SocketIOWithLogging()


### PR DESCRIPTION
Allow an external process to receive notifications of events and to send notifications to users who have active websocket connections, using Redis.

Publish all messages sent via `socketio.emit` to Redis, using keys of the form `{namespace}:{event}:{room}` and encoding the payload with JSON.  Subscribe to keys on Redis of the form `/send:{event}:{room}`, and when a message is received decode the payload from JSON and send it out in the `/snt` namespace using `socketio.emit`, as well as republishing it on Redis as `/snt:{event}:{room}`.

The emitting and republishing uses a greenlet task so is only done if the server is running under `gevent`.  Since there may be more than one such server process, have another greenlet task maintain a key on Redis with a short expiration time, and use those keys to determine which process will do the work.