### PR TITLE
Improve user and admin upload pages

### DIFF
--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -518,6 +518,11 @@ body.dark .poll-space.deleted {
   border: 1px solid red;
 }
 
+body.dark .uploaditem.deleted {
+  background-color: #171717;
+  border: 1px solid red;
+}
+
 body.dark .deleted-user {
   background-color: #171717;
   border: 1px solid red;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -2493,6 +2493,10 @@ article.text-post.comment.deleted {
   background-color: #FDD8D4;
 }
 
+.uploaditem.deleted {
+  background-color: #FDD8D4;
+}
+
 .post-history-controls {
   margin: 1em 1em 0 1em;
 }

--- a/app/templates/admin/uploads.html
+++ b/app/templates/admin/uploads.html
@@ -43,7 +43,7 @@
   {% if page > 1 %}
     <a href="{{url_for('admin.user_uploads', page=(page-1))}}" class="pure-button">prev</a>
   {% endif %}
-  {% if uploads|length == 30 %}
+  {% if uploads|length == 60 %}
     <a href="{{url_for('admin.user_uploads', page=(page+1))}}" class="pure-button">next</a>
   {% endif %}
 </div>

--- a/app/templates/admin/uploads.html
+++ b/app/templates/admin/uploads.html
@@ -4,11 +4,13 @@
 {% block sidebar %}
 {{ super() }}
   {% include 'admin/sidebar.html' %}
-  <hr>
-  <h3 class="center">Allowed to upload</h3>
-  {% for user in users %}
-    <div>• {{user.name}}</div>
-  {% endfor %}
+  {% if users %}
+    <hr>
+    <h3 class="center">Allowed to upload</h3>
+    {% for user in users %}
+      <div>• {{user.name}}</div>
+    {% endfor %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -17,7 +19,7 @@
 <div id="center-container">
   <div class="uploads content">
       {% for item in uploads %}
-        <div class="uploaditem">
+        <div class="uploaditem {{'deleted' if item.deleted != 0 else '' }}">
           <div class="uploadthumb">
             {% if item.thumbnail == '' %}
               <span class="placeholder" data-icon="link"></span>
@@ -39,10 +41,10 @@
 </div>
 <div class="col-12">
   {% if page > 1 %}
-  <a href="{{url_for('admin.user_uploads', page=(page-1))}}" class="pure-button">prev</a>
+    <a href="{{url_for('admin.user_uploads', page=(page-1))}}" class="pure-button">prev</a>
   {% endif %}
-  {% if subs|length == 30 %}
-  <a href="{{url_for('admin.user_uploads', page=(page+1))}}" class="pure-button">next</a>
+  {% if uploads|length == 30 %}
+    <a href="{{url_for('admin.user_uploads', page=(page+1))}}" class="pure-button">next</a>
   {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/uploads.html
+++ b/app/templates/uploads.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {{ super() }}
-{% if not uploads %}<h3 class="noshit">There are no uploads, yet.</h3>{% endif %}
+{% if not uploads %}<h3 class="noshit">You haven't uploaded anything, yet.</h3>{% endif %}
 <div id="center-container">
   <div class="uploads content">
       {% for item in uploads %}
@@ -38,10 +38,10 @@
 </div>
 <div class="col-12">
   {% if page > 1 %}
-  <a href="{{url_for('user.view_user_uploads', page=(page-1))}}" class="pure-button">prev</a>
+    <a href="{{url_for('user.view_user_uploads', page=(page-1))}}" class="pure-button">prev</a>
   {% endif %}
-  {% if subs|length == 30 %}
-  <a href="{{url_for('user.view_user_uploads', page=(page+1))}}" class="pure-button">next</a>
+  {% if uploads|length == 30 %}
+    <a href="{{url_for('user.view_user_uploads', page=(page+1))}}" class="pure-button">next</a>
   {% endif %}
 </div>
 {% endblock %}

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -719,7 +719,19 @@ def user_uploads(page):
     """ View user uploads """
     if not current_user.is_admin():
         abort(404)
-    uploads = UserUploads.select().order_by(UserUploads.pid.desc()).paginate(page, 30)
+    uploads = (
+        UserUploads.select(
+            UserUploads.thumbnail,
+            UserUploads.xid,
+            UserUploads.pid,
+            UserUploads.fileid,
+            SubPost.deleted,
+        )
+        .join(SubPost)
+        .order_by(UserUploads.pid.desc())
+        .paginate(page, 30)
+        .dicts()
+    )
     users = (
         User.select(User.name).join(UserMetadata).where(UserMetadata.key == "canupload")
     )

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -729,7 +729,7 @@ def user_uploads(page):
         )
         .join(SubPost)
         .order_by(UserUploads.pid.desc())
-        .paginate(page, 30)
+        .paginate(page, 60)
         .dicts()
     )
     users = (

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -262,7 +262,8 @@ def view_user_uploads(page):
     """ View user uploads """
     uploads = (
         UserUploads.select()
-        .where(UserUploads.uid == current_user.uid)
+        .join(SubPost)
+        .where((UserUploads.uid == current_user.uid) & (SubPost.deleted != 1))
         .paginate(page, 30)
     )
     return render_template("uploads.html", page=page, uploads=uploads)


### PR DESCRIPTION
Don't show users content that they deleted on their uploads page.

Change the user uploads page to say "You haven't uploaded anything yet" instead of "There are no uploads yet" if there are no uploads to show.

Change the admin uploads page to show 60 items per page instead of 30, and to show a red background for uploads from deleted posts.

Fix the bug on both the user and admin upload pages that was stopping the Next page button from displaying.

Resolves #306.