### PR TITLE
Log execution times of template rendering and SQL queries

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -226,12 +226,13 @@ logging:
     socketio.server:
       level: WARNING
     peewee:
-      handlers:
-        - console
-    flask.app:
-      level: DEBUG
-    flask.app.socketio:
       level: WARNING
+    app:
+      level: DEBUG
+    app.socketio:
+      level: WARNING
+    app.sql_timing:      # Logs SQL like the peewee logger, but with execution timing.
+      level: DEBUG
     flask-limiter:
       level: WARNING
       handlers:


### PR DESCRIPTION
Log the time it takes to render each template.  Add a new logger, `app.sql_timing`, which logs SQL queries like peewee's logger does with the addition of the execution time of the SQL query.