### PR TITLE
Fix disappearing mod notifications

### DIFF
--- a/app/static/js/Socket.js
+++ b/app/static/js/Socket.js
@@ -149,7 +149,7 @@ socket.on('notification', function(d){
   for (let sub in d.modmail) {
     modData["messages"][sub] = d.modmail[sub];
   }
-  updateModNotifications();
+  updateModNotifications(modData);
   updateTitleNotifications();
 });
 


### PR DESCRIPTION
Fix a regression from #421 which causes the count of open reports to disappear from a moderator's shield icon when the moderator receives a new private message.