### PR TITLE
Make modmail notifications show the number received from socketio

### DIFF
--- a/app/static/js/Socket.js
+++ b/app/static/js/Socket.js
@@ -146,8 +146,8 @@ u.ready(function () {
 
 socket.on('notification', function(d){
   updateNotifications(d.count.messages + d.count.notifications);
-  for (let sub in d.modmail) {
-    modData["messages"][sub] = d.modmail[sub];
+  for (let sub in d.count.modmail) {
+    modData["messages"][sub] = d.count.modmail[sub];
   }
   updateModNotifications(modData);
   updateTitleNotifications();


### PR DESCRIPTION
Fix a regression from #421 that caused the number of moderator notifications on the shield icon to not update when a new count is received.