### PR TITLE
Add an admin config option to show or hide votes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -403,6 +403,14 @@ configurable_defaults = {
                     },
                 },
             },
+            "show_votes": {
+                "type": "bool",
+                "doc": _l(
+                    "If enabled, show upvotes and downvotes in addition to total score. "
+                    "Otherwise, only show upvotes and downloads to admins and mods in their own subs."
+                ),
+                "value": True,
+            },
         },
     },
     "storage": {

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -55,7 +55,11 @@
     @if post['edited']:
       @{_('edited %(timeago)s', timeago='<time-ago datetime="' + post['edited'].isoformat() + 'Z"></time-ago>')!!html}<br/>
     @end
-    @{_('Score: %(score)i <b>(+%(upvotes)i|-%(downvotes)i)</b>', score=post['score'], upvotes=post['upvotes'], downvotes=post['downvotes'])!!html}
+    @if config.site.show_votes or current_user.is_admin() or current_user.uid in subMods['all']:
+      @{_('Score: %(score)i <b>(+%(upvotes)i|-%(downvotes)i)</b>', score=post['score'], upvotes=post['upvotes'], downvotes=post['downvotes'])!!html}
+    @else:
+      @{_('Score: %(score)i', score=post['score'])!!html}
+    @endif
   </div>
 <hr>
   @include('shared/sidebar/sub.html')

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -40,7 +40,11 @@
                   <span class="helper-text">@{_('[Blocked]')}</span>
                 @end
               @end
-              <b>@{_('<span class="cscore">%(score)i</span> points</b> (+<b>%(upvotes)i</b>|-<b>%(downvotes)i</b>)', score=comment['score'], upvotes=comment['upvotes'], downvotes=comment['downvotes'])!!html}
+              @if config.site.show_votes or current_user.is_admin() or current_user.uid in subMods['all']:
+                <b>@{_('<span class="cscore">%(score)i</span> points</b> (+<b>%(upvotes)i</b>|-<b>%(downvotes)i</b>)', score=comment['score'], upvotes=comment['upvotes'], downvotes=comment['downvotes'])!!html}
+              @else:
+                <b>@{_('<span class="cscore">%(score)i</span> points</b>', score=comment['score'])!!html}
+              @endif
               <span class="time ">
                   <time-ago datetime="@{comment['time'].isoformat()}Z"></time-ago>
               </span>

--- a/migrations/038_show_votes.py
+++ b/migrations/038_show_votes.py
@@ -1,0 +1,22 @@
+"""Peewee migrations -- 038_show_votes.
+
+Add a admin site configuration option to control whether the counts of
+upvotes and downvotes on a post or comment are visible to users.
+
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.create(key="site.show_votes", value="1")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(SiteMetadata.key == "site.show_votes").execute()


### PR DESCRIPTION
Allow an admin who is tired of repeated complaints from users about being downvoted to make the issue go away with a new admin configuration option that controls whether a post or comment is shown with its upvote and downvote numbers, or just the total score. When the new option `site.show_votes` is disabled, only admins and mods looking at their own subs will be able to see the vote breakdown, and everyone else will see the total score.