### PR TITLE
Fixing YouTube & Twitter thumbs/title fetching

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -239,7 +239,8 @@ def safe_request(
             url,
             stream=True,
             timeout=receive_timeout,
-            headers={"User-Agent": "Throat/1 (Phuks)"},
+            headers={"User-Agent": "Yahoo! Slurp/Site Explorer"},
+            cookies={"CONSENT": "YES+"},
         )
     except:  # noqa
         raise ValueError("error fetching")


### PR DESCRIPTION
COOKIES part is Bypassing YouTube's GDPR consent page (only useful for EU-based Throat installations). User Agent change, although unfortunate, fixes fetching of titles and thumbs for Twitter posts (useful for everyone I believe).