### PR TITLE
Fix bug in loading more comments when sort is set to new

### DIFF
--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -131,7 +131,7 @@
         </div>
         <div id="child-@{comment['cid']}" class="pchild@{(comment['visibility'] != '') and ' hidden' or ''}">
           @if comment['children']:
-            @{renderComments(post, postmeta, subInfo, subMods, comment['children'], highlight)!!html}
+            @{renderComments(post, postmeta, subInfo, subMods, comment['children'], highlight, sort)!!html}
           @end
         </div>
       </article>
@@ -147,4 +147,4 @@
   @end
 @end
 
-@{renderComments(post, postmeta, subInfo, subMods, comments, highlight)!!html}
+@{renderComments(post, postmeta, subInfo, subMods, comments, highlight, sort)!!html}


### PR DESCRIPTION
To reproduce this bug, make a post and add over twenty comments, with a number in each one so you can tell in which order you entered them.  Log in as a different user and upvote a few of the oldest ones.  Then scroll to the top and set the sort order to "new", and scroll down.  After you scroll past the oldest comment, some of the newer ones will repeat below it.

Fix by passing the sort order parameter in all the calls to `renderComments`.