### PR TITLE
Allow mods to reapprove posts and comments they have deleted

### DIFF
--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -139,8 +139,10 @@ Mod |\
                 <div class="preview-text">
                   <div class="postinfo" id="postinfo" pid="@{report['pid']!!s}">
                     @if post['deleted'] != 1 or current_user.is_admin():
-                      @if post['deleted'] == 2:
-                        <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
+                      @if post['deleted'] == 3:
+                        <p class="helper-text">@{_('[post deleted by admin]')}</p>
+                      @elif post['deleted'] == 2:
+                        <p class="helper-text">@{_('[post deleted by mod]')}</p>
                       @elif post['deleted'] == 1:
                         <p class="helper-text">@{_('[post deleted by user]')}</p>
                       @end

--- a/app/html/mod/reportdetails.html
+++ b/app/html/mod/reportdetails.html
@@ -164,12 +164,14 @@ Mod |\
 
             @else:
             <h3>@{_('Comment Preview:')}</h3>
-              <div class="preview-text-container @{((comment['status'] == 1) or (comment['status'] == 2)) and 'deleted ' or ''}">
+              <div class="preview-text-container @{(comment['status'] in [1, 2, 3]) and 'deleted ' or ''}">
                 <div class="preview-text">
                   @if comment['status'] != 1:
                     @if comment['status'] == 2:
-                      <p class="helper=text">@{_('[comment deleted by mod or admin]')}</p>
-                    @end
+                      <p class="helper=text">@{_('[comment deleted by mod]')}</p>
+                    @elif comment['status'] == 3:
+                      <p class="helper=text">@{_('[comment deleted by admin]')}</p>
+		    @end
                     <div id="commentcontent">@{comment['content']}</div>
                   @elif current_user.is_admin():
                     <p class="helper=text">@{_('[comment deleted by user]')}</p>
@@ -199,7 +201,7 @@ Mod |\
                   </div>
                   <div class="pure-u-1-2 pure-u-md-1-6">
                     @if report['type'] == 'comment':
-                      @if (comment['status'] != 1) and (comment['status'] != 2):
+                      @if (comment['status'] not in [1, 2, 3]):
                         <button class="pure-button pure-button-primary button-small btn-editpost delete-comment" data-cid="@{report['cid']}">
                           @{_('Delete Comment')}
                         </button>

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -19,7 +19,7 @@
 
 @def meta_description():
 
-    @if post['content']:
+    @if post['content'] and post['deleted'] == 0:
         <meta name="description" content="@{func.word_truncate(''.join(BeautifulSoup(markdown(post['content']), features='lxml').findAll(text=True)).replace('\n', ' '), 250)}"/>
     @else:
         <meta name="description" content="@{sub['title']}" />
@@ -111,12 +111,12 @@
             <a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
               @if (post['visibility'] == ''):
                 <span class="@{post['blur']}">@{post['title']}</span>
-              @elif (post['visibility'] == 'admin-self-del') or (post['visibility'] == 'user-self-del'):
+              @elif post['visibility'] in ['admin-self-del', 'mod-self-del', 'user-self-del']:
                 @{_('[Deleted by User]')} <span class="@{post['blur']}">@{post['title']}</span>
-              @elif (post['visibility'] == 'mod-self-del'):
-                @{_('[Deleted by User]')}
-              @elif (post['visibility'] == 'mod-del'):
-                @{_('[Deleted by Mod or Admin]')} <span class="@{post['blur']}">@{post['title']}</span>
+              @elif (post['visibility'] in ['mod-del', 'user-mod-del']):
+                @{_('[Deleted by Mod]')} <span class="@{post['blur']}">@{post['title']}</span>
+              @elif (post['visibility'] == 'admin-del'):
+                @{_('[Deleted by Admin]')} <span class="@{post['blur']}">@{post['title']}</span>
               @elif (post['visibility'] == 'none'):
                 @{_('[Deleted]')}
               @end
@@ -130,12 +130,12 @@
             <a rel="noopener nofollow ugc" href="@{((post['visibility'] != 'none') and post['link']) or '#'}" target="@{((post['visibility'] != 'none') and '_blank') or '_self'}" class="title">
               @if (post['visibility'] == ''):
                 <span class="@{post['blur']}">@{post['title']}</span>
-              @elif (post['visibility'] == 'admin-self-del') or (post['visibility'] == 'user-self-del'):
+              @elif post['visibility'] in ['admin-self-del', 'mod-self-del', 'user-self-del']:
                 @{_('[Deleted by User]')} <span class="@{post['blur']}">@{post['title']}</span>
-              @elif (post['visibility'] == 'mod-self-del'):
-                @{_('[Deleted by User]')}
-              @elif (post['visibility'] == 'mod-del'):
-                @{_('[Deleted by Mod or Admin]')} <span class="@{post['blur']}">@{post['title']}</span>
+              @elif (post['visibility'] in ['mod-del', 'user-mod-del']):
+                @{_('[Deleted by Mod]')} <span class="@{post['blur']}">@{post['title']}</span>
+              @elif (post['visibility'] == 'admin-del'):
+                @{_('[Deleted by Admin]')} <span class="@{post['blur']}">@{post['title']}</span>
               @elif (post['visibility'] == 'none'):
                 @{_('[Deleted]')}
               @end
@@ -147,7 +147,7 @@
         @end
         </div>
 
-        @if title_history and (post['visibility'] != 'none' and  post['visibility'] != 'mod-self-del'):
+        @if title_history and post['visibility'] != 'none':
             @for count, old_title in enumerate(title_history):
               <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
                 @if post['link'] == None:
@@ -275,7 +275,7 @@
             <li><a class="post-open-reports" href="@{url_for('mod.report_details', sub=sub['name'], report_type='post', report_id=list(open_reports)[0]['id'])}">@{_('open reports (%(num)s)', num=len(open_reports))}</a></li>
           @end
         @end
-        @if current_user.is_admin() and post['deleted'] == 2:
+        @if (current_user.is_admin() and post['deleted'] in [2, 3]) or (current_user.uid in subMods['all'] and post['deleted'] == 2):
           <li id="delpostli"><a class="undelete-post"> @{_('un-delete')} </a></li>
         @end
         @if (current_user.uid == post['uid'] and (current_user.is_admin() or current_user.uid in subMods['all'])) and post['deleted'] == 0:
@@ -299,7 +299,7 @@
     </div>
   @end
 
-  @if (post['ptype'] == 3) and (post['deleted'] == 0 or post['visibility'] == 'admin-self-del' or post['visibility'] == 'mod-del' or post['visibility'] == 'user-self-del'):
+  @if (post['ptype'] == 3) and (post['deleted'] == 0 or post['visibility'] in ['admin-self-del', 'mod-self-del', 'mod-del', 'user-mod-del']):
     <span class="@{post['blur']}">@{polls.renderPoll(pollData, postmeta, post)!!html}</span>
   @end
   <div>
@@ -311,11 +311,11 @@
       </span>
       <div id="post-source">@{post['content']}</div>
     @else:
-      @if ((post['visibility'] == 'none') or (post['visibility'] == 'mod-self-del')):
-        <div id="postcontent" class="post-content-container @{(post['visibility'] == 'mod-self-del') and 'deleted ' or ''}">
+      @if post['visibility'] in ['none', 'user-self-del']:
+        <div id="postcontent" class="post-content-container @{(post['visibility'] == 'user-self-del') and 'deleted ' or ''}">
           @{_('[deleted]')}
         </div>
-      @elif ((post['visibility'] == 'admin-self-del') or (post['visibility'] == 'mod-del') or (post['visibility'] == 'user-self-del')):
+      @elif post['visibility'] in ['admin-self-del', 'mod-self-del', 'mod-del', 'admin-del', 'user-mod-del']:
         <span class="current history" data-id="0">
           <div id="postcontent" class="post-content-container deleted">@{markdown(post['content'])!!html}</div>
         </span>
@@ -328,7 +328,7 @@
     <div id="post-source" class="post-content-container"></div>
   @end
 
-  @if content_history and post['content'] and  (post['visibility'] != 'none' and  post['visibility'] != 'mod-self-del'):
+  @if content_history and post['content'] and  (post['visibility'] not in ['none', 'user-self-del']):
       @for count, old_version in enumerate(content_history):
         <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
           <div class="post-content-container @{(post['visibility'] != '') and 'deleted ' or ''}">@{markdown(old_version['content'])!!html}</div>

--- a/app/html/sub/postcomments.html
+++ b/app/html/sub/postcomments.html
@@ -59,23 +59,24 @@
               <br/>
             </div>
 
-            <div class="content  @{(comment['visibility'] != '' and comment['visibility'] != 'mod-del' ) and 'hidden' or ''}" id="content-@{comment['cid']}">
+            <div class="content  @{(comment['visibility'] != '' and comment['visibility'] != 'mod-del' and comment['visibility'] != 'admin-del') and 'hidden' or ''}" id="content-@{comment['cid']}">
               @if comment['visibility'] == 'none':
                 @{comment['user']} \
-              @elif comment['visibility'] == 'admin-self-del':
+              @elif comment['visibility'] in ['admin-self-del', 'mod-self-del']:
                 <p class="helper-text">@{_('[post deleted by user]')}</p>
                 <span class="current history" data-id="0">@{comment['content']!!html}</span>
-              @elif comment['visibility'] == 'mod-self-del':
-                <p class="helper-text">@{_('[post deleted by user]')}</p>
               @elif comment['visibility'] == 'mod-del':
-                <p class="helper-text">@{_('[post deleted by mod or admin]')}</p>
+                <p class="helper-text">@{_('[post deleted by mod]')}</p>
+                <span class="current history" data-id="0">@{comment['content']!!html}</span>
+              @elif comment['visibility'] == 'admin-del':
+                <p class="helper-text">@{_('[post deleted by admin]')}</p>
                 <span class="current history" data-id="0">@{comment['content']!!html}</span>
               @elif comment['visibility'] == 'hide-block' and comment['userstatus'] != 10:
                 <p class="helper-text">@{_('[You have blocked <a href="%(link)s">%(name)s</a>]', link=url_for('user.view', user=comment['blocked_user']), name=comment['blocked_user'])!!html}</p>
               @elif comment['visibility'] != 'hide-block':
                 <span class="current history" data-id="0">@{comment['content']!!html}</span>
               @end
-              @if comment['history'] and (comment['visibility'] != 'none' and  comment['visibility'] != 'mod-self-del'):
+              @if comment['history'] and comment['visibility'] != 'none':
                   @for count, history in enumerate(comment['history']):
                   <span style="display:none;" class="old history" data-id="@{(count + 1)!!s}">
                       @{history['content']!!html}
@@ -97,7 +98,7 @@
             @if comment['visibility'] != 'none':
               <div hidden id="sauce-@{comment['cid']}">@{comment['source']}</div>
             @end
-            <ul class="bottombar links @{(comment['visibility'] != '') and 'hidden' or ''}">
+            <ul class="bottombar links @{(comment['visibility'] not in ['', 'admin-del', 'mod-del']) and 'hidden' or ''}">
               @if comment['visibility'] in ['blur-block', 'hide-block'] and comment['userstatus'] != 10:
                 <li><a href="@{url_for('user.view_ignores', menu='user')}">@{_('blocked users')}</a></li>
               @end
@@ -117,7 +118,7 @@
               @if current_user.is_authenticated and comment['visibility'] == '' and (comment['uid'] == current_user.uid or current_user.is_admin() or current_user.uid in subMods['all']):
                 <li><a @{(comment['uid'] == current_user.uid) and 'selfdel="true"' or ''!!html} class="delete-comment" data-cid="@{comment['cid']}">@{_('delete')}</a></li>
               @end
-              @if (current_user.is_admin() and comment['status'] == 2):
+              @if ((current_user.is_admin() or current_user.uid in subMods['all']) and comment['status'] == 2) or (current_user.is_admin() and comment['status'] == 3):
                 <li><a class="undelete-comment" data-cid="@{comment['cid']}">@{_('un-delete')}</a></li>
               @end
               @if (current_user.uid == comment['uid'] and (current_user.is_admin() or current_user.uid in subMods['all'])):

--- a/app/misc.py
+++ b/app/misc.py
@@ -1142,7 +1142,7 @@ def postListQueryBase(
                 (SubPost.deleted == 0) | (Sub.sid << include_deleted_posts)
             )
         elif not current_user.is_admin():
-            posts = posts.where(SubPost.deleted << [0, 2])
+            posts = posts.where(SubPost.deleted << [0, 2, 3])
     else:
         posts = posts.where(SubPost.deleted == 0)
 

--- a/app/misc.py
+++ b/app/misc.py
@@ -2595,6 +2595,12 @@ def get_comment_tree(
                 else:
                     comm["user"] = _("[Deleted]")
                     comm.update(remove_content)
+            elif comm["status"] == 3:
+                if is_admin or is_mod:
+                    comm["visibility"] = "admin-del"
+                else:
+                    comm["user"] = _("[Deleted]")
+                    comm.update(remove_content)
 
         if comm["userstatus"] == 10:
             if not current_user.is_admin():

--- a/app/models.py
+++ b/app/models.py
@@ -367,9 +367,13 @@ class SubPostComment(BaseModel):
     score = IntegerField(null=True)
     upvotes = IntegerField(default=0)
     downvotes = IntegerField(default=0)
-    status = IntegerField(
-        null=True
-    )  # 1=self delete, 2=mod delete, 0 or null=not deleted
+
+    # status:
+    #   null or 0: Either not deleted, or reinstated.
+    #   1:         The user removed it themselves; still visible to mods, admins.
+    #   2:         A mod removed it; still visible to mods, admins and the user.
+    #   3:         An admin removed it; still visible to mods, admins and the user.
+    status = IntegerField(null=True)
     distinguish = IntegerField(null=True)  # 1=mod, 2=admin, 0 or null = normal
     time = DateTimeField(null=True)
     uid = ForeignKeyField(

--- a/app/models.py
+++ b/app/models.py
@@ -296,7 +296,9 @@ class SubMetadata(BaseModel):
 
 class SubPost(BaseModel):
     content = TextField(null=True)
-    deleted = IntegerField(default=0)  # 1=self delete, 2=mod delete, 0=not deleted
+    deleted = IntegerField(
+        default=0
+    )  # 1=self delete, 2=mod delete, 3=admin delete, 0=not deleted
     distinguish = IntegerField(null=True)  # 1=mod, 2=admin, 0 or null = normal
     link = CharField(null=True)
     nsfw = BooleanField(null=True)

--- a/app/templates/admin/post.html
+++ b/app/templates/admin/post.html
@@ -68,7 +68,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for comment in comms if not comment.status == 1 %}
+            {% for comment in comms if not comment.status %}
             <tr>
               <td>{{comment.score}}</td>
               <td>
@@ -93,7 +93,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for comment in comms if comment.status == 1 %}
+            {% for comment in comms if comment.status %}
             <tr>
               <td>{{comment.score}}</td>
               <td>

--- a/app/templates/admin/posts.html
+++ b/app/templates/admin/posts.html
@@ -55,7 +55,7 @@
                 <td><a href="{{url_for('site.view_post_inbox', pid=post.pid)}}">{{post.title|truncate(30, True)}}</a></td>
                 <td><a href="{{url_for('user.view', user=post.user)}}">{{post.user}}</a></td>
                 <td><a href="{{url_for('sub.view_sub', sub=post.sub)}}">{{post.sub}}</a></td>
-                <td>{% if post.deleted == 1 %}user{% elif post.deleted == 2 %}admin{% endif %}</td>
+                <td>{% if post.deleted == 1 %}user{% elif post.deleted == 2 %}mod{% elif post.deleted == 3%}admin{% endif %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/app/templates/indexpost.html
+++ b/app/templates/indexpost.html
@@ -38,7 +38,7 @@
           <a href="{{url_for('sub.view_post', sub=post.sub, pid=post.pid)}}" class="title">
           {% if post.deleted == 1 %}
             {{_('[Deleted by User]')}}
-          {% elif post.deleted == 2 %}
+          {% elif post.deleted in [2, 3] %}
             {{_('[Deleted by Mod or Admin]')}}
           {% endif %}
           <span class="{{ post.blur }}">{{post.title}}</span>
@@ -48,7 +48,7 @@
           <a rel="noopener nofollow ugc" target="_blank" href="{{post.link}}" class="title">
             {% if post.deleted == 1 %}
               {{_('[Deleted by User]')}}
-            {% elif post.deleted == 2 %}
+            {% elif post.deleted in [2, 3] %}
               {{_('[Deleted by Mod or Admin]')}}
             {% endif %}
             <span class="{{ post.blur }}">{{post.title}}</span>

--- a/app/templates/usercomments.html
+++ b/app/templates/usercomments.html
@@ -38,7 +38,7 @@
                 <span class="title"><a href="{{ url_for('sub.view_post', sub=comment.sub, pid=comment.pid) }}">
                   {% if comment.status == 1 %}
                     {{_('[Deleted by User]')}}
-                  {% elif comment.status == 2 %}
+                  {% elif comment.status == 2 or comment.status == 3 %}
                     {{_('[Deleted by Mod or Admin]')}}
                   {% endif %}
                   <span class="{{comment.blur}}">{{comment.title}}</span>
@@ -70,13 +70,13 @@
                     <!-- TODO needs peewee <li><a href="{# url_for('sub.view_perm', sub=sub.name, cid=comment.cid, pid=post.pid) #}">permalink</a></li>-->
                     <li><a href="{{url_for('sub.view_perm', sub=comment.sub, pid=comment.pid, cid=comment.cid)}}">permalink</a></li>
                     {%if current_user.is_authenticated%}
-                      {%if not postmeta[comment.pid].get('lock-comments') and not comment.archived and comment.status not in [1, 2] and comment.post_deleted == 0%}
+                      {%if not postmeta[comment.pid].get('lock-comments') and not comment.archived and comment.status not in [1, 2, 3] and comment.post_deleted == 0%}
                         <li><a class="reply-comment" data-pid="{{comment.pid}}" data-to="{{comment.cid}}">reply</a></li>
                         {% if comment.uid == current_user.uid %}
                           <li><a class="edit-comment" data-cid="{{comment.cid}}">edit</a></li>
                         {% endif %}
                       {%endif%}
-                      {% if comment.uid == current_user.uid or current_user.is_admin() and comment.status not in [1, 2] %}
+                      {% if comment.uid == current_user.uid or current_user.is_admin() and comment.status not in [1, 2, 3] %}
                         <li><a {{ ((comment['uid'] == current_user.uid) and 'selfdel="true"' or '')|safe }} class="delete-comment" data-cid="{{comment.cid}}">delete</a></li>
                       {% endif %}
                     {%endif%}

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -584,13 +584,11 @@ def view_post(sub, pid, slug=None, comments=False, highlight=None):
             post["visibility"] = "mod-self-del"
         else:
             post["visibility"] = "none"
-    elif post["deleted"] == 2:
-        if (
-            current_user.is_admin()
-            or current_user.is_mod(sub["sid"], 1)
-            or current_user.uid == post["uid"]
-        ):
-            post["visibility"] = "mod-del"
+    elif post["deleted"] in [2, 3]:
+        if current_user.is_admin() or current_user.is_mod(sub["sid"], 1):
+            post["visibility"] = "mod-del" if post["deleted"] == 2 else "admin-del"
+        elif current_user.uid == post["uid"]:
+            post["visibility"] = "user-mod-del"
         else:
             post["visibility"] = "none"
 

--- a/test/views/test_moderation.py
+++ b/test/views/test_moderation.py
@@ -1,0 +1,252 @@
+import json
+import re
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from app.config import config
+from test.utilities import (
+    create_sub,
+    csrf_token,
+    log_in_user,
+    log_out_current_user,
+    promote_user_to_admin,
+    register_user,
+)
+
+
+def test_mod_comment_delete(client, user_info, user2_info, user3_info):
+    config.update_value("site.sub_creation_min_level", 0)
+    user, admin, mod = user_info, user2_info, user3_info
+    register_user(client, admin)
+    promote_user_to_admin(client, admin)
+    log_out_current_user(client)
+
+    register_user(client, mod)
+    create_sub(client)
+    log_out_current_user(client)
+
+    register_user(client, user)
+
+    # User makes a post.
+    rv = client.get(url_for("subs.submit", ptype="text", sub="test"))
+    csrf = csrf_token(rv.data)
+    data = {
+        "csrf_token": csrf,
+        "title": "the title",
+        "ptype": "text",
+        "content": "the content",
+    }
+    rv = client.post(
+        url_for("subs.submit", ptype="text", sub="test"),
+        data=data,
+        follow_redirects=False,
+    )
+    assert rv.status == "302 FOUND"
+    soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
+    link = soup.a.get_text()
+    pid = link.split("/")[-1]
+
+    # User adds some comments.
+    rv = client.get(link, follow_redirects=True)
+    assert b"the title |  test" in rv.data
+    cids = {}
+    comments = [
+        "delete_user",
+        "delete_admin",
+        "delete_then_undelete_by_admin",
+        "delete_mod",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]
+    for comment in comments:
+        data = {
+            "csrf_token": csrf,
+            "post": pid,
+            "parent": "0",
+            "comment": comment,
+        }
+        rv = client.post(
+            url_for("do.create_comment", pid=pid), data=data, follow_redirects=False
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "ok"
+        cids[comment] = reply["cid"]
+
+    # User reloads the page and can see all the comments.
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        assert comment in data
+    # Check for the css class on the bottombar delete links.
+    assert len(re.findall("[^n]delete-comment", data)) == len(comments)
+
+    rv = client.post(
+        url_for("do.delete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_user"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+
+    # User can no longer see deleted comment.
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        if comment == "delete_user":
+            assert comment not in data
+        else:
+            assert comment in data
+    log_out_current_user(client)
+
+    # Admin sees deleted comment content, and n-1 delete links.
+    log_in_user(client, admin)
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        assert comment in data
+    # Check for the css class on the bottombar delete links.
+    assert len(re.findall("[^n]delete-comment", data)) == len(comments) - 1
+    assert "undelete-comment" not in data
+
+    # Admin tries to remove user's deleted comment.
+    rv = client.post(
+        url_for("do.delete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_user"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "error"
+    assert reply["error"] == "Comment is already deleted"
+
+    # Admin removes two comments.
+    for comment in ["delete_admin", "delete_then_undelete_by_admin"]:
+        rv = client.post(
+            url_for("do.delete_comment"),
+            data={"csrf_token": csrf, "cid": cids[comment]},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "ok"
+
+    # Admin can still see all comment content and now has two undelete links.
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        assert comment in data
+    # Check for the css class on the bottombar delete links.
+    assert len(re.findall("undelete-comment", data)) == 2
+    assert len(re.findall("[^n]delete-comment", data)) == len(comments) - 3
+
+    # Admin undeletes a comment.
+    rv = client.post(
+        url_for("do.undelete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_then_undelete_by_admin"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    # Mod sees content of deleted and undeleted comments.
+    log_in_user(client, mod)
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        assert comment in data
+    # Mod should see delete links for undeleted comments.
+    assert len(re.findall("[^n]delete-comment", data)) == len(comments) - 2
+    assert len(re.findall("undelete-comment", data)) == 0
+
+    # Mod tries to remove already deleted comments.
+    for comment in ["delete_user", "delete_admin"]:
+        rv = client.post(
+            url_for("do.delete_comment"),
+            data={"csrf_token": csrf, "cid": cids[comment]},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "error"
+        assert reply["error"] == "Comment is already deleted"
+
+    # Mod tries to undelete comment deleted by admin.
+    rv = client.post(
+        url_for("do.undelete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_admin"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "error"
+    assert reply["error"] == "Not authorized"
+
+    # Mod removes some comments.
+    for comment in [
+        "delete_mod",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]:
+        rv = client.post(
+            url_for("do.delete_comment"),
+            data={"csrf_token": csrf, "cid": cids[comment]},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "ok"
+
+    # Mod sees content of all comments, and now has two undelete links.
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        assert comment in data
+    # Mod should see delete links for undeleted comments.
+    assert len(re.findall("[^n]delete-comment", data)) == len(comments) - 5
+    assert len(re.findall("undelete-comment", data)) == 3
+
+    # Mod undeletes a comment.
+    rv = client.post(
+        url_for("do.undelete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_then_undelete_by_mod"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    log_in_user(client, admin)
+    # Admin has undelete links for the content admin deleted as well as
+    # the content the mod deleted.
+    assert len(re.findall("undelete-comment", data)) == 3
+
+    # Admin can undelete a comment deleted by the mod.
+    rv = client.post(
+        url_for("do.undelete_comment"),
+        data={"csrf_token": csrf, "cid": cids["delete_undelete_by_mod_then_admin"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    log_in_user(client, user)
+    # User can see comments which are not deleted.
+    undeleted = [
+        "delete_then_undelete_by_admin",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]
+    rv = client.get(link, follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for comment in comments:
+        if comment in undeleted:
+            assert comment in data
+        else:
+            assert comment not in data
+
+    # User should see delete links for undeleted comments.
+    assert len(re.findall("[^n]delete-comment", data)) == len(undeleted)
+    assert len(re.findall("undelete-comment", data)) == 0
+
+    # User can't undelete any comment
+    for comment in comments:
+        rv = client.post(
+            url_for("do.undelete_comment"),
+            data={"csrf_token": csrf, "cid": cids[comment]},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "error"
+        if comment in undeleted:
+            assert reply["error"] == "Comment is not deleted"
+        elif comment == "delete_user":
+            assert reply["error"] == "Can not un-delete a self-deleted comment"
+        else:
+            assert reply["error"] == "Not authorized"

--- a/test/views/test_moderation.py
+++ b/test/views/test_moderation.py
@@ -14,6 +14,313 @@ from test.utilities import (
 )
 
 
+def test_mod_post_delete(client, user_info, user2_info, user3_info):
+    config.update_value("site.sub_creation_min_level", 0)
+    user, admin, mod = user_info, user2_info, user3_info
+    register_user(client, admin)
+    promote_user_to_admin(client, admin)
+    log_out_current_user(client)
+
+    register_user(client, mod)
+    create_sub(client)
+    log_out_current_user(client)
+
+    register_user(client, user)
+
+    # User makes several posts.
+    pids = {}
+    posts = [
+        "delete_user",
+        "delete_admin",
+        "delete_then_undelete_by_admin",
+        "delete_mod",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]
+    rv = client.get(url_for("subs.submit", ptype="text", sub="test"))
+    csrf = csrf_token(rv.data)
+    for post in posts:
+        rv = client.post(
+            url_for("subs.submit", ptype="text", sub="test"),
+            data={
+                "csrf_token": csrf,
+                "title": post,
+                "ptype": "text",
+                "content": "the content",
+            },
+            follow_redirects=False,
+        )
+        assert rv.status == "302 FOUND"
+        soup = BeautifulSoup(rv.data, "html.parser", from_encoding="utf-8")
+        link = soup.a.get_text()
+        pids[post] = link.split("/")[-1]
+
+    # User can see all the posts.
+    rv = client.get(url_for("sub.view_sub", sub="test"), follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for post in posts:
+        assert post in data
+
+    # User has a delete link on a single-post page.
+    rv = client.get(
+        url_for("sub.view_post", sub="test", pid=pids["delete_user"]),
+        follow_redirects=True,
+    )
+    assert len(re.findall("[^n]delete-post", rv.data.decode("utf-8"))) == 1
+
+    # User deletes a post.
+    rv = client.post(
+        url_for("do.delete_post"),
+        data={"csrf_token": csrf, "post": pids["delete_user"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+
+    # User can now not see deleted post
+    rv = client.get(url_for("sub.view_sub", sub="test"), follow_redirects=True)
+    data = rv.data.decode("utf-8")
+    for post in posts:
+        if post == "delete_user":
+            assert post not in data
+        else:
+            assert post in data
+
+    # User can go to deleted post page but there is no delete or undelete link.
+    rv = client.get(
+        url_for("sub.view_post", sub="test", pid=pids["delete_user"]),
+        follow_redirects=True,
+    )
+    data = rv.data.decode("utf-8")
+    assert "the content" not in data
+    assert len(re.findall("delete-post", data)) == 0
+
+    log_out_current_user(client)
+
+    # Admin sees deleted post content, and no delete or undelete link.
+    log_in_user(client, admin)
+    rv = client.get(
+        url_for("sub.view_post", sub="test", pid=pids["delete_user"]),
+        follow_redirects=True,
+    )
+    data = rv.data.decode("utf-8")
+    assert "the content" in data
+    assert len(re.findall("delete-post", data)) == 0
+
+    # Admin tries to remove user's deleted post.
+    rv = client.post(
+        url_for("do.delete_post"),
+        data={"csrf_token": csrf, "post": pids["delete_user"]},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "error"
+    assert reply["error"] == ["Post was already deleted"]
+
+    # Admin deletes two posts.
+    for post in ["delete_admin", "delete_then_undelete_by_admin"]:
+        rv = client.post(
+            url_for("do.delete_post"),
+            data={"csrf_token": csrf, "post": pids[post], "reason": "admin"},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "ok"
+
+    # Admin can still see the post content and now has undelete links.
+    for post in ["delete_admin", "delete_then_undelete_by_admin"]:
+        rv = client.get(
+            url_for("sub.view_post", sub="test", pid=pids[post]), follow_redirects=True
+        )
+        data = rv.data.decode("utf-8")
+        assert "the content" in data
+        # Check for the css class on the bottombar delete links.
+        assert len(re.findall("undelete-post", data)) == 1
+        assert len(re.findall("[^n]delete-post", data)) == 0
+
+    # Admin undeletes a post.
+    rv = client.post(
+        url_for("do.undelete_post"),
+        data={
+            "csrf_token": csrf,
+            "post": pids["delete_then_undelete_by_admin"],
+            "reason": "admin",
+        },
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    # Mod can see content of all posts.  Mod sees delete links for the
+    # posts which are not deleted, and does not have delete or
+    # undelete links for the deleted posts.
+    log_in_user(client, mod)
+    for post in posts:
+        rv = client.get(
+            url_for("sub.view_post", sub="test", pid=pids[post]), follow_redirects=True
+        )
+        data = rv.data.decode("utf-8")
+        assert post in data
+        assert "the content" in data
+        if post in ["delete_user", "delete_admin"]:
+            assert len(re.findall("delete-post", data)) == 0
+        else:
+            assert len(re.findall("undelete-post", data)) == 0
+            assert len(re.findall("[^n]delete-post", data)) == 1
+
+    # Mod tries to remove already deleted posts.
+    for post in ["delete_user", "delete_admin"]:
+        rv = client.post(
+            url_for("do.delete_post"),
+            data={"csrf_token": csrf, "post": pids[post], "reason": "mod"},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "error"
+        assert reply["error"] == ["Post was already deleted"]
+
+    # Mod can't undelete post deleted by admin.
+    rv = client.post(
+        url_for("do.undelete_post"),
+        data={"csrf_token": csrf, "post": pids["delete_admin"], "reason": "mod"},
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "error"
+    assert reply["error"] == ["Not authorized"]
+
+    # Mod deletes some posts.
+    for post in [
+        "delete_mod",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]:
+        rv = client.post(
+            url_for("do.delete_post"),
+            data={"csrf_token": csrf, "post": pids[post], "reason": "mod"},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "ok"
+
+    # Mod sees content of all posts, and now has two undelete links.
+    for post in posts:
+        rv = client.get(
+            url_for("sub.view_post", sub="test", pid=pids[post]), follow_redirects=True
+        )
+        data = rv.data.decode("utf-8")
+        assert post in data
+        assert "the content" in data
+        if post in ["delete_user", "delete_admin"]:
+            assert len(re.findall("delete-post", data)) == 0
+        elif post in [
+            "delete_mod",
+            "delete_then_undelete_by_mod",
+            "delete_undelete_by_mod_then_admin",
+        ]:
+            assert len(re.findall("[^n]delete-post", data)) == 0
+            assert len(re.findall("undelete-post", data)) == 1
+        else:
+            assert len(re.findall("undelete-post", data)) == 0
+            assert len(re.findall("[^n]delete-post", data)) == 1
+
+    # Mod undeletes a post.
+    rv = client.post(
+        url_for("do.undelete_post"),
+        data={
+            "csrf_token": csrf,
+            "post": pids["delete_then_undelete_by_mod"],
+            "reason": "mod",
+        },
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    log_in_user(client, admin)
+    # Admin has undelete links for the content admin deleted as well as
+    # the content the mod deleted.
+    for post in posts:
+        rv = client.get(
+            url_for("sub.view_post", sub="test", pid=pids[post]), follow_redirects=True
+        )
+        data = rv.data.decode("utf-8")
+        assert post in data
+        assert "the content" in data
+        if post == "delete_user":
+            assert len(re.findall("delete-post", data)) == 0
+        elif post in [
+            "delete_admin",
+            "delete_mod",
+            "delete_undelete_by_mod_then_admin",
+        ]:
+            assert len(re.findall("[^n]delete-post", data)) == 0
+            assert len(re.findall("undelete-post", data)) == 1
+        else:
+            assert len(re.findall("undelete-post", data)) == 0
+            assert len(re.findall("[^n]delete-post", data)) == 1
+
+    # Admin can undelete a post deleted by the mod.
+    rv = client.post(
+        url_for("do.undelete_post"),
+        data={
+            "csrf_token": csrf,
+            "post": pids["delete_undelete_by_mod_then_admin"],
+            "reason": "admin",
+        },
+    )
+    reply = json.loads(rv.data.decode("utf-8"))
+    assert reply["status"] == "ok"
+    log_out_current_user(client)
+
+    log_in_user(client, user)
+    # User can see posts which were deleted by mod or admin.
+    undeleted = [
+        "delete_then_undelete_by_admin",
+        "delete_then_undelete_by_mod",
+        "delete_undelete_by_mod_then_admin",
+    ]
+    for post in posts:
+        rv = client.get(
+            url_for("sub.view_post", sub="test", pid=pids[post]), follow_redirects=True
+        )
+        data = rv.data.decode("utf-8")
+        assert post in data
+        if post != "delete_user":
+            assert "the content" in data
+        # User has a delete link for posts which are not deleted, and
+        # no undelete links.
+        if post in undeleted:
+            assert len(re.findall("[^n]delete-post", data)) == 1
+        else:
+            assert len(re.findall("[^n]delete-post", data)) == 0
+        assert len(re.findall("undelete-post", data)) == 0
+
+    for post in posts:
+        if post not in undeleted:
+            # User can't delete anything which has already been deleted.
+            rv = client.post(
+                url_for("do.delete_post"),
+                data={
+                    "csrf_token": csrf,
+                    "post": pids["delete_user"],
+                    "reason": "user",
+                },
+            )
+            reply = json.loads(rv.data.decode("utf-8"))
+            assert reply["status"] == "error"
+            assert reply["error"] == ["Post was already deleted"]
+
+    # User can't undelete any posts.
+    for post in posts:
+        rv = client.post(
+            url_for("do.undelete_post"),
+            data={"csrf_token": csrf, "post": pids[post], "reason": "user"},
+        )
+        reply = json.loads(rv.data.decode("utf-8"))
+        assert reply["status"] == "error"
+        if post == "delete_user":
+            assert reply["error"] == ["Can not un-delete a self-deleted post"]
+        elif "undelete" in post:
+            assert reply["error"] == ["Post is not deleted"]
+        else:
+            assert reply["error"] == ["Not authorized"]
+
+
 def test_mod_comment_delete(client, user_info, user2_info, user3_info):
     config.update_value("site.sub_creation_min_level", 0)
     user, admin, mod = user_info, user2_info, user3_info


### PR DESCRIPTION
Use `SubPost.deleted` and `SubPostComment.status` to keep track of whether posts or comments were deleted by the author, a mod, or an admin.  Allow mods to undelete content deleted by themselves or other mods, but not to undelete comments deleted by the user or an admin.  Allow admins to undelete content deleted by mods or admins.  Show the content of a deleted post or comment to the mods/admins to assist them with this decision.

Add tests to exercise the post and comment deletion and undeletion functionality for users, mods and admins.