### PR TITLE
While marking notifications read, delete ones over a month old

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -1,5 +1,5 @@
 """ Manages notifications """
-
+from datetime import datetime, timedelta
 from peewee import JOIN
 from flask_babel import _
 from pyfcm import FCMNotification
@@ -156,6 +156,21 @@ class Notifications(object):
             n["comment_positive"] = votes_by_id[n["id"]]["comment_positive"]
             n["post_positive"] = votes_by_id[n["id"]]["post_positive"]
         return notifications
+
+    @staticmethod
+    def mark_read(uid, notifs=None):
+        if notifs:
+            # Help the users who can't be bothered to delete their
+            # notifications by removing anything over a month old
+            # unless it appears on the first page of notifications.
+            Notification.delete().where(
+                (Notification.target == uid)
+                & (Notification.created < datetime.utcnow() - timedelta(days=30))
+                & ~(Notification.id << [n["id"] for n in notifs])
+            ).execute()
+        Notification.update(read=datetime.utcnow()).where(
+            (Notification.read.is_null(True)) & (Notification.target == uid)
+        ).execute()
 
     def send(
         self,

--- a/app/views/api3.py
+++ b/app/views/api3.py
@@ -1372,9 +1372,7 @@ def get_notifications():
             ntf["sender"] = None
 
     if autoMarkAsRead:
-        Notification.update(read=datetime.datetime.utcnow()).where(
-            (Notification.read.is_null(True)) & (Notification.target == uid)
-        ).execute()
+        notifications.mark_read(uid, notification_list)
     return jsonify(notifications=notification_list)
 
 

--- a/app/views/messages.py
+++ b/app/views/messages.py
@@ -1,5 +1,4 @@
 """ Messages endpoints """
-from datetime import datetime
 from flask import Blueprint, redirect, url_for, render_template, abort, jsonify
 from flask_login import login_required, current_user
 from .. import misc
@@ -37,9 +36,7 @@ def view_notifications(page):
             n["archived"] = misc.is_archived(n)
             misc.add_blur(n)
 
-    Notification.update(read=datetime.utcnow()).where(
-        (Notification.read.is_null(True)) & (Notification.target == current_user.uid)
-    ).execute()
+    Notifications.mark_read(current_user.uid, notifications)
     return engine.get_template("user/messages/notifications.html").render(
         {"notifications": notifications, "postmeta": postmeta}
     )


### PR DESCRIPTION
We are currently averaging 1500 new notifications created per day, and 10 requests to /notifications/delete per week (the "delete notification" link on the notifications page).  We have a route for paginated notifications (/notifications/xxx) but get zero requests for it, because there are no pagination buttons on the first notification page.  In the past year, it has also not occurred to any of our users to ask for pagination buttons on that page.

All of this has lead to a giant backlog of notifications in our database that no one cares about or is ever going to look at.  Start pruning the backlog by deleting old notifications when marking notifications read, defining old as both older than a month and not in the newest 50 for that user.