### PR TITLE
Allow users to filter sub listings by post flair

### DIFF
--- a/app/html/shared/post.html
+++ b/app/html/shared/post.html
@@ -45,7 +45,7 @@
         <div class="nsfw" alt="@{_('Not safe for work')}">@{_('NSFW')}</div> \
         @end
         @if post['flair']:
-        <span class="postflair">@{post['flair']!!e}</span> \
+          <a class="postflair" href="@{url_for('sub.view_sub_hot', sub=post['sub'], flair=post['flair'])}">@{post['flair']}</a> \
         @end
         @if post['link'] == None:
           <a href="/@{config.site.sub_prefix}/@{post['sub']}/@{post['pid']}/@{func.slugify(post['title'])}" class="title @{post['blur']}">@{post['title']}</a> \

--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -31,7 +31,7 @@
     @{_("Your flair:")}
     <a class="user" href="/u/@{current_user.name}">@{current_user.name}</a>
     @if func.get_user_flair(sub['sid'], current_user.uid):
-      <span class="user_flair">@{func.get_user_flair(sub['sid'], current_user.uid)!!e}</span>
+      <span class="user_flair">@{func.get_user_flair(sub['sid'], current_user.uid)}</span>
     @end
     @if subInfo.get('user_can_flair_self', 0) == '1' or subInfo.get('freeform_user_flairs', 0) == '1':
       <a href="#" id="change_user_flair" class="small">@{_("(change)")}</a>
@@ -69,7 +69,7 @@
           <div>@{_('... or pick a pre-defined one')}</div>
         @end
         @for ll in func.get_sub_flair_choices(sub['sid']):
-          <span class="selflair" data-sub="@{sub['name']}" data-flair="@{ll['id']}">@{ll['flair']!!e}</span>
+          <span class="selflair" data-sub="@{sub['name']}" data-flair="@{ll['id']}">@{ll['flair']}</span>
         @end
       @end
       <form method="POST" class="ajaxform" data-reload="true" action="@{url_for('do.delete_user_own_flair', sub=sub['name'])}">
@@ -78,6 +78,18 @@
     </div>
   @end
 @end
+
+@if subInfo.get('flairs'):
+  <form class="pure-form pure-g flairpicker">
+    <select id="flairpicker" class="pure-u-1">
+      <option value="" disabled selected>@{_('Show posts with flair...')}</option>
+      @for flair in subInfo.get('flairs'):
+        <option value="@{url_for('sub.view_sub_hot', sub=sub['name'], flair=flair)}">@{flair}</option>
+      @end
+    </select>
+  </form>
+@end
+
 <hr>
 @if sub['sidebar'] != '':
   @{func.our_markdown(sub['sidebar'])!!html}

--- a/app/html/sub.html
+++ b/app/html/sub.html
@@ -1,6 +1,6 @@
 @extends("shared/layout.html")
 @import "shared/post.html" as ipost
-@require(sub, posts, page, sort_type, subInfo)
+@require(sub, posts, page, sort_type, subInfo, flair)
 
 
 @def title():
@@ -9,11 +9,17 @@
 
 @def sidebar():
 
+<div id="flair">
+  @if flair:
+    <span class="postflair">@{flair}</span>
+    <a href="@{url_for('sub.view_sub_hot', sub=sub['name'])}">@{_('(show all)')}</a>
+  @end
+</div>
 <div id="sortbuttons" role="group" class="pure-button-group">
   <div class="pure-g">
-    <a href="@{url_for('sub.view_sub_hot', sub=sub['name'])}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_hot') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('Hot')}</a>
-    <a href="@{url_for('sub.view_sub_top', sub=sub['name'])}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_top') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('Top')}</a>
-    <a href="@{url_for('sub.view_sub_new', sub=sub['name'])}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_new') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('New')}</a>
+    <a href="@{url_for('sub.view_sub_hot', sub=sub['name'], flair=flair)}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_hot') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('Hot')}</a>
+    <a href="@{url_for('sub.view_sub_top', sub=sub['name'], flair=flair)}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_top') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('Top')}</a>
+    <a href="@{url_for('sub.view_sub_new', sub=sub['name'], flair=flair)}" class="sbm-post pure-button button-xsmall @{(sort_type == 'sub.view_sub_new') and 'pure-button-primary' or ''} pure-u-md-7-24">@{_('New')}</a>
   </div>
 </div>
 @include('shared/sidebar/sub.html')
@@ -24,7 +30,9 @@
   @if func.getStickyPid:
     <div class="stickyposts">
       @for post in func.getStickies(sub['sid']):
-        @{ipost.singlePost(post, sub)!!html}
+        @if flair is None or post['flair'] == flair:
+          @{ipost.singlePost(post, sub)!!html}
+        @end
       @end
     </div>
   @end

--- a/app/html/sub/post.html
+++ b/app/html/sub/post.html
@@ -106,7 +106,7 @@
         @if post['link'] == None:
           <h1>
             @if post['flair']:
-              <span class="postflair">@{post['flair']!!e}</span>
+              <a class="postflair" href="@{url_for('sub.view_sub_hot', sub=post['sub'], flair=post['flair'])}">@{post['flair']}</a> \
             @end
             <a href="@{url_for('sub.view_post', sub=sub['name'], pid=post['pid'])}" class="title">
               @if (post['visibility'] == ''):
@@ -125,7 +125,7 @@
         @else:
           <h1>
             @if post['flair']:
-              <span class="postflair">@{post['flair']!!e}</span>
+              <a class="postflair" href="@{url_for('sub.view_sub_hot', sub=post['sub'], flair=post['flair'])}">@{post['flair']}</a> \
             @end
             <a rel="noopener nofollow ugc" href="@{((post['visibility'] != 'none') and post['link']) or '#'}" target="@{((post['visibility'] != 'none') and '_blank') or '_self'}" class="title">
               @if (post['visibility'] == ''):
@@ -215,7 +215,7 @@
           @end
           @if ((subInfo.get('ucf', 0) == '1' or subInfo.get('umf', 0) == '1') and current_user.uid == post['uid']) or current_user.uid in subMods['all']:
             @if len(func.getSubFlairs(post['sid'])) != 0:
-            <li><a class="editflair">@{_('flair')!!e}</a></li>
+            <li><a class="editflair">@{_('flair')}</a></li>
             @end
           @end
           @if post['uid'] == current_user.uid:
@@ -301,7 +301,7 @@
       @end
       <h4>@{_('Select a new flair')}</h4>
       @for ll in func.getSubFlairs(post['sid']):
-        <span class="selflair" data-sub="@{post['sub']}" data-flair="@{ll.xid}" data-pid="@{post['pid']}">@{ll.text!!e}</span>
+        <span class="selflair" data-sub="@{post['sub']}" data-flair="@{ll.xid}" data-pid="@{post['pid']}">@{ll.text}</span>
       @end
     </div>
   @end

--- a/app/misc.py
+++ b/app/misc.py
@@ -1002,6 +1002,7 @@ def postListQueryBase(
     # subs to include deleted posts from.
     include_deleted_posts=False,
     isSubMod=False,
+    flair=None,  # if set, return only posts with this flair.
 ):
     fields = [
         SubPost.nsfw,
@@ -1137,6 +1138,9 @@ def postListQueryBase(
                 | (UserContentBlock.method != UserContentBlockMethod.HIDE)
                 | SubMod.id.is_null(False)
             )
+
+    if flair:
+        posts = posts.where(SubPost.flair == flair)
 
     if include_deleted_posts:
         if isinstance(include_deleted_posts, list):
@@ -1898,6 +1902,13 @@ def getSubData(sid, simple=False, extra=False):
             if creator.get("status", None) == 0
             else {"uid": "0", "name": _("[Deleted]")}
         )
+
+        data["flairs"] = [
+            sf.text
+            for sf in SubFlair.select(SubFlair.text)
+            .where(SubFlair.sid == sid)
+            .order_by(SubFlair.text)
+        ]
 
         try:
             data["stylesheet"] = SubStylesheet.get(SubStylesheet.sid == sid).content

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -48,6 +48,7 @@ body.dark #toggledark i {
 }
 body.dark .postflair {
   background-color: #000;
+  color: #7d7d7d;
   border: 1px solid #1d1d1d;
 }
 body.dark .user_flair {
@@ -260,6 +261,12 @@ body.dark .sidebar h4 {
 }
 
 body.dark input[type="search"] {
+  background-color: #000;
+  color: #fff;
+  border-color: black;
+}
+
+body.dark .flairpicker select {
   background-color: #000;
   color: #fff;
   border-color: black;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -952,11 +952,22 @@ img.nsfw-blur, img.block-blur {
 .postflair, .selflair, .submitflair {
   border: 1px solid #aaa;
   border-radius: 2px;
+  color: black;
   background-color: #eee;
   padding: 5px;
   line-height: 2em;
   white-space: nowrap;
   cursor: pointer;
+}
+
+#flair {
+    text-align: center;
+    padding-bottom: .2em;
+}
+
+#flair a {
+    font-size: small;
+    white-space: pre;
 }
 
 .submitflair {
@@ -1374,6 +1385,17 @@ input[type=search] {
 
 .search .icon path {
   fill: darkgray;
+}
+
+.flairpicker select {
+  box-sizing: border-box;
+  border: solid lightgray 1px;
+  border-radius: 4px;
+  font-size: .9em;
+  background-color: white;
+  -webkit-transition: width .4s ease-in-out;
+  transition: width .4s ease-in-out;
+  margin: 10px 5px 5px 5px;
 }
 
 /* /SIDEBAR STYLES */

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -979,4 +979,10 @@ u.addEventForChild(document, 'click', 'a.unblk', function (e, qelem) {
 u.addEventForChild(document, 'click', '.show-post-comments', function(e, qelem) {
     document.getElementById('post-comments').classList.remove('hide');
     qelem.classList.add('hide');
-})
+});
+
+u.addEventForChild(document, 'change', '#flairpicker', function(e, qelem) {
+    if (qelem.selectedIndex !== 0) {
+        window.location.href = qelem.value;
+    }
+});

--- a/app/templates/indexpost.html
+++ b/app/templates/indexpost.html
@@ -33,7 +33,9 @@
         {% if post.nsfw %}
         <div class="nsfw" alt="Not safe for work">{{_('NSFW')}}</div>
         {%endif%}
-        {% if post.flair %}<span class="postflair">{{post.flair}}</span>{% endif %}
+        {% if post.flair %}
+          <a class="postflair" href="{{url_for('sub.view_sub_hot', sub=post.sub, flair=post.flair)}}">{{post.flair}}</a>
+        {% endif %}
         {% if post.link == None %}
           <a href="{{url_for('sub.view_post', sub=post.sub, pid=post.pid)}}" class="title">
           {% if post.deleted == 1 %}

--- a/app/views/sub.py
+++ b/app/views/sub.py
@@ -312,6 +312,8 @@ def view_sub_new(sub, page):
     if sub.lower() == "all":
         return redirect(url_for("home.all_new", page=1))
 
+    flair = request.args.get("flair")
+
     try:
         sub = Sub.select().where(fn.Lower(Sub.name) == sub.lower()).dicts().get()
     except Sub.DoesNotExist:
@@ -320,7 +322,7 @@ def view_sub_new(sub, page):
     isSubMod = current_user.is_mod(sub["sid"], 1) or current_user.is_admin()
 
     posts = misc.getPostList(
-        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod).where(
+        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod, flair=flair).where(
             Sub.sid == sub["sid"]
         ),
         "new",
@@ -335,6 +337,7 @@ def view_sub_new(sub, page):
             "page": page,
             "sort_type": "sub.view_sub_new",
             "subMods": misc.getSubMods(sub["sid"]),
+            "flair": flair,
         }
     )
 
@@ -415,6 +418,8 @@ def view_sub_top(sub, page):
     if sub.lower() == "all":
         return redirect(url_for("home.all_top", page=1))
 
+    flair = request.args.get("flair")
+
     try:
         sub = Sub.select().where(fn.Lower(Sub.name) == sub.lower()).dicts().get()
     except Sub.DoesNotExist:
@@ -423,7 +428,7 @@ def view_sub_top(sub, page):
     isSubMod = current_user.is_mod(sub["sid"], 1) or current_user.is_admin()
 
     posts = misc.getPostList(
-        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod).where(
+        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod, flair=flair).where(
             Sub.sid == sub["sid"]
         ),
         "top",
@@ -438,6 +443,7 @@ def view_sub_top(sub, page):
             "page": page,
             "sort_type": "sub.view_sub_top",
             "subMods": misc.getSubMods(sub["sid"]),
+            "flair": flair,
         }
     )
 
@@ -448,6 +454,9 @@ def view_sub_hot(sub, page):
     """ The index page, /hot sorting """
     if sub.lower() == "all":
         return redirect(url_for("home.all_hot", page=1))
+
+    flair = request.args.get("flair")
+
     try:
         sub = Sub.select().where(fn.Lower(Sub.name) == sub.lower()).dicts().get()
     except Sub.DoesNotExist:
@@ -456,7 +465,7 @@ def view_sub_hot(sub, page):
     isSubMod = current_user.is_mod(sub["sid"], 1) or current_user.is_admin()
 
     posts = misc.getPostList(
-        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod).where(
+        misc.postListQueryBase(noAllFilter=True, isSubMod=isSubMod, flair=flair).where(
             Sub.sid == sub["sid"]
         ),
         "hot",
@@ -471,6 +480,7 @@ def view_sub_hot(sub, page):
             "page": page,
             "sort_type": "sub.view_sub_hot",
             "subMods": misc.getSubMods(sub["sid"]),
+            "flair": flair,
         }
     )
 


### PR DESCRIPTION
Implement #255, by adding a `flair` query variable to the sub post listing routes which makes them show only posts with a flair exactly matching the supplied value.  Make post flairs link to the "hot" sub listing filtered by that flair, and add a flair picker to the sub sidebar (if the mods have created any post flairs) that also navigates to the "hot" listing filtered by flair.

