### PR TITLE
Let admins configure whether users can vote on their own content

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -411,6 +411,29 @@ configurable_defaults = {
                 ),
                 "value": True,
             },
+            "self_voting": {
+                "type": "map",
+                "value": {
+                    "posts": {
+                        "type": "bool",
+                        "doc": _l(
+                            "If enabled, users will automatically upvote their own posts, "
+                            "and are allowed to change their vote.  If disabled, users "
+                            "cannot upvote or downvote their own posts."
+                        ),
+                        "value": True,
+                    },
+                    "comments": {
+                        "type": "bool",
+                        "doc": _l(
+                            "If enabled, users will automatically upvote their own comments, "
+                            "and are allowed to change their vote.  If disabled, users "
+                            "cannot upvote or downvote their own comments."
+                        ),
+                        "value": False,
+                    },
+                },
+            },
         },
     },
     "storage": {

--- a/app/misc.py
+++ b/app/misc.py
@@ -2724,6 +2724,8 @@ def cast_vote(uid, target_type, pcid, value):
         except SubPost.DoesNotExist:
             return jsonify(msg=_("Post does not exist")), 404
 
+        if target.uid_id == user.uid and not config.site.self_voting.posts:
+            return jsonify(msg=_("You can't vote on your own posts")), 400
         if target.deleted:
             return jsonify(msg=_("You can't vote on deleted posts")), 400
 
@@ -2760,7 +2762,7 @@ def cast_vote(uid, target_type, pcid, value):
         except SubPostComment.DoesNotExist:
             return jsonify(msg=_("Comment does not exist")), 404
 
-        if target.uid_id == user.uid:
+        if target.uid_id == user.uid and not config.site.self_voting.comments:
             return jsonify(msg=_("You can't vote on your own comments")), 400
         if target.status:
             return jsonify(msg=_("You can't vote on deleted comments")), 400

--- a/app/static/js/Post.js
+++ b/app/static/js/Post.js
@@ -794,6 +794,7 @@ u.addEventForChild(document, 'click', '.btn-postcomment', function (e, qelem) {
                     document.querySelector('.reply-comment[data-to="' + cid + '"] s').click();
                     document.getElementById('child-' + cid).prepend(div.firstChild);
                 }
+                Icons.rendericons();
             }
         }, function (e) {
             qelem.parentNode.querySelector('.error').style.display = 'block';

--- a/migrations/040_vote_config.py
+++ b/migrations/040_vote_config.py
@@ -1,0 +1,25 @@
+"""Peewee migrations -- 040_vote_config
+
+Add admin site configuration options to control whether users can
+upvote their own posts and comments.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.create(key="site.self_voting.posts", value="1")
+        SiteMetadata.create(key="site.self_voting.comments", value="0")
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    SiteMetadata = migrator.orm["site_metadata"]
+    if not fake:
+        SiteMetadata.delete().where(
+            (SiteMetadata.key == "site.self_voting.posts")
+            | (SiteMetadata.key == "site.self_voting.comments")
+        ).execute()


### PR DESCRIPTION
In the past users have been given an automatic vote on their own posts and have been allowed to change it, but get no automatic vote on their own comments and are not allowed to vote on them.

Add admin options to permit or deny voting by users on their own posts and comments, so that admins can make this behavior consistent between posts and comments. If self-voting is permitted, an automatic upvote will be generated when the content is posted.  The defaults preserve the existing behavior.