### PR TITLE
Fix set own user flair form on iPhone

### DIFF
--- a/app/html/shared/sidebar/sub.html
+++ b/app/html/shared/sidebar/sub.html
@@ -60,7 +60,7 @@
           <div class="alert div-error"></div>
           @{ form.SetOwnUserFlairForm().csrf_token() !!html}
           <input type="text" name="flair" placeholder="Write down your flair here" maxlength="16" required />
-          <button class="pure-button">Change flair</button>
+          <button type="submit" class="pure-button">Change flair</button>
         </form>
       @end
       @if func.get_sub_flair_choices(sub['sid']) and subInfo.get('user_can_flair_self', 0) == '1':
@@ -73,7 +73,7 @@
         @end
       @end
       <form method="POST" class="ajaxform" data-reload="true" action="@{url_for('do.delete_user_own_flair', sub=sub['name'])}">
-        <button class="pure-button button-error body_admin">Delete my flair</button>
+        <button type="submit" class="pure-button button-error body_admin">Delete my flair</button>
       </form>
     </div>
   @end


### PR DESCRIPTION
When a sub permits free-form user flairs, the user is given the option to change their flair in the sub sidebar.  This option brings up a form with two buttons, which would work on Linux desktop browsers but not on iPhone Safari. Add `type="submit"` to the buttons to make them work on iPhone browsers.