### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 CUR_DIR=$(shell pwd)
 NPM_CMD?=install
 
-.PHONY: docker-compose-build
-
+.PHONY: docker-npm
 docker-npm:
 	docker run \
 		-v $(CUR_DIR):/throat \
 		-w /throat node:14-buster-slim \
 		npm $(NPM_CMD)
 
+.PHONY: docker-compose-build
 docker-compose-build:
 	docker-compose build
 	@$(DONE)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you prefer to develop on docker
 inside the container for dev. It also runs the migrations on start-up. `make down` will spin down the containerized services.
 
 To add an admin user to a running docker-compose application:
-`docker exec throat_throat_1 python3 scripts/admins.py --add {{username}}`
+`docker exec throat_throat_1 ./throat.py admin add {{username}}`
 
 If Wheezy templates are not automatically reloading in docker between changes, try `docker restart throat_throat_1`.
 

--- a/app/forms/user.py
+++ b/app/forms/user.py
@@ -40,16 +40,6 @@ class RedirectForm(FlaskForm):
         return redirect(target or url_for(endpoint, **values))
 
 
-class LoginForm(RedirectForm):
-    """ Login form. """
-
-    username = StringField(_l("Username"), validators=[DataRequired(), Length(max=32)])
-    password = PasswordField(
-        _l("Password"), validators=[DataRequired(), Length(min=7, max=256)]
-    )
-    remember = BooleanField(_l("Remember me"))
-
-
 class OptionalIfFieldIsEmpty(Optional):
     """ A custom field validator. """
 
@@ -83,6 +73,16 @@ class UsernameLength:
                 )
 
             raise ValidationError(message % dict(min=min, max=max, length=length))
+
+
+class LoginForm(RedirectForm):
+    """ Login form. """
+
+    username = StringField(_l("Username"), validators=[UsernameLength()])
+    password = PasswordField(
+        _l("Password"), validators=[DataRequired(), Length(min=7, max=256)]
+    )
+    remember = BooleanField(_l("Remember me"))
 
 
 class RegistrationForm(FlaskForm):

--- a/app/html/user/settings/preferences.html
+++ b/app/html/user/settings/preferences.html
@@ -36,12 +36,12 @@
             @end
 
             <div class="pure-control-group">
-                <label for="nochat" class="pure-checkbox">@{edituserform.subtheme.label.text}</label>
+                <label for="subtheme" class="pure-checkbox">@{edituserform.subtheme.label.text}</label>
                 @{edituserform.subtheme(class_="sub_autocomplete")!!html}
             </div>
 
             <div class="pure-control-group">
-                <label for="nochat" class="pure-checkbox">@{edituserform.language.label.text}</label>
+                <label for="language" class="pure-checkbox">@{edituserform.language.label.text}</label>
                 @{edituserform.language(autocomplete="off")!!html}
             </div>
 


### PR DESCRIPTION
- Fix bug where you cannot log in if your username is over 32 characters (possible when `site.username_max_length` is changed)
- Fix `for` attributes on the user preferences template so the `label`s are labelling the correct element
- Fix adding admin user instructions in readme (`python3 scripts/admins.py --add` → `./thoat.py admin add`)
- Make the Make `docker-npm` recipe a `.PHONY` target

Let me know if I should split this into multiple PRs.