### PR TITLE
Disable invite codes made by banned or deleted users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -818,10 +818,14 @@ class InviteCode(BaseModel):
 
         return (
             InviteCode.select()
+            .join(User)
             .where(InviteCode.code == invite_code)
             .where(
-                InviteCode.expires.is_null()
-                | (InviteCode.expires > datetime.datetime.utcnow())
+                (
+                    InviteCode.expires.is_null()
+                    | (InviteCode.expires > datetime.datetime.utcnow())
+                )
+                & (User.status == UserStatus.OK)
             )
             .where(InviteCode.max_uses > InviteCode.uses)
             .get()


### PR DESCRIPTION
Make invite codes invalid if the user account that created them is banned or deleted, making it harder for people to repeatedly create accounts after getting banned, or after posting rulebreaking content and then deleting the account they used.