### PR TITLE
Allow users with names longer than the current limit to log in

### DIFF
--- a/app/forms/user.py
+++ b/app/forms/user.py
@@ -78,7 +78,7 @@ class UsernameLength:
 class LoginForm(RedirectForm):
     """ Login form. """
 
-    username = StringField(_l("Username"), validators=[UsernameLength()])
+    username = StringField(_l("Username"), validators=[Length(max=256)])
     password = PasswordField(
         _l("Password"), validators=[DataRequired(), Length(min=7, max=256)]
     )


### PR DESCRIPTION
One of the changes in #488 prevents users with names longer than the current value of `site.username_max_length` from logging in.  This means that if an admin ever changes that setting to a smaller value, they will effectively be banning users.  Fix this by allowing usernames up to 256 characters long in the login form, giving admins much more room to permit long usernames than the 32-character limit that existed before #488.