### PR TITLE
ReadME on Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A phoxy link and discussion aggregator with snek (python3)
 
 ## Setup:
 
-We recommend using a virtualenv or Pyenv
+We recommend using a virtualenv or Pyenv and setting it up to use Python 3.7 for best compatibility (higher versions might fail to build dependencies). See for e.g. [pyenv](https://github.com/pyenv/pyenv) to learn how to install multiple Python versions on your workstation. Refer to your virtual environment manager for documentation on selecting specific Python versions. 
 
 1. Install Python dependencies with `pip install -r requirements.txt`
 2. Install Node dependencies with `npm install`

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -227,7 +227,7 @@ def search_and_build_feed(page, term):
     fg.link(href=request.url, rel="self")
     return Response(
         misc.populate_feed(fg, posts).atom_str(pretty=True),
-        mimetype="application/atom+xml"
+        mimetype="application/atom+xml",
     )
 
 

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -212,25 +212,6 @@ def search(page, term):
     )
 
 
-@bp.route("/search/<term>/.rss")
-def search_and_build_feed(page, term):
-    """ Posts matching search keywords rendered as web feed """
-    term = re.sub(r'[^A-Za-z0-9.,\-_\'" ]+', "", term)
-    posts = misc.getPostList(
-        misc.postListQueryBase().where(SubPost.title ** ("%" + term + "%")), "new", page
-    )
-    posts = misc.getPostList(misc.postListQueryBase(), "new", 1)
-    fg = FeedGenerator()
-    fg.id(request.url)
-    fg.title(f"Search results matching {term}")
-    fg.link(href=request.url_root, rel="alternate")
-    fg.link(href=request.url, rel="self")
-    return Response(
-        misc.populate_feed(fg, posts).atom_str(pretty=True),
-        mimetype="application/atom+xml",
-    )
-
-
 @bp.route("/all/top", defaults={"page": 1})
 @bp.route("/all/top/<int:page>")
 def all_top(page):

--- a/app/views/home.py
+++ b/app/views/home.py
@@ -212,6 +212,25 @@ def search(page, term):
     )
 
 
+@bp.route("/search/<term>/.rss")
+def search_and_build_feed(page, term):
+    """ Posts matching search keywords rendered as web feed """
+    term = re.sub(r'[^A-Za-z0-9.,\-_\'" ]+', "", term)
+    posts = misc.getPostList(
+        misc.postListQueryBase().where(SubPost.title ** ("%" + term + "%")), "new", page
+    )
+    posts = misc.getPostList(misc.postListQueryBase(), "new", 1)
+    fg = FeedGenerator()
+    fg.id(request.url)
+    fg.title(f"Search results matching {term}")
+    fg.link(href=request.url_root, rel="alternate")
+    fg.link(href=request.url, rel="self")
+    return Response(
+        misc.populate_feed(fg, posts).atom_str(pretty=True),
+        mimetype="application/atom+xml"
+    )
+
+
 @bp.route("/all/top", defaults={"page": 1})
 @bp.route("/all/top/<int:page>")
 def all_top(page):


### PR DESCRIPTION
Added a small edit to the README as installing dependencies from the repository as is will fail if the interpreter is 3.9 or above. I didn't bother to try all interpreter versions down to 3.7, though.