### PR TITLE
Added image name to throat service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     image: redis
   throat:
     build: .
+    image: throat_throat
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
Without the name there's a high chance the migration service will fail to notice that the image has already been built and is available to localhost.